### PR TITLE
Use AES ICM state counter to determine when to reinitialize the prng.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,6 +37,7 @@ crypto/test/kernel_driver
 crypto/test/rand_gen
 crypto/test/sha1_driver
 crypto/test/stat_driver
+crypto/test/rand_gen_soak
 tables/aes_tables
 test/dtls_srtp_driver
 test/rdbx_driver

--- a/Makefile.in
+++ b/Makefile.in
@@ -29,6 +29,7 @@ runtest: build_table_apps test
 	test/roc_driver$(EXE) -v >/dev/null
 	test/replay_driver$(EXE) -v >/dev/null
 	test/dtls_srtp_driver$(EXE) >/dev/null
+	crypto/test/rand_gen_soak$(EXE) -v >/dev/null
 	cd test; $(abspath $(srcdir))/test/rtpw_test.sh >/dev/null	
 ifeq (1, $(USE_OPENSSL))
 	cd test; $(abspath $(srcdir))/test/rtpw_test_gcm.sh >/dev/null	
@@ -138,7 +139,7 @@ endif
 crypto_testapp = $(AES_CALC) crypto/test/cipher_driver$(EXE) \
 	crypto/test/datatypes_driver$(EXE) crypto/test/kernel_driver$(EXE) \
 	crypto/test/rand_gen$(EXE) crypto/test/sha1_driver$(EXE) \
-	crypto/test/stat_driver$(EXE)
+	crypto/test/stat_driver$(EXE) crypto/test/rand_gen_soak$(EXE)
 
 testapp = $(crypto_testapp) test/srtp_driver$(EXE) test/replay_driver$(EXE) \
 	  test/roc_driver$(EXE) test/rdbx_driver$(EXE) test/rtpw$(EXE) \

--- a/crypto/cipher/aes_icm.c
+++ b/crypto/cipher/aes_icm.c
@@ -476,6 +476,10 @@ aes_icm_output(aes_icm_ctx_t *c, uint8_t *buffer, int num_octets_to_output) {
   return aes_icm_encrypt(c, buffer, &len);
 }
 
+uint16_t
+aes_icm_bytes_encrypted(aes_icm_ctx_t *c) {
+    return htons(c->counter.v16[7]);
+}
 
 char 
 aes_icm_description[] = "aes integer counter mode";

--- a/crypto/include/aes_icm.h
+++ b/crypto/include/aes_icm.h
@@ -53,5 +53,8 @@ aes_icm_alloc_ismacryp(cipher_t **c,
 		       int key_len, 
 		       int forIsmacryp);
 
+uint16_t
+aes_icm_bytes_encrypted(aes_icm_ctx_t *c);
+
 #endif /* AES_ICM_H */
 

--- a/crypto/rng/ctr_prng.c
+++ b/crypto/rng/ctr_prng.c
@@ -83,10 +83,8 @@ ctr_prng_get_octet_string(void *dest, uint32_t len) {
 
   /* 
    * if we need to re-initialize the prng, do so now 
-   *
-   * avoid 32-bit overflows by subtracting instead of adding
    */
-  if (ctr_prng.octet_count > MAX_PRNG_OUT_LEN - len) {
+  if ((aes_icm_bytes_encrypted(&ctr_prng.state) + len) > 0xffff) {
     status = ctr_prng_init(ctr_prng.rand);    
     if (status)
       return status;

--- a/crypto/test/rand_gen_soak.c
+++ b/crypto/test/rand_gen_soak.c
@@ -1,0 +1,76 @@
+/*
+ * Soak test the RNG for exhaustion failures
+ */
+#include <stdio.h>           /* for printf() */
+#include <unistd.h>          /* for getopt() */
+#include "crypto_kernel.h"
+
+#define BUF_LEN (MAX_PRINT_STRING_LEN/2)
+
+int main(int argc, char *argv[])
+{
+    int q;
+    extern char *optarg;
+    int num_octets = 0;
+    err_status_t status;
+    uint32_t iterations = 0;
+    int print_values = 0;
+
+    if (argc == 1) {
+        exit(255);
+    }
+
+    status = crypto_kernel_init();
+    if (status) {
+        printf("error: crypto_kernel init failed\n");
+        exit(1);
+    }
+
+    while (1) {
+        q = getopt(argc, argv, "pvn:");
+        if (q == -1) {
+            break;
+        }
+        switch (q) {
+        case 'p':
+            print_values = 1;
+            break;
+        case 'n':
+            num_octets = atoi(optarg);
+            if (num_octets < 0 || num_octets > BUF_LEN) {
+                exit(255);
+            }
+            break;
+        case 'v':
+            num_octets = 30;
+            print_values = 0;
+            break;
+        default:
+            exit(255);
+        }
+    }
+
+    if (num_octets > 0) {
+        while (iterations < 300000) {
+            uint8_t buffer[BUF_LEN];
+
+            status = crypto_get_random(buffer, num_octets);
+            if (status) {
+                printf("iteration %d error: failure in random source\n", iterations);
+                exit(255);
+            } else if (print_values) {
+                printf("%s\n", octet_string_hex_string(buffer, num_octets));
+            }
+            iterations++;
+        }
+    }
+
+    status = crypto_kernel_shutdown();
+    if (status) {
+        printf("error: crypto_kernel shutdown failed\n");
+        exit(1);
+    }
+
+    return 0;
+}
+


### PR DESCRIPTION
This patch fixes #5 by using the same logic aes_icm uses to determine if a request for random data can be fulfilled by the current state. Otherwise, the prng returns err_status_terminus prematurely.
