### PR TITLE
allow_repeat_tx for srtp_unprotect

### DIFF
--- a/srtp/srtp.c
+++ b/srtp/srtp.c
@@ -1444,8 +1444,11 @@ srtp_unprotect(srtp_ctx_t *ctx, void *srtp_hdr, int *pkt_octet_len) {
     
     /* check replay database */
     status = rdbx_check(&stream->rtp_rdbx, delta);
-    if (status)
-      return status;
+    if (status) {
+      if (status != err_status_replay_fail || !stream->allow_repeat_tx)
+        return status;  /* we've been asked to reuse an index */
+    }
+
   }
 
 #ifdef NO_64BIT_MATH


### PR DESCRIPTION
The current allow_repeat_tx flag allows bypassing repeat protection only for srtp_protect().
However, it may be useful also to unprotect already repeated RTP traffic and such functionality has not been implemented in the library.

The patch allows bypassing the repeating protection for srtp_unprotect().
