### PR TITLE
Take advantage of base64 conversion in testapps

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -157,12 +157,14 @@ endif
 
 $(testapp): libsrtp.a
 
-test/rtpw$(EXE): test/rtpw.c test/rtp.c test/getopt_s.c
-	$(COMPILE) $(LDFLAGS) -o $@ $^ $(LIBS) $(SRTPLIB)
+test/rtpw$(EXE): test/rtpw.c test/rtp.c test/getopt_s.c \
+        crypto/math/datatypes.c
+	$(COMPILE) -DTESTAPP_SOURCE=1 $(LDFLAGS) -o $@ $^ $(LIBS) $(SRTPLIB)
 
 ifeq (1, $(HAVE_PCAP))
-test/rtp_decoder$(EXE): test/rtp_decoder.c test/rtp.c test/getopt_s.c
-	$(COMPILE) $(LDFLAGS) -o $@ $^ $(LIBS) $(SRTPLIB)
+test/rtp_decoder$(EXE): test/rtp_decoder.c test/rtp.c test/getopt_s.c \
+        crypto/math/datatypes.c
+	$(COMPILE) -DTESTAPP_SOURCE=1 $(LDFLAGS) -o $@ $^ $(LIBS) $(SRTPLIB)
 endif
 
 test/srtp_driver$(EXE): test/srtp_driver.c test/getopt_s.c

--- a/README
+++ b/README
@@ -78,7 +78,7 @@ Applications
   Manual srtp keying uses the -k option; automated key management
   using gdoi will be added later.
 
-usage: rtpw [-d <debug>]* [-k <key> [-a][-e <key size>][-g]] [-s | -r] dest_ip dest_port
+usage: rtpw [-d <debug>]* [-k|b <key> [-a][-e <key size>][-g]] [-s | -r] dest_ip dest_port
 or     rtpw -l
 
   Either the -s (sender) or -r (receiver) option must be chosen.
@@ -95,6 +95,8 @@ or     rtpw -l
   -k <key>      use srtp master key <key>, where the
 		key is a hexadecimal value (without the
                 leading "0x")
+
+  -b <key>      same as -k but with base64 encoded key
 
   -e <keysize>  encrypt/decrypt (for data confidentiality)
                 (requires use of -k option as well)

--- a/crypto/include/datatypes.h
+++ b/crypto/include/datatypes.h
@@ -509,4 +509,8 @@ bitvector_left_shift(bitvector_t *x, int index);
 char *
 bitvector_bit_string(bitvector_t *x, char* buf, int len);
 
+#ifdef TESTAPP_SOURCE
+int base64_string_to_octet_string(char *raw, int *pad, char *base64, int len);
+#endif
+
 #endif /* _DATATYPES_H */

--- a/test/rtp_decoder.h
+++ b/test/rtp_decoder.h
@@ -51,6 +51,7 @@
 #include "srtp_priv.h"
 #include "rtp_priv.h"
 #include "rtp.h"
+#include "datatypes.h"
 
 #define DEFAULT_RTP_OFFSET 42
 

--- a/test/rtpw_test.sh
+++ b/test/rtpw_test.sh
@@ -8,9 +8,9 @@ RTPW=./rtpw
 DEST_PORT=9999
 DURATION=3
 
-key=2b2edc5034f61a72345ca5986d7bfd0189aa6dc2ecab32fd9af74df6dfc6
+key=Ky7cUDT2GnI0XKWYbXv9AYmqbcLsqzL9mvdN9t/G
 
-ARGS="-k $key -a -e 128"
+ARGS="-b $key -a -e 128"
 
 # First, we run "killall" to get rid of all existing rtpw processes.
 # This step also enables this script to clean up after itself; if this


### PR DESCRIPTION
There was a non-working function and a working one in the source of
the contributed "rtp_decoder".  Have a working conversion function
and use it from both tools for parsing the command-line crypto-key.
