### PR TITLE
Clear 'session' if 'srtp_create' fails.

### DIFF
--- a/srtp/srtp.c
+++ b/srtp/srtp.c
@@ -2028,6 +2028,7 @@ srtp_create(srtp_t *session,               /* handle for session     */
     if (stat) {
       /* clean up everything */
       srtp_dealloc(*session);
+      *session = NULL;
       return stat;
     }    
 


### PR DESCRIPTION
This prevents potential double-free if caller tries to destroy received (but invalid) 'session'.