### PR TITLE
Add srtp_set_user_data() and srtp_get_user_data() functions.

### DIFF
--- a/include/srtp.h
+++ b/include/srtp.h
@@ -358,8 +358,7 @@ srtp_protect(srtp_t ctx, void *rtp_hdr, int *len_ptr);
  * @warning This function assumes that the SRTP packet is aligned on a
  * 32-bit boundary.
  *
- * @param ctx is a pointer to the srtp_t which applies to the
- * particular packet.
+ * @param ctx is the SRTP session which applies to the particular packet.
  *
  * @param srtp_hdr is a pointer to the header of the SRTP packet
  * (before the call).  after the function returns, it points to the
@@ -392,7 +391,8 @@ srtp_unprotect(srtp_t ctx, void *srtp_hdr, int *len_ptr);
  * initializes an SRTP session context, applying the given policy and
  * key.
  *
- * @param session is the SRTP session to which the policy is to be added.
+ * @param session is a pointer to the SRTP session to which the policy is
+ * to be added.
  * 
  * @param policy is the srtp_policy_t struct that describes the policy
  * for the session.  The struct may be a single element, or it may be
@@ -1082,6 +1082,57 @@ srtp_unprotect_rtcp(srtp_t ctx, void *srtcp_hdr, int *pkt_octet_len);
 /**
  * @}
  */
+
+
+/**
+ * @defgroup User data associated to a SRTP session.
+ * @ingroup  SRTP
+ *
+ * @brief Store custom user data within a SRTP session.
+ *
+ * @{
+ */
+
+/**
+ * @brief srtp_set_user_data() stores the given pointer into the SRTP
+ * session for later retrieval.
+ *
+ * @param ctx is the srtp_t context in which the given data pointer is
+ * stored.
+ *
+ * @param data is a pointer to the custom information (struct, function,
+ * etc) associated with the SRTP session.
+ *
+ * @return void.
+ *
+ */
+
+void
+srtp_set_user_data(srtp_t ctx, void *data);
+
+/**
+ * @brief srtp_get_user_data() retrieves the pointer to the custom data
+ * previously stored with srtp_set_user_data().
+ *
+ * This function is mostly useful for retrieving data associated to a
+ * SRTP session when an event fires. The user can then get such a custom
+ * data by calling this function with the session field of the
+ * srtp_event_data_t struct as argument.
+ *
+ * @param ctx is the srtp_t context in which the given data pointer was
+ * stored.
+ *
+ * @return void* pointer to the user data.
+ *
+ */
+
+void*
+srtp_get_user_data(srtp_t ctx);
+
+/**
+ * @}
+ */
+
 
 /**
  * @defgroup SRTPevents SRTP events and callbacks

--- a/include/srtp_priv.h
+++ b/include/srtp_priv.h
@@ -233,6 +233,7 @@ typedef struct srtp_stream_ctx_t {
 typedef struct srtp_ctx_t {
   srtp_stream_ctx_t *stream_list;     /* linked list of streams            */
   srtp_stream_ctx_t *stream_template; /* act as template for other streams */
+  void *user_data;                    /* user custom data */
 } srtp_ctx_t;
 
 

--- a/srtp/srtp.c
+++ b/srtp/srtp.c
@@ -1875,6 +1875,7 @@ srtp_create(srtp_t *session,               /* handle for session     */
    */
   ctx->stream_template = NULL;
   ctx->stream_list = NULL;
+  ctx->user_data = NULL;
   while (policy != NULL) {    
 
     stat = srtp_add_stream(ctx, policy);
@@ -3005,6 +3006,20 @@ srtp_unprotect_rtcp(srtp_t ctx, void *srtcp_hdr, int *pkt_octet_len) {
   return err_status_ok;  
 }
 
+
+/*
+ * user data within srtp_t context
+ */
+
+void
+srtp_set_user_data(srtp_t ctx, void *data) {
+  ctx->user_data = data;
+}
+
+void*
+srtp_get_user_data(srtp_t ctx) {
+  return ctx->user_data;
+}
 
 
 /*


### PR DESCRIPTION
Two new functions:
- `void srtp_set_user_data(srtp_t ctx, void *data)`
- `void* srtp_get_user_data(srtp_t ctx)`

It allows the user to associate custom data within a given `srtp_t` context. Useful for later retrieval when a SRTP event is fired (so the user can retrieve the custom data by calling `srtp_get_user_data()` with the `session` field of the `srtp_event_data_t` struct as argument).

This pull request fixes #65.

The commit also includes some minor fixes in the srtp.h documentation (some functions get a `srtp_t` as argument rather than a pointer to a `srtp_t` and vice-versa).
