### PR TITLE
Add support for cross-compiling the shared library for Windows and OS X

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -18,7 +18,7 @@ USE_OPENSSL = @USE_OPENSSL@
 HAVE_PCAP = @HAVE_PCAP@
 HAVE_PKG_CONFIG = @HAVE_PKG_CONFIG@
 
-.PHONY: all test build_table_apps
+.PHONY: all shared_library test build_table_apps
 
 all: test 
 
@@ -44,10 +44,10 @@ endif
 CC	= @CC@
 INCDIR	= -Icrypto/include -I$(srcdir)/include -I$(srcdir)/crypto/include
 DEFS	= @DEFS@
-CPPFLAGS= @CPPFLAGS@
+CPPFLAGS= -fPIC @CPPFLAGS@
 CFLAGS	= @CFLAGS@
 LIBS	= @LIBS@
-LDFLAGS	= @LDFLAGS@ -L.
+LDFLAGS	= -L. @LDFLAGS@
 COMPILE = $(CC) $(DEFS) $(INCDIR) $(CPPFLAGS) $(CFLAGS)
 SRTPLIB	= -lsrtp
 
@@ -76,10 +76,31 @@ prefix = @prefix@
 exec_prefix = @exec_prefix@
 includedir = @includedir@
 libdir = @libdir@
+bindir = @bindir@
 
 ifeq (1, $(HAVE_PKG_CONFIG))
 pkgconfigdir = $(libdir)/pkgconfig
 pkgconfig_DATA = libsrtp.pc
+endif
+
+SHAREDLIBVERSION = 1
+ifeq (linux,$(findstring linux,@host@))
+SHAREDLIB_DIR = $(libdir)
+SHAREDLIB_LDFLAGS = -shared -Wl,-soname,$@
+SHAREDLIBSUFFIXNOVER = so
+SHAREDLIBSUFFIX = $(SHAREDLIBSUFFIXNOVER).$(SHAREDLIBVERSION)
+else ifeq (mingw,$(findstring mingw,@host@))
+SHAREDLIB_DIR = $(bindir)
+SHAREDLIB_LDFLAGS = -shared -Wl,--out-implib,libsrtp.dll.a
+SHAREDLIBVERSION =
+SHAREDLIBSUFFIXNOVER = dll
+SHAREDLIBSUFFIX = $(SHAREDLIBSUFFIXNOVER)
+else ifeq (darwin,$(findstring darwin,@host@))
+SHAREDLIB_DIR = $(libdir)
+SHAREDLIB_LDFLAGS = -dynamiclib -twolevel_namespace -undefined dynamic_lookup \
+        -fno-common -headerpad_max_install_names -install_name $(libdir)/$@
+SHAREDLIBSUFFIXNOVER = dylib
+SHAREDLIBSUFFIX = $(SHAREDLIBVERSION).$(SHAREDLIBSUFFIXNOVER)
 endif
 
 # implicit rules for object files and test apps
@@ -122,9 +143,14 @@ libsrtp.a: $(srtpobj) $(cryptobj) $(gdoi)
 	ar cr libsrtp.a $^
 	$(RANLIB) libsrtp.a
 
-libsrtp.so: $(srtpobj) $(cryptobj) $(gdoi) 
-	$(CC) -shared -Wl,-soname,libsrtp.so \
-	    -o libsrtp.so $^ $(LDFLAGS)
+libsrtp.$(SHAREDLIBSUFFIX): $(srtpobj) $(cryptobj) $(gdoi)
+	$(CC) -shared -o $@ $(SHAREDLIB_LDFLAGS) \
+                $^ $(LDFLAGS) $(LIBS)
+	if [ -n "$(SHAREDLIBVERSION)" ]; then \
+		ln -sfn $@ libsrtp.$(SHAREDLIBSUFFIXNOVER); \
+	fi
+
+shared_library: libsrtp.$(SHAREDLIBSUFFIX)
 
 # libcryptomath.a contains general-purpose routines that are used to
 # generate tables and verify cryptoalgorithm implementations - this
@@ -224,16 +250,18 @@ libsrtpdoc:
 .PHONY: clean superclean distclean install
 
 install:
-	@if [ -r $(DESTDIR)$(includedir)/srtp/srtp.h ]; then \
-	   echo "you should run 'make uninstall' first"; exit 1;  \
-	fi
 	$(INSTALL) -d $(DESTDIR)$(includedir)/srtp
 	$(INSTALL) -d $(DESTDIR)$(libdir)
+	$(INSTALL) -d $(DESTDIR)$(bindir)
 	cp $(srcdir)/include/*.h $(DESTDIR)$(includedir)/srtp  
 	cp $(srcdir)/crypto/include/*.h $(DESTDIR)$(includedir)/srtp
 	if [ "$(srcdir)" != "." ]; then cp crypto/include/*.h $(DESTDIR)$(includedir)/srtp; fi
 	if [ -f libsrtp.a ]; then cp libsrtp.a $(DESTDIR)$(libdir)/; fi
-	if [ -f libsrtp.so ]; then cp libsrtp.so $(DESTDIR)$(libdir)/; fi
+	if [ -f libsrtp.dll.a ]; then cp libsrtp.dll.a $(DESTDIR)$(libdir)/; fi
+	if [ -f libsrtp.$(SHAREDLIBSUFFIX) ]; then \
+		cp libsrtp.$(SHAREDLIBSUFFIX) $(DESTDIR)$(SHAREDLIB_DIR)/; \
+		cp libsrtp.$(SHAREDLIBSUFFIXNOVER) $(DESTDIR)$(SHAREDLIB_DIR)/; \
+	fi
 	if [ "$(pkgconfig_DATA)" != "" ]; then \
 		$(INSTALL) -d $(DESTDIR)$(pkgconfigdir); \
 		cp $(srcdir)/$(pkgconfig_DATA) $(DESTDIR)$(pkgconfigdir)/; \
@@ -241,8 +269,7 @@ install:
 
 uninstall:
 	rm -f $(DESTDIR)$(includedir)/srtp/*.h
-	rm -f $(DESTDIR)$(libdir)/libsrtp.a
-	rm -f $(DESTDIR)$(libdir)/libsrtp.so
+	rm -f $(DESTDIR)$(libdir)/libsrtp.*
 	-rmdir $(DESTDIR)$(includedir)/srtp
 	if [ "$(pkgconfig_DATA)" != "" ]; then \
 		rm -f $(DESTDIR)$(pkgconfigdir)/$(pkgconfig_DATA); \
@@ -250,7 +277,7 @@ uninstall:
 
 clean:
 	rm -rf $(cryptobj) $(srtpobj) $(cryptomath) TAGS \
-        libcryptomath.a libsrtp.a libsrtp.so core *.core test/core
+        libcryptomath.a libsrtp.* core *.core test/core
 	for a in * */* */*/*; do			\
               if [ -f "$$a~" ] ; then rm -f $$a~; fi;	\
         done;


### PR DESCRIPTION
Also ensure that the shared library is versioned, and an implib is created on Windows.

This involves adding -fPIC, fixing the LDFLAGS order (needed for building the shared library), creating a symlink for the unversioned shared library, and so on.

This change is used by the GStreamer project with its continuous integration system based around [Cerbero](http://cgit.freedesktop.org/gstreamer/sdk/cerbero) for the srtp GStreamer plugin. This change has been tested on Mac OS X, Linux (Ubuntu/Fedora/Debian), Windows 32-bit and 64-bit (cross-compiled, mingw), and Android (cross-compiled).
