### PR TITLE
Avoid problems due to unsafe macros

### DIFF
--- a/crypto/cipher/aes_icm.c
+++ b/crypto/cipher/aes_icm.c
@@ -333,7 +333,8 @@ aes_icm_advance_ismacryp(aes_icm_ctx_t *c, uint8_t forIsmacryp) {
     uint32_t temp;    
     //alex's clock counter forward
     temp = ntohl(c->counter.v32[3]);
-    c->counter.v32[3] = htonl(++temp);
+    ++temp;
+    c->counter.v32[3] = htonl(temp);
   } else {
     if (!++(c->counter.v8[15])) 
       ++(c->counter.v8[14]);


### PR DESCRIPTION
Having parameters with side effects causes problems when unsafe
function like macros are pulled in from the build environment.
As per Open Group specification htonl may a function like macro,
which may have an unsafe implementation.
