### PR TITLE
Cleanup: miscellaneous cleanup of initial OpenSSL AES support

### DIFF
--- a/crypto/Makefile.in
+++ b/crypto/Makefile.in
@@ -9,7 +9,7 @@ top_builddir = @top_builddir@
 VPATH = @srcdir@
 
 CC	= @CC@
-INCDIR	= -Iinclude -I$(srcdir)/include 
+INCDIR	= -Iinclude -I$(srcdir)/include
 DEFS	= @DEFS@
 CPPFLAGS= @CPPFLAGS@
 CFLAGS	= @CFLAGS@

--- a/crypto/cipher/aes_icm.c
+++ b/crypto/cipher/aes_icm.c
@@ -469,7 +469,7 @@ aes_icm_encrypt(aes_icm_ctx_t *c, unsigned char *buf, unsigned int *enc_len) {
 }
 
 err_status_t
-aes_icm_output(aes_icm_ctx_t *c, uint8_t *buffer, int num_octets_to_output) {
+aes_icm_output(aes_icm_ctx_t *c, uint8_t *buffer, unsigned int num_octets_to_output) {
   unsigned int len = num_octets_to_output;
   
   /* zeroize the buffer */

--- a/crypto/cipher/aes_icm_ossl.c
+++ b/crypto/cipher/aes_icm_ossl.c
@@ -74,7 +74,7 @@ extern cipher_type_t aes_icm_256;
  * 16 bits
  * <----->
  * +------+------+------+------+------+------+------+------+
- * |           nonce           |    pakcet index    |  ctr |---+
+ * |           nonce           |    packet index    |  ctr |---+
  * +------+------+------+------+------+------+------+------+   |
  *                                                             |
  * +------+------+------+------+------+------+------+------+   v
@@ -317,26 +317,12 @@ err_status_t aes_icm_openssl_encrypt (aes_icm_ctx_t *c, unsigned char *buf, unsi
     }
     *enc_len = len;
 
-    if (!EVP_EncryptFinal_ex(&c->ctx, buf, (int*)&len)) {
+    if (!EVP_EncryptFinal_ex(&c->ctx, buf, &len)) {
         return err_status_cipher_fail;
     }
     *enc_len += len;
 
     return err_status_ok;
-}
-
-/*
- * Abstraction layer for encrypt.
- */
-err_status_t aes_icm_output (aes_icm_ctx_t *c, uint8_t *buffer, int num_octets_to_output)
-{
-    unsigned int len = num_octets_to_output;
-
-    /* zeroize the buffer */
-    octet_string_set_to_zero(buffer, num_octets_to_output);
-
-    /* exor keystream into buffer */
-    return aes_icm_openssl_encrypt(c, buffer, &len);
 }
 
 /*

--- a/crypto/include/aes_icm.h
+++ b/crypto/include/aes_icm.h
@@ -37,7 +37,7 @@ aes_icm_encrypt(aes_icm_ctx_t *c,
 
 err_status_t
 aes_icm_output(aes_icm_ctx_t *c,
-	       unsigned char *buf, int bytes_to_output);
+	       unsigned char *buf, unsigned int bytes_to_output);
 
 err_status_t 
 aes_icm_dealloc(cipher_t *c);


### PR DESCRIPTION
Use unsigned for lengths (which can't be negative); fix typos; remove
unnecessary casts; remove duplicated function (aes_icm_output); replace
magic numbers with manifest constants or computed sizes.
