### PR TITLE
Include "config.h" to get "inline" on Windows.

### DIFF
--- a/crypto/include/sha1.h
+++ b/crypto/include/sha1.h
@@ -47,6 +47,10 @@
 #ifndef SHA1_H
 #define SHA1_H
 
+#ifdef HAVE_CONFIG_H
+    #include <config.h>
+#endif
+
 #include "err.h"
 #ifdef OPENSSL
 #include <openssl/evp.h>


### PR DESCRIPTION
`sha1.h` uses `inline` in the OpenSSL case which is not available when compiling with Visual Studio and therefore `#define`d in `config.h`, so this file should be included here.