### PR TITLE
Fix out-of-source tree builds.

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -264,7 +264,7 @@ install:
 	fi
 	if [ "$(pkgconfig_DATA)" != "" ]; then \
 		$(INSTALL) -d $(DESTDIR)$(pkgconfigdir); \
-		cp $(srcdir)/$(pkgconfig_DATA) $(DESTDIR)$(pkgconfigdir)/; \
+		cp $(top_builddir)/$(pkgconfig_DATA) $(DESTDIR)$(pkgconfigdir)/; \
 	fi
 
 uninstall:


### PR DESCRIPTION
The pkg-config file is generated in the build directory, so we need to
copy it from there.