### PR TITLE
Various fixes for compiling with Visual Studio

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -44,5 +44,6 @@ test/dtls_srtp_driver
 test/rdbx_driver
 test/replay_driver
 test/roc_driver
+test/rtp_decoder
 test/rtpw
 test/srtp_driver

--- a/Makefile.in
+++ b/Makefile.in
@@ -202,6 +202,18 @@ test/rdbx_driver$(EXE): test/rdbx_driver.c test/getopt_s.c
 test/dtls_srtp_driver$(EXE): test/dtls_srtp_driver.c test/getopt_s.c
 	$(COMPILE) $(LDFLAGS) -o $@ $^ $(LIBS) $(SRTPLIB)
 
+crypto/test/cipher_driver$(EXE): crypto/test/cipher_driver.c test/getopt_s.c
+	$(COMPILE) $(LDFLAGS) -o $@ $^ $(LIBS) $(SRTPLIB)
+
+crypto/test/kernel_driver$(EXE): crypto/test/kernel_driver.c test/getopt_s.c
+	$(COMPILE) $(LDFLAGS) -o $@ $^ $(LIBS) $(SRTPLIB)
+
+crypto/test/rand_gen$(EXE): crypto/test/rand_gen.c test/getopt_s.c
+	$(COMPILE) $(LDFLAGS) -o $@ $^ $(LIBS) $(SRTPLIB)
+
+crypto/test/rand_gen_soak$(EXE): crypto/test/rand_gen_soak.c test/getopt_s.c
+	$(COMPILE) $(LDFLAGS) -o $@ $^ $(LIBS) $(SRTPLIB)
+
 test: $(testapp)
 	@echo "Build done. Please run '$(MAKE) runtest' to run self tests."
 

--- a/crypto/Makefile.in
+++ b/crypto/Makefile.in
@@ -9,7 +9,7 @@ top_builddir = @top_builddir@
 VPATH = @srcdir@
 
 CC	= @CC@
-INCDIR	= -Iinclude -I$(srcdir)/include
+INCDIR	= -Iinclude -I$(srcdir)/include -I$(top_srcdir)/include
 DEFS	= @DEFS@
 CPPFLAGS= @CPPFLAGS@
 CFLAGS	= @CFLAGS@
@@ -82,8 +82,8 @@ endif
 %.o: %.c
 	$(COMPILE) -c $< -o $@
 
-%$(EXE): %.c  
-	$(COMPILE) $(LDFLAGS) $< -o $@ $(CRYPTOLIB) $(LIBS)
+%$(EXE): %.c ../test/getopt_s.c
+	$(COMPILE) $(LDFLAGS) $< ../test/getopt_s.c -o $@ $(CRYPTOLIB) $(LIBS)
 
 all: $(testapp)
 

--- a/crypto/math/datatypes.c
+++ b/crypto/math/datatypes.c
@@ -535,7 +535,7 @@ static const char b64chars[] = "ABCDEFGHIJKLMNOPQRSTUVWXYZ"
   "abcdefghijklmnopqrstuvwxyz0123456789+/";
 
 static int base64_block_to_octet_triple(char *out, char *in) {
-  unsigned char sextets[4] = {};
+  unsigned char sextets[4] = {0};
   int j = 0;
   int i;
 

--- a/crypto/test/cipher_driver.c
+++ b/crypto/test/cipher_driver.c
@@ -50,7 +50,7 @@
 #include <stdio.h>           /* for printf() */
 #include <stdlib.h>          /* for rand() */
 #include <string.h>          /* for memset() */
-#include <unistd.h>          /* for getopt() */
+#include "getopt_s.h"
 #include "cipher.h"
 #ifdef OPENSSL
 #include "aes_icm_ossl.h"
@@ -153,7 +153,7 @@ main(int argc, char *argv[]) {
 
   /* process input arguments */
   while (1) {
-    q = getopt(argc, argv, "tva");
+    q = getopt_s(argc, argv, "tva");
     if (q == -1) 
       break;
     switch (q) {

--- a/crypto/test/cipher_driver.c
+++ b/crypto/test/cipher_driver.c
@@ -373,11 +373,12 @@ cipher_driver_self_test(cipher_type_t *ct) {
  * calls
  */
 
+#define INITIAL_BUFLEN 1024
 err_status_t
 cipher_driver_test_buffering(cipher_t *c) {
   int i, j, num_trials = 1000;
-  unsigned len, buflen = 1024;
-  uint8_t buffer0[buflen], buffer1[buflen], *current, *end;
+  unsigned len, buflen = INITIAL_BUFLEN;
+  uint8_t buffer0[INITIAL_BUFLEN], buffer1[INITIAL_BUFLEN], *current, *end;
   uint8_t idx[16] = { 
     0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 
     0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x12, 0x34
@@ -390,8 +391,9 @@ cipher_driver_test_buffering(cipher_t *c) {
   for (i=0; i < num_trials; i++) {
 
    /* set buffers to zero */
-    for (j=0; j < buflen; j++) 
+    for (j=0; j < (int) buflen; j++) {
       buffer0[j] = buffer1[j] = 0;
+    }
     
     /* initialize cipher  */
     status = cipher_set_iv(c, idx, direction_encrypt);
@@ -433,7 +435,7 @@ cipher_driver_test_buffering(cipher_t *c) {
     }
 
     /* compare buffers */
-    for (j=0; j < buflen; j++)
+    for (j=0; j < (int) buflen; j++) {
       if (buffer0[j] != buffer1[j]) {
 #if PRINT_DEBUG
 	printf("test case %d failed at byte %d\n", i, j);
@@ -442,6 +444,7 @@ cipher_driver_test_buffering(cipher_t *c) {
 #endif 
 	return err_status_algo_fail;
       }
+    }
   }
   
   printf("passed\n");

--- a/crypto/test/datatypes_driver.c
+++ b/crypto/test/datatypes_driver.c
@@ -209,7 +209,7 @@ test_hex_string_funcs(void) {
 
 void
 print_string(char *s) {
-  int i;  
+  size_t i;
   printf("%s\n", s);
   printf("strlen(s) = %u\n", (unsigned)strlen(s));
   printf("{ ");

--- a/crypto/test/kernel_driver.c
+++ b/crypto/test/kernel_driver.c
@@ -48,7 +48,7 @@
 #endif
 
 #include <stdio.h>           /* for printf() */
-#include <unistd.h>          /* for getopt() */
+#include "getopt_s.h"
 #include "crypto_kernel.h"
 
 void
@@ -59,7 +59,6 @@ usage(char *prog_name) {
 
 int
 main (int argc, char *argv[]) {
-  extern char *optarg;
   int q;
   int do_validation      = 0;
   err_status_t status;
@@ -77,7 +76,7 @@ main (int argc, char *argv[]) {
 
   /* process input arguments */
   while (1) {
-    q = getopt(argc, argv, "vd:");
+    q = getopt_s(argc, argv, "vd:");
     if (q == -1) 
       break;
     switch (q) {
@@ -85,9 +84,9 @@ main (int argc, char *argv[]) {
       do_validation = 1;
       break;
     case 'd':
-      status = crypto_kernel_set_debug_module(optarg, 1);
+      status = crypto_kernel_set_debug_module(optarg_s, 1);
       if (status) {
-	printf("error: set debug module (%s) failed\n", optarg);
+	printf("error: set debug module (%s) failed\n", optarg_s);
 	exit(1);
       }
       break;

--- a/crypto/test/rand_gen.c
+++ b/crypto/test/rand_gen.c
@@ -48,7 +48,7 @@
 #endif
 
 #include <stdio.h>           /* for printf() */
-#include <unistd.h>          /* for getopt() */
+#include "getopt_s.h"
 #include "crypto_kernel.h"
 
 /*
@@ -72,7 +72,6 @@ usage(char *prog_name) {
 
 int
 main (int argc, char *argv[]) {
-  extern char *optarg;
   int q;
   int num_octets = 0;
   unsigned do_list_mods = 0;
@@ -90,14 +89,14 @@ main (int argc, char *argv[]) {
 
   /* process input arguments */
   while (1) {
-    q = getopt(argc, argv, "ld:n:");
+    q = getopt_s(argc, argv, "ld:n:");
     if (q == -1) 
       break;
     switch (q) {
     case 'd':
-      status = crypto_kernel_set_debug_module(optarg, 1);
+      status = crypto_kernel_set_debug_module(optarg_s, 1);
       if (status) {
-	printf("error: set debug module (%s) failed\n", optarg);
+	printf("error: set debug module (%s) failed\n", optarg_s);
 	exit(1);
       }
       break;
@@ -105,7 +104,7 @@ main (int argc, char *argv[]) {
       do_list_mods = 1;
       break;
     case 'n':
-      num_octets = atoi(optarg);
+      num_octets = atoi(optarg_s);
       if (num_octets < 0 || num_octets > BUF_LEN)
 	usage(argv[0]);
       break;

--- a/crypto/test/rand_gen_soak.c
+++ b/crypto/test/rand_gen_soak.c
@@ -43,7 +43,7 @@
 #endif
 
 #include <stdio.h>           /* for printf() */
-#include <unistd.h>          /* for getopt() */
+#include "getopt_s.h"
 #include "crypto_kernel.h"
 
 #define BUF_LEN (MAX_PRINT_STRING_LEN/2)
@@ -51,7 +51,6 @@
 int main(int argc, char *argv[])
 {
     int q;
-    extern char *optarg;
     int num_octets = 0;
     err_status_t status;
     uint32_t iterations = 0;
@@ -68,7 +67,7 @@ int main(int argc, char *argv[])
     }
 
     while (1) {
-        q = getopt(argc, argv, "pvn:");
+        q = getopt_s(argc, argv, "pvn:");
         if (q == -1) {
             break;
         }
@@ -77,7 +76,7 @@ int main(int argc, char *argv[])
             print_values = 1;
             break;
         case 'n':
-            num_octets = atoi(optarg);
+            num_octets = atoi(optarg_s);
             if (num_octets < 0 || num_octets > BUF_LEN) {
                 exit(255);
             }

--- a/srtp/srtp.c
+++ b/srtp/srtp.c
@@ -1090,7 +1090,7 @@ srtp_unprotect_aead (srtp_ctx_t *ctx, srtp_stream_ctx_t *stream, int delta,
      * the tag size.  It must always be at least as large
      * as the tag length.
      */
-    if (enc_octet_len < tag_len) {
+    if (enc_octet_len < (unsigned int) tag_len) {
         return err_status_cipher_fail;
     }
 
@@ -2878,7 +2878,7 @@ srtp_unprotect_rtcp(srtp_t ctx, void *srtcp_hdr, int *pkt_octet_len) {
   /* check the packet length - it must contain at least a full RTCP
      header, an auth tag (if applicable), and the SRTCP encrypted flag
      and 31-bit index value */
-  if (*pkt_octet_len < (octets_in_rtcp_header + tag_len + sizeof(srtcp_trailer_t))) {
+  if (*pkt_octet_len < (int) (octets_in_rtcp_header + tag_len + sizeof(srtcp_trailer_t))) {
     return err_status_bad_param;
   }
 

--- a/test/rdbx_driver.c
+++ b/test/rdbx_driver.c
@@ -242,7 +242,7 @@ test_replay_dbx(int num_trials, unsigned long ws) {
    *  test sequential insertion 
    */
   printf("\ttesting sequential insertion...");
-  for (idx=0; idx < num_trials; idx++) {
+  for (idx=0; (int) idx < num_trials; idx++) {
     status = rdbx_check_add(&rdbx, idx);
     if (status)
       return status;
@@ -261,7 +261,7 @@ test_replay_dbx(int num_trials, unsigned long ws) {
     printf("warning: no false positive tests performed\n");
   }
   printf("\ttesting for false positives...");
-  for (idx=0; idx < num_fp_trials; idx++) {
+  for (idx=0; (int) idx < num_fp_trials; idx++) {
     status = rdbx_check_expect_failure(&rdbx, idx);
     if (status)
       return status;
@@ -285,7 +285,7 @@ test_replay_dbx(int num_trials, unsigned long ws) {
   ut_init(&utc);
 
   printf("\ttesting non-sequential insertion...");  
-  for (idx=0; idx < num_trials; idx++) {
+  for (idx=0; (int) idx < num_trials; idx++) {
     ircvd = ut_next_index(&utc);
     status = rdbx_check_add_unordered(&rdbx, ircvd);
     if (status)
@@ -309,7 +309,7 @@ test_replay_dbx(int num_trials, unsigned long ws) {
    * check for false positives for each insertion.
    */
   printf("\ttesting insertion with large gaps...");  
-  for (idx=0, ircvd=0; idx < num_trials; idx++, ircvd += (1 << (rand() % 12))) {
+  for (idx=0, ircvd=0; (int) idx < num_trials; idx++, ircvd += (1 << (rand() % 12))) {
     status = rdbx_check_add(&rdbx, ircvd);
     if (status)
       return status;
@@ -345,7 +345,7 @@ rdbx_check_adds_per_second(int num_trials, unsigned long ws) {
 
   failures = 0;
   timer = clock();
-  for(i=0; i < num_trials; i++) {
+  for(i=0; (int) i < num_trials; i++) {
     
     delta = index_guess(&rdbx.index, &est, i);
     

--- a/test/rtp.c
+++ b/test/rtp.c
@@ -223,5 +223,5 @@ rtp_receiver_alloc(void) {
 
 void
 rtp_receiver_dealloc(rtp_receiver_t rtp_ctx) {
-  return free(rtp_ctx);
+  free(rtp_ctx);
 }

--- a/test/rtpw.c
+++ b/test/rtpw.c
@@ -68,6 +68,9 @@
 
 #ifdef HAVE_UNISTD_H
 #include <unistd.h>         /* for close()         */
+#elif defined(_MSC_VER)
+#include <io.h>             /* for _close()        */
+#define close _close
 #endif
 #ifdef HAVE_SYS_SOCKET_H
 # include <sys/socket.h>

--- a/test/rtpw.c
+++ b/test/rtpw.c
@@ -473,7 +473,7 @@ main (int argc, char *argv[]) {
 	      expected_len, len);
       exit(1);    
     } 
-    if (strlen(input_key) > policy.rtp.cipher_key_len*2) {
+    if ((int) strlen(input_key) > policy.rtp.cipher_key_len*2) {
       fprintf(stderr, 
 	      "error: too many digits in key/salt "
 	      "(should be %d hexadecimal digits, found %u)\n",


### PR DESCRIPTION
- Added explicit casts where necessary (signed/unsigned comparison)
- Use minimal `getopt_s` function instead of including `unistd.h` (not available on Windows)
- Fixed compiler errors (invalid array initializers, non-const array sizes).