### PR TITLE
Disable cipher that is not in boringssl (AES-192 counter mode).

### DIFF
--- a/config_in.h
+++ b/config_in.h
@@ -1,5 +1,8 @@
 /* config_in.h.  Generated from configure.in by autoheader.  */
 
+/* Define this to enable compatibility with BoringSSL. */
+#undef BORINGSSL
+
 /* Define if building for a CISC machine (e.g. Intel). */
 #undef CPU_CISC
 

--- a/configure
+++ b/configure
@@ -4990,6 +4990,9 @@ fi
 
 $as_echo "#define OPENSSL 1" >>confdefs.h
 
+
+$as_echo "#define BORINGSSL 1" >>confdefs.h
+
    AES_ICM_OBJS="crypto/cipher/aes_icm_ossl.o crypto/cipher/aes_gcm_ossl.o"
    RNG_OBJS=rand_source_ossl.o
    HMAC_OBJS=crypto/hash/hmac_ossl.o

--- a/configure.in
+++ b/configure.in
@@ -149,6 +149,7 @@ if test "$enable_openssl" = "yes"; then
    AC_CHECK_LIB([crypto], [EVP_aes_128_gcm], [],
              [AC_MSG_FAILURE([can't find openssl >1.0.1 crypto lib])])
    AC_DEFINE(OPENSSL, 1, [Define this to use OpenSSL crypto.])
+   AC_DEFINE(BORINGSSL, 1, [Define this to enable compatibility with BoringSSL.])
    AES_ICM_OBJS="crypto/cipher/aes_icm_ossl.o crypto/cipher/aes_gcm_ossl.o"
    RNG_OBJS=rand_source_ossl.o
    HMAC_OBJS=crypto/hash/hmac_ossl.o

--- a/crypto/include/aes_icm_ossl.h
+++ b/crypto/include/aes_icm_ossl.h
@@ -52,10 +52,14 @@
 
 #define     SALT_SIZE               14
 #define     AES_128_KEYSIZE         AES_BLOCK_SIZE
+#ifndef BORINGSSL
 #define     AES_192_KEYSIZE         AES_BLOCK_SIZE + AES_BLOCK_SIZE / 2
+#endif
 #define     AES_256_KEYSIZE         AES_BLOCK_SIZE * 2
 #define     AES_128_KEYSIZE_WSALT   AES_128_KEYSIZE + SALT_SIZE
+#ifndef BORINGSSL
 #define     AES_192_KEYSIZE_WSALT   AES_192_KEYSIZE + SALT_SIZE
+#endif
 #define     AES_256_KEYSIZE_WSALT   AES_256_KEYSIZE + SALT_SIZE
 
 typedef struct {

--- a/crypto/test/cipher_driver.c
+++ b/crypto/test/cipher_driver.c
@@ -126,7 +126,9 @@ extern cipher_type_t aes_icm;
 #ifndef OPENSSL
 extern cipher_type_t aes_cbc;
 #else
+#ifndef BORINGSSL
 extern cipher_type_t aes_icm_192;
+#endif
 extern cipher_type_t aes_icm_256;
 extern cipher_type_t aes_gcm_128_openssl;
 extern cipher_type_t aes_gcm_256_openssl;
@@ -197,8 +199,10 @@ main(int argc, char *argv[]) {
     for (num_cipher=1; num_cipher < max_num_cipher; num_cipher *=8)
       cipher_driver_test_array_throughput(&aes_cbc, 32, num_cipher); 
 #else
+#ifndef BORINGSSL
     for (num_cipher=1; num_cipher < max_num_cipher; num_cipher *=8)
       cipher_driver_test_array_throughput(&aes_icm_192, 38, num_cipher); 
+#endif
 
     for (num_cipher=1; num_cipher < max_num_cipher; num_cipher *=8)
       cipher_driver_test_array_throughput(&aes_icm_256, 46, num_cipher); 
@@ -219,7 +223,9 @@ main(int argc, char *argv[]) {
 #ifndef OPENSSL
     cipher_driver_self_test(&aes_cbc);
 #else
+#ifndef BORINGSSL
     cipher_driver_self_test(&aes_icm_192);
+#endif
     cipher_driver_self_test(&aes_icm_256);
     cipher_driver_self_test(&aes_gcm_128_openssl);
     cipher_driver_self_test(&aes_gcm_256_openssl);


### PR DESCRIPTION
This change makes libsrtp work with boringssl (fork of openssl: https://boringssl.googlesource.com/boringssl), which doesn't have AES-192 counter mode. The configure part needs some work (right now it just `#define`'s `BORINGSSL` if you enable openssl), but I wasn't sure how you'd like that done.