### PR TITLE
Align the AES ICM nonce

### DIFF
--- a/crypto/cipher/aes_icm.c
+++ b/crypto/cipher/aes_icm.c
@@ -287,12 +287,15 @@ aes_icm_set_octet(aes_icm_ctx_t *c,
 
 err_status_t
 aes_icm_set_iv(aes_icm_ctx_t *c, void *iv, int direction) {
-  v128_t *nonce = (v128_t *) iv;
+  v128_t nonce;
+
+  /* set nonce (for alignment) */
+  v128_copy_octet_string(&nonce, iv);
 
   debug_print(mod_aes_icm, 
-	      "setting iv: %s", v128_hex_string(nonce)); 
+	      "setting iv: %s", v128_hex_string(&nonce)); 
  
-  v128_xor(&c->counter, &c->offset, nonce);
+  v128_xor(&c->counter, &c->offset, &nonce);
   
   debug_print(mod_aes_icm, 
 	      "set_counter: %s", v128_hex_string(&c->counter)); 

--- a/crypto/cipher/aes_icm_ossl.c
+++ b/crypto/cipher/aes_icm_ossl.c
@@ -271,11 +271,14 @@ err_status_t aes_icm_openssl_context_init (aes_icm_ctx_t *c, const uint8_t *key,
 err_status_t aes_icm_openssl_set_iv (aes_icm_ctx_t *c, void *iv, int dir)
 {
     const EVP_CIPHER *evp;
-    v128_t *nonce = (v128_t*)iv;
+    v128_t nonce;
 
-    debug_print(mod_aes_icm, "setting iv: %s", v128_hex_string(nonce));
+    /* set nonce (for alignment) */
+    v128_copy_octet_string(&nonce, iv);
 
-    v128_xor(&c->counter, &c->offset, nonce);
+    debug_print(mod_aes_icm, "setting iv: %s", v128_hex_string(&nonce));
+
+    v128_xor(&c->counter, &c->offset, &nonce);
 
     debug_print(mod_aes_icm, "set_counter: %s", v128_hex_string(&c->counter));
 


### PR DESCRIPTION
While setting the IV for AES ICM the nonce is simply typecast from
a void \* to a v128_t *. This breaches alignment requirements for
v128_t objects on platforms that require it.
Instead make a copy of the nonce to assure proper alignment.
