### PR TITLE
Don't include AES-192 when compiling against BoringSSL.

### DIFF
--- a/crypto/cipher/aes_icm_ossl.c
+++ b/crypto/cipher/aes_icm_ossl.c
@@ -65,7 +65,7 @@ debug_module_t mod_aes_icm = {
 };
 extern cipher_test_case_t aes_icm_test_case_0;
 extern cipher_type_t aes_icm;
-#ifndef OPENSSL_IS_BORINGSSL
+#ifndef SRTP_NO_AES192
 extern cipher_type_t aes_icm_192;
 #endif
 extern cipher_type_t aes_icm_256;
@@ -124,7 +124,7 @@ err_status_t aes_icm_openssl_alloc (cipher_t **c, int key_len, int tlen)
      * Verify the key_len is valid for one of: AES-128/192/256
      */
     if (key_len != AES_128_KEYSIZE_WSALT &&
-#ifndef OPENSSL_IS_BORINGSSL
+#ifndef SRTP_NO_AES192
         key_len != AES_192_KEYSIZE_WSALT &&
 #endif
         key_len != AES_256_KEYSIZE_WSALT) {
@@ -151,7 +151,7 @@ err_status_t aes_icm_openssl_alloc (cipher_t **c, int key_len, int tlen)
         aes_icm.ref_count++;
         ((aes_icm_ctx_t*)(*c)->state)->key_size = AES_128_KEYSIZE;
         break;
-#ifndef OPENSSL_IS_BORINGSSL
+#ifndef SRTP_NO_AES192
     case AES_192_KEYSIZE_WSALT:
         (*c)->algorithm = AES_192_ICM;
         (*c)->type = &aes_icm_192;
@@ -197,7 +197,7 @@ err_status_t aes_icm_openssl_dealloc (cipher_t *c)
         case AES_256_KEYSIZE:
             aes_icm_256.ref_count--;
             break;
-#ifndef OPENSSL_IS_BORINGSSL
+#ifndef SRTP_NO_AES192
         case AES_192_KEYSIZE:
             aes_icm_192.ref_count--;
             break;
@@ -259,7 +259,7 @@ err_status_t aes_icm_openssl_context_init (aes_icm_ctx_t *c, const uint8_t *key,
      * regardless of the cipher in use.
      */
     if (c->key_size == AES_256_KEYSIZE
-#ifndef OPENSSL_IS_BORINGSSL
+#ifndef SRTP_NO_AES192
         || c->key_size == AES_192_KEYSIZE
 #endif
         ) {
@@ -299,7 +299,7 @@ err_status_t aes_icm_openssl_set_iv (aes_icm_ctx_t *c, void *iv, int dir)
     case AES_256_KEYSIZE:
         evp = EVP_aes_256_ctr();
         break;
-#ifndef OPENSSL_IS_BORINGSSL
+#ifndef SRTP_NO_AES192
     case AES_192_KEYSIZE:
         evp = EVP_aes_192_ctr();
         break;
@@ -356,7 +356,7 @@ uint16_t aes_icm_bytes_encrypted(aes_icm_ctx_t *c)
  * Name of this crypto engine
  */
 char aes_icm_openssl_description[] = "AES-128 counter mode using openssl";
-#ifndef OPENSSL_IS_BORINGSSL
+#ifndef SRTP_NO_AES192
 char aes_icm_192_openssl_description[] = "AES-192 counter mode using openssl";
 #endif
 char aes_icm_256_openssl_description[] = "AES-256 counter mode using openssl";
@@ -406,7 +406,7 @@ cipher_test_case_t aes_icm_test_case_0 = {
     NULL                                   /* pointer to next testcase */
 };
 
-#ifndef OPENSSL_IS_BORINGSSL
+#ifndef SRTP_NO_AES192
 /*
  * KAT values for AES-192-CTR self-test.  These
  * values came from section 7 of RFC 6188.
@@ -519,7 +519,7 @@ cipher_type_t aes_icm = {
     (cipher_type_id_t)             AES_ICM
 };
 
-#ifndef OPENSSL_IS_BORINGSSL
+#ifndef SRTP_NO_AES192
 /*
  * This is the function table for this crypto engine.
  * note: the encrypt function is identical to the decrypt function

--- a/crypto/cipher/aes_icm_ossl.c
+++ b/crypto/cipher/aes_icm_ossl.c
@@ -65,7 +65,9 @@ debug_module_t mod_aes_icm = {
 };
 extern cipher_test_case_t aes_icm_test_case_0;
 extern cipher_type_t aes_icm;
+#ifndef OPENSSL_IS_BORINGSSL
 extern cipher_type_t aes_icm_192;
+#endif
 extern cipher_type_t aes_icm_256;
 
 /*
@@ -121,7 +123,10 @@ err_status_t aes_icm_openssl_alloc (cipher_t **c, int key_len, int tlen)
     /*
      * Verify the key_len is valid for one of: AES-128/192/256
      */
-    if (key_len != AES_128_KEYSIZE_WSALT && key_len != AES_192_KEYSIZE_WSALT &&
+    if (key_len != AES_128_KEYSIZE_WSALT &&
+#ifndef OPENSSL_IS_BORINGSSL
+        key_len != AES_192_KEYSIZE_WSALT &&
+#endif
         key_len != AES_256_KEYSIZE_WSALT) {
         return err_status_bad_param;
     }
@@ -146,12 +151,14 @@ err_status_t aes_icm_openssl_alloc (cipher_t **c, int key_len, int tlen)
         aes_icm.ref_count++;
         ((aes_icm_ctx_t*)(*c)->state)->key_size = AES_128_KEYSIZE;
         break;
+#ifndef OPENSSL_IS_BORINGSSL
     case AES_192_KEYSIZE_WSALT:
         (*c)->algorithm = AES_192_ICM;
         (*c)->type = &aes_icm_192;
         aes_icm_192.ref_count++;
         ((aes_icm_ctx_t*)(*c)->state)->key_size = AES_192_KEYSIZE;
         break;
+#endif
     case AES_256_KEYSIZE_WSALT:
         (*c)->algorithm = AES_256_ICM;
         (*c)->type = &aes_icm_256;
@@ -190,9 +197,11 @@ err_status_t aes_icm_openssl_dealloc (cipher_t *c)
         case AES_256_KEYSIZE:
             aes_icm_256.ref_count--;
             break;
+#ifndef OPENSSL_IS_BORINGSSL
         case AES_192_KEYSIZE:
             aes_icm_192.ref_count--;
             break;
+#endif
         case AES_128_KEYSIZE:
             aes_icm.ref_count--;
             break;
@@ -249,7 +258,11 @@ err_status_t aes_icm_openssl_context_init (aes_icm_ctx_t *c, const uint8_t *key,
      * key is statically allocated to handle a full 32 byte key
      * regardless of the cipher in use.
      */
-    if (c->key_size == AES_256_KEYSIZE || c->key_size == AES_192_KEYSIZE) {
+    if (c->key_size == AES_256_KEYSIZE
+#ifndef OPENSSL_IS_BORINGSSL
+        || c->key_size == AES_192_KEYSIZE
+#endif
+        ) {
         debug_print(mod_aes_icm, "Copying last 16 bytes of key: %s",
                     v128_hex_string((v128_t*)(key + AES_128_KEYSIZE)));
         v128_copy_octet_string(((v128_t*)(&c->key.v8)) + 1, key + AES_128_KEYSIZE);
@@ -286,9 +299,11 @@ err_status_t aes_icm_openssl_set_iv (aes_icm_ctx_t *c, void *iv, int dir)
     case AES_256_KEYSIZE:
         evp = EVP_aes_256_ctr();
         break;
+#ifndef OPENSSL_IS_BORINGSSL
     case AES_192_KEYSIZE:
         evp = EVP_aes_192_ctr();
         break;
+#endif
     case AES_128_KEYSIZE:
         evp = EVP_aes_128_ctr();
         break;
@@ -341,7 +356,9 @@ uint16_t aes_icm_bytes_encrypted(aes_icm_ctx_t *c)
  * Name of this crypto engine
  */
 char aes_icm_openssl_description[] = "AES-128 counter mode using openssl";
+#ifndef OPENSSL_IS_BORINGSSL
 char aes_icm_192_openssl_description[] = "AES-192 counter mode using openssl";
+#endif
 char aes_icm_256_openssl_description[] = "AES-256 counter mode using openssl";
 
 
@@ -389,6 +406,7 @@ cipher_test_case_t aes_icm_test_case_0 = {
     NULL                                   /* pointer to next testcase */
 };
 
+#ifndef OPENSSL_IS_BORINGSSL
 /*
  * KAT values for AES-192-CTR self-test.  These
  * values came from section 7 of RFC 6188.
@@ -433,7 +451,7 @@ cipher_test_case_t aes_icm_192_test_case_1 = {
     0,
     NULL                                   /* pointer to next testcase */
 };
-
+#endif
 
 /*
  * KAT values for AES-256-CTR self-test.  These
@@ -501,6 +519,7 @@ cipher_type_t aes_icm = {
     (cipher_type_id_t)             AES_ICM
 };
 
+#ifndef OPENSSL_IS_BORINGSSL
 /*
  * This is the function table for this crypto engine.
  * note: the encrypt function is identical to the decrypt function
@@ -520,6 +539,7 @@ cipher_type_t aes_icm_192 = {
     (debug_module_t*)              &mod_aes_icm,
     (cipher_type_id_t)             AES_192_ICM
 };
+#endif
 
 /*
  * This is the function table for this crypto engine.

--- a/crypto/include/aes_icm_ossl.h
+++ b/crypto/include/aes_icm_ossl.h
@@ -52,10 +52,14 @@
 
 #define     SALT_SIZE               14
 #define     AES_128_KEYSIZE         AES_BLOCK_SIZE
+#ifndef OPENSSL_IS_BORINGSSL
 #define     AES_192_KEYSIZE         AES_BLOCK_SIZE + AES_BLOCK_SIZE / 2
+#endif
 #define     AES_256_KEYSIZE         AES_BLOCK_SIZE * 2
 #define     AES_128_KEYSIZE_WSALT   AES_128_KEYSIZE + SALT_SIZE
+#ifndef OPENSSL_IS_BORINGSSL
 #define     AES_192_KEYSIZE_WSALT   AES_192_KEYSIZE + SALT_SIZE
+#endif
 #define     AES_256_KEYSIZE_WSALT   AES_256_KEYSIZE + SALT_SIZE
 
 typedef struct {

--- a/crypto/include/aes_icm_ossl.h
+++ b/crypto/include/aes_icm_ossl.h
@@ -50,14 +50,19 @@
 #include <openssl/evp.h>
 #include <openssl/aes.h>
 
+#ifdef OPENSSL_IS_BORINGSSL
+// BoringSSL doesn't support AES-192, cipher will be disabled
+#define SRTP_NO_AES192
+#endif
+
 #define     SALT_SIZE               14
 #define     AES_128_KEYSIZE         AES_BLOCK_SIZE
-#ifndef OPENSSL_IS_BORINGSSL
+#ifndef SRTP_NO_AES192
 #define     AES_192_KEYSIZE         AES_BLOCK_SIZE + AES_BLOCK_SIZE / 2
 #endif
 #define     AES_256_KEYSIZE         AES_BLOCK_SIZE * 2
 #define     AES_128_KEYSIZE_WSALT   AES_128_KEYSIZE + SALT_SIZE
-#ifndef OPENSSL_IS_BORINGSSL
+#ifndef SRTP_NO_AES192
 #define     AES_192_KEYSIZE_WSALT   AES_192_KEYSIZE + SALT_SIZE
 #endif
 #define     AES_256_KEYSIZE_WSALT   AES_256_KEYSIZE + SALT_SIZE

--- a/crypto/test/cipher_driver.c
+++ b/crypto/test/cipher_driver.c
@@ -126,7 +126,7 @@ extern cipher_type_t aes_icm;
 #ifndef OPENSSL
 extern cipher_type_t aes_cbc;
 #else
-#ifndef OPENSSL_IS_BORINGSSL
+#ifndef SRTP_NO_AES192
 extern cipher_type_t aes_icm_192;
 #endif
 extern cipher_type_t aes_icm_256;
@@ -199,7 +199,7 @@ main(int argc, char *argv[]) {
     for (num_cipher=1; num_cipher < max_num_cipher; num_cipher *=8)
       cipher_driver_test_array_throughput(&aes_cbc, 32, num_cipher); 
 #else
-#ifndef OPENSSL_IS_BORINGSSL
+#ifndef SRTP_NO_AES192
     for (num_cipher=1; num_cipher < max_num_cipher; num_cipher *=8)
       cipher_driver_test_array_throughput(&aes_icm_192, 38, num_cipher); 
 #endif
@@ -222,7 +222,7 @@ main(int argc, char *argv[]) {
 #ifndef OPENSSL
     cipher_driver_self_test(&aes_cbc);
 #else
-#ifndef OPENSSL_IS_BORINGSSL
+#ifndef SRTP_NO_AES192
     cipher_driver_self_test(&aes_icm_192);
 #endif
     cipher_driver_self_test(&aes_icm_256);

--- a/crypto/test/cipher_driver.c
+++ b/crypto/test/cipher_driver.c
@@ -126,7 +126,9 @@ extern cipher_type_t aes_icm;
 #ifndef OPENSSL
 extern cipher_type_t aes_cbc;
 #else
+#ifndef OPENSSL_IS_BORINGSSL
 extern cipher_type_t aes_icm_192;
+#endif
 extern cipher_type_t aes_icm_256;
 extern cipher_type_t aes_gcm_128_openssl;
 extern cipher_type_t aes_gcm_256_openssl;
@@ -197,9 +199,10 @@ main(int argc, char *argv[]) {
     for (num_cipher=1; num_cipher < max_num_cipher; num_cipher *=8)
       cipher_driver_test_array_throughput(&aes_cbc, 32, num_cipher); 
 #else
+#ifndef OPENSSL_IS_BORINGSSL
     for (num_cipher=1; num_cipher < max_num_cipher; num_cipher *=8)
       cipher_driver_test_array_throughput(&aes_icm_192, 38, num_cipher); 
-
+#endif
     for (num_cipher=1; num_cipher < max_num_cipher; num_cipher *=8)
       cipher_driver_test_array_throughput(&aes_icm_256, 46, num_cipher); 
 
@@ -219,7 +222,9 @@ main(int argc, char *argv[]) {
 #ifndef OPENSSL
     cipher_driver_self_test(&aes_cbc);
 #else
+#ifndef OPENSSL_IS_BORINGSSL
     cipher_driver_self_test(&aes_icm_192);
+#endif
     cipher_driver_self_test(&aes_icm_256);
     cipher_driver_self_test(&aes_gcm_128_openssl);
     cipher_driver_self_test(&aes_gcm_256_openssl);


### PR DESCRIPTION
libsrtp is used for WebRTC in Chromium. There are currently plans to update to newer versions of libsrtp and compile against OpenSSL (which is actually BoringSSL for Chromium). As BoringSSL doesn't support AES-192, this cipher should not be included if libsrtp is compiled against it.

This patch implements the check, so any updates to newer upstream versions of libsrtp in Chromium don't need further changes.