### PR TITLE
Correct intermittent failure in stat_driver on sparc 64 target

### DIFF
--- a/crypto/test/stat_driver.c
+++ b/crypto/test/stat_driver.c
@@ -51,6 +51,7 @@ main (int argc, char *argv[]) {
 
   printf("statistical tests driver\n");
 
+  v128_set_to_zero(&nonce);
   for (i=0; i < 2500; i++)
     buffer[i] = 0;
 


### PR DESCRIPTION
This fix zeroizes the nonce value prior to use. It's possible the stack contains garbage, which results in a failure of the stat_driver test cases.
