### PR TITLE
Add -f <pcap filter> option to rtp_decoder

### DIFF
--- a/test/rtp_decoder.c
+++ b/test/rtp_decoder.c
@@ -139,7 +139,7 @@ main (int argc, char *argv[]) {
         exit(1);
       }
       fprintf(stderr, "Setting filter as %s\n", optarg_s);
-      memcpy(filter_exp, optarg_s, strlen(optarg_s));
+      strcpy(filter_exp, optarg_s);
       break;
     case 'l':
       do_list_mods = 1;


### PR DESCRIPTION
The decoder needs to be ran with only the SRTP packets.
But most of the time, people have a capture made on the wild containing different types of packets.
To avoid having to transform the capture every time a capture is made, this options makes it easier through a standard pcap filter (e.g. "host 192.168.1.1 and port 5050").
The caveat is that the filter must be between quotes (").
The code to use the filter was already there, it just needed to be enabled in the command line.
I added the instructions to usage() as well.
