### PR TITLE
This patch adds "allow_repeat_rx" to srtp_policy_t.

### DIFF
--- a/include/srtp.h
+++ b/include/srtp.h
@@ -227,6 +227,13 @@ typedef struct srtp_policy_t {
 				*   transmissions must have the same RTP
 				*   payload, or a severe security weakness
 				*   is introduced!)                      */
+  int        allow_repeat_rx;  /**< Whether rerecptions of
+				*   packets with the same sequence number
+				*   are allowed. (Note this is a special feature
+				*   for SRTP-to-SRTP translators to not need
+				*   a jitterbuffer for reordering packets
+				*   and dealing with retransmitted packets
+				*   (caused by RTCP NACKs) */
   struct srtp_policy_t *next;  /**< Pointer to next stream policy.       */
 } srtp_policy_t;
 

--- a/include/srtp_priv.h
+++ b/include/srtp_priv.h
@@ -219,6 +219,7 @@ typedef struct srtp_stream_ctx_t {
   key_limit_ctx_t *limit;
   direction_t direction;
   int        allow_repeat_tx;
+  int        allow_repeat_rx;
   ekt_stream_t ekt; 
   struct srtp_stream_ctx_t *next;   /* linked list of streams */
 } srtp_stream_ctx_t;


### PR DESCRIPTION
It is the receive-side equivalent of "allow_repeat_tx".
When set to 1 it will disable replay detection for already received packets (which still fit into the receive window).

This is a useful feature for certain SRTP-to-SRTP translators (e.g. in WebRTC video MCUs) as it removes the need for a jitterbuffer (packet reordering) in the translator.