### PR TITLE
Validate passed in signed length value (again)

### DIFF
--- a/srtp/srtp.c
+++ b/srtp/srtp.c
@@ -2755,6 +2755,12 @@ srtp_unprotect_rtcp(srtp_t ctx, void *srtcp_hdr, int *pkt_octet_len) {
 
   /* we assume the hdr is 32-bit aligned to start */
 
+  /* check that the length value is sane; we'll check again once we
+     know the tag length, but we at least want to know that it is
+     a positive value */
+  if (*pkt_octet_len < octets_in_rtcp_header + sizeof(srtcp_trailer_t))
+    return err_status_bad_param;
+
   /*
    * look up ssrc in srtp_stream list, and process the packet with 
    * the appropriate stream.  if we haven't seen this stream before,


### PR DESCRIPTION
In other functions we check right away that the `pkt_octet_len` is
greater than zero, but in `srtp_unprotect_rtcp` we were waiting until
we knew the tag length, at which point we had already used the value.
We'll do an initial check here to make sure the value is sane.

We tried adding this check back in commit
444a544c0c525c1fe6ccc560ae2ddcf38e6a461c, but that commit erroneously
used the tag length in the calculation.  The comment above it made it
clear that was unintended.

This check must come before we compute the tag length or we'll have
cast the `*pkt_octet_length` to an unsigned value in the call to
`srtp_stream_init_from_ekt()` without first checking that the value is
greater than zero.

This reverts the non-whitespace changes in commit
73e3093fcc309328aeb1201373e30ade6137b9f2.
