### PR TITLE
srtp_remove_stream fix: convert SSRC to network order before comparing

### DIFF
--- a/srtp/srtp.c
+++ b/srtp/srtp.c
@@ -1973,6 +1973,9 @@ srtp_remove_stream(srtp_t session, uint32_t ssrc) {
   /* sanity check arguments */
   if (session == NULL)
     return srtp_err_status_bad_param;
+
+  /* will be compared against values in network order in the stream list */
+  ssrc = htonl(ssrc);
   
   /* find stream in list; complain if not found */
   last_stream = stream = session->stream_list;


### PR DESCRIPTION
srtp_remove_stream() always returned error err_status_no_ctx for us. The problem is in comparison logic. SSRC is saved in network byte order internally, but is being compared against SSRC passed in host byte order.