### PR TITLE
Perform const-correctness to global data, test cases, "virtual tables", discriptions, and pointers to them.

### DIFF
--- a/crypto/cipher/aes.c
+++ b/crypto/cipher/aes.c
@@ -64,7 +64,7 @@
 
 #ifndef WORDS_BIGENDIAN
 
-static uint32_t T0[256] = {
+static const uint32_t T0[256] = {
     0xa56363c6, 0x847c7cf8,  0x997777ee,  0x8d7b7bf6,
     0xdf2f2ff,  0xbd6b6bd6,  0xb16f6fde,  0x54c5c591,
     0x50303060, 0x3010102,   0xa96767ce,  0x7d2b2b56,
@@ -131,7 +131,7 @@ static uint32_t T0[256] = {
     0xcbb0b07b, 0xfc5454a8,  0xd6bbbb6d,  0x3a16162c,
 };
 
-static uint32_t T1[256] = {
+static const uint32_t T1[256] = {
     0x6363c6a5, 0x7c7cf884,  0x7777ee99,  0x7b7bf68d,
     0xf2f2ff0d, 0x6b6bd6bd,  0x6f6fdeb1,  0xc5c59154,
     0x30306050, 0x1010203,   0x6767cea9,  0x2b2b567d,
@@ -198,7 +198,7 @@ static uint32_t T1[256] = {
     0xb0b07bcb, 0x5454a8fc,  0xbbbb6dd6,  0x16162c3a,
 };
 
-static uint32_t T2[256] = {
+static const uint32_t T2[256] = {
     0x63c6a563, 0x7cf8847c,  0x77ee9977,  0x7bf68d7b,
     0xf2ff0df2, 0x6bd6bd6b,  0x6fdeb16f,  0xc59154c5,
     0x30605030, 0x1020301,   0x67cea967,  0x2b567d2b,
@@ -265,7 +265,7 @@ static uint32_t T2[256] = {
     0xb07bcbb0, 0x54a8fc54,  0xbb6dd6bb,  0x162c3a16,
 };
 
-static uint32_t T3[256] = {
+static const uint32_t T3[256] = {
     0xc6a56363, 0xf8847c7c,  0xee997777,  0xf68d7b7b,
     0xff0df2f2, 0xd6bd6b6b,  0xdeb16f6f,  0x9154c5c5,
     0x60503030, 0x2030101,   0xcea96767,  0x567d2b2b,
@@ -332,7 +332,7 @@ static uint32_t T3[256] = {
     0x7bcbb0b0, 0xa8fc5454,  0x6dd6bbbb,  0x2c3a1616,
 };
 
-static uint32_t U0[256] = {
+static const uint32_t U0[256] = {
     0x50a7f451, 0x5365417e,  0xc3a4171a,  0x965e273a,
     0xcb6bab3b, 0xf1459d1f,  0xab58faac,  0x9303e34b,
     0x55fa3020, 0xf66d76ad,  0x9176cc88,  0x254c02f5,
@@ -399,7 +399,7 @@ static uint32_t U0[256] = {
     0x6184cb7b, 0x70b632d5,  0x745c6c48,  0x4257b8d0,
 };
 
-static uint32_t U1[256] = {
+static const uint32_t U1[256] = {
     0xa7f45150, 0x65417e53,  0xa4171ac3,  0x5e273a96,
     0x6bab3bcb, 0x459d1ff1,  0x58faacab,  0x3e34b93,
     0xfa302055, 0x6d76adf6,  0x76cc8891,  0x4c02f525,
@@ -466,7 +466,7 @@ static uint32_t U1[256] = {
     0x84cb7b61, 0xb632d570,  0x5c6c4874,  0x57b8d042,
 };
 
-static uint32_t U2[256] = {
+static const uint32_t U2[256] = {
     0xf45150a7, 0x417e5365,  0x171ac3a4,  0x273a965e,
     0xab3bcb6b, 0x9d1ff145,  0xfaacab58,  0xe34b9303,
     0x302055fa, 0x76adf66d,  0xcc889176,  0x2f5254c,
@@ -533,7 +533,7 @@ static uint32_t U2[256] = {
     0xcb7b6184, 0x32d570b6,  0x6c48745c,  0xb8d04257,
 };
 
-static uint32_t U3[256] = {
+static const uint32_t U3[256] = {
     0x5150a7f4, 0x7e536541,  0x1ac3a417,  0x3a965e27,
     0x3bcb6bab, 0x1ff1459d,  0xacab58fa,  0x4b9303e3,
     0x2055fa30, 0xadf66d76,  0x889176cc,  0xf5254c02,
@@ -602,7 +602,7 @@ static uint32_t U3[256] = {
 
 #else /* assume big endian */
 
-static uint32_t T0[256] = {
+static const uint32_t T0[256] = {
     0xc66363a5, 0xf87c7c84,  0xee777799,  0xf67b7b8d,
     0xfff2f20d, 0xd66b6bbd,  0xde6f6fb1,  0x91c5c554,
     0x60303050, 0x2010103,   0xce6767a9,  0x562b2b7d,
@@ -669,7 +669,7 @@ static uint32_t T0[256] = {
     0x7bb0b0cb, 0xa85454fc,  0x6dbbbbd6,  0x2c16163a,
 };
 
-static uint32_t T1[256] = {
+static const uint32_t T1[256] = {
     0xa5c66363, 0x84f87c7c,  0x99ee7777,  0x8df67b7b,
     0xdfff2f2,  0xbdd66b6b,  0xb1de6f6f,  0x5491c5c5,
     0x50603030, 0x3020101,   0xa9ce6767,  0x7d562b2b,
@@ -736,7 +736,7 @@ static uint32_t T1[256] = {
     0xcb7bb0b0, 0xfca85454,  0xd66dbbbb,  0x3a2c1616,
 };
 
-static uint32_t T2[256] = {
+static const uint32_t T2[256] = {
     0x63a5c663, 0x7c84f87c,  0x7799ee77,  0x7b8df67b,
     0xf20dfff2, 0x6bbdd66b,  0x6fb1de6f,  0xc55491c5,
     0x30506030, 0x1030201,   0x67a9ce67,  0x2b7d562b,
@@ -803,7 +803,7 @@ static uint32_t T2[256] = {
     0xb0cb7bb0, 0x54fca854,  0xbbd66dbb,  0x163a2c16,
 };
 
-static uint32_t T3[256] = {
+static const uint32_t T3[256] = {
     0x6363a5c6, 0x7c7c84f8,  0x777799ee,  0x7b7b8df6,
     0xf2f20dff, 0x6b6bbdd6,  0x6f6fb1de,  0xc5c55491,
     0x30305060, 0x1010302,   0x6767a9ce,  0x2b2b7d56,
@@ -870,7 +870,7 @@ static uint32_t T3[256] = {
     0xb0b0cb7b, 0x5454fca8,  0xbbbbd66d,  0x16163a2c,
 };
 
-static uint32_t U0[256] = {
+static const uint32_t U0[256] = {
     0x51f4a750, 0x7e416553,  0x1a17a4c3,  0x3a275e96,
     0x3bab6bcb, 0x1f9d45f1,  0xacfa58ab,  0x4be30393,
     0x2030fa55, 0xad766df6,  0x88cc7691,  0xf5024c25,
@@ -937,7 +937,7 @@ static uint32_t U0[256] = {
     0x7bcb8461, 0xd532b670,  0x486c5c74,  0xd0b85742
 };
 
-static uint32_t U1[256] = {
+static const uint32_t U1[256] = {
     0x5051f4a7, 0x537e4165,  0xc31a17a4,  0x963a275e,
     0xcb3bab6b, 0xf11f9d45,  0xabacfa58,  0x934be303,
     0x552030fa, 0xf6ad766d,  0x9188cc76,  0x25f5024c,
@@ -1004,7 +1004,7 @@ static uint32_t U1[256] = {
     0x617bcb84, 0x70d532b6,  0x74486c5c,  0x42d0b857
 };
 
-static uint32_t U2[256] = {
+static const uint32_t U2[256] = {
     0xa75051f4, 0x65537e41,  0xa4c31a17,  0x5e963a27,
     0x6bcb3bab, 0x45f11f9d,  0x58abacfa,  0x3934be3,
     0xfa552030, 0x6df6ad76,  0x769188cc,  0x4c25f502,
@@ -1071,7 +1071,7 @@ static uint32_t U2[256] = {
     0x84617bcb, 0xb670d532,  0x5c74486c,  0x5742d0b8
 };
 
-static uint32_t U3[256] = {
+static const uint32_t U3[256] = {
     0xf4a75051, 0x4165537e,  0x17a4c31a,  0x275e963a,
     0xab6bcb3b, 0x9d45f11f,  0xfa58abac,  0xe303934b,
     0x30fa5520, 0x766df6ad,  0xcc769188,  0x24c25f5,
@@ -1145,7 +1145,7 @@ static uint32_t U3[256] = {
  * endian-neutral
  */
 
-static uint8_t
+static const uint8_t
     aes_sbox[256] = {
     0x63, 0x7c, 0x77, 0x7b, 0xf2, 0x6b, 0x6f, 0xc5,
     0x30, 0x01, 0x67, 0x2b, 0xfe, 0xd7, 0xab, 0x76,
@@ -1182,7 +1182,7 @@ static uint8_t
 };
 
 #ifndef CPU_RISC
-static uint8_t
+static const uint8_t
     aes_inv_sbox[256] = {
     0x52, 0x09, 0x6a, 0xd5, 0x30, 0x36, 0xa5, 0x38,
     0xbf, 0x40, 0xa3, 0x9e, 0x81, 0xf3, 0xd7, 0xfb,
@@ -1220,7 +1220,7 @@ static uint8_t
 #endif /* ! CPU_RISC */
 
 #ifdef CPU_RISC
-static uint32_t
+static const uint32_t
     T4[256] = {
     0x63636363, 0x7c7c7c7c, 0x77777777, 0x7b7b7b7b,
     0xf2f2f2f2, 0x6b6b6b6b, 0x6f6f6f6f, 0xc5c5c5c5,
@@ -1288,7 +1288,7 @@ static uint32_t
     0xb0b0b0b0, 0x54545454, 0xbbbbbbbb, 0x16161616
 };
 
-static uint32_t U4[256] = {
+static const uint32_t U4[256] = {
     0x52525252, 0x9090909,   0x6a6a6a6a,  0xd5d5d5d5,
     0x30303030, 0x36363636,  0xa5a5a5a5,  0x38383838,
     0xbfbfbfbf, 0x40404040,  0xa3a3a3a3,  0x9e9e9e9e,

--- a/crypto/cipher/aes_gcm_ossl.c
+++ b/crypto/cipher/aes_gcm_ossl.c
@@ -64,8 +64,8 @@ srtp_debug_module_t srtp_mod_aes_gcm = {
  * The following are the global singleton instances for the
  * 128-bit and 256-bit GCM ciphers.
  */
-extern srtp_cipher_type_t srtp_aes_gcm_128_openssl;
-extern srtp_cipher_type_t srtp_aes_gcm_256_openssl;
+extern const srtp_cipher_type_t srtp_aes_gcm_128_openssl;
+extern const srtp_cipher_type_t srtp_aes_gcm_256_openssl;
 
 /*
  * For now we only support 8 and 16 octet tags.  The spec allows for
@@ -247,7 +247,7 @@ static srtp_err_status_t srtp_aes_gcm_openssl_set_iv (srtp_aes_gcm_ctx_t *c, con
  *	aad	Additional data to process for AEAD cipher suites
  *	aad_len	length of aad buffer
  */
-static srtp_err_status_t srtp_aes_gcm_openssl_set_aad (srtp_aes_gcm_ctx_t *c, uint8_t *aad, uint32_t aad_len)
+static srtp_err_status_t srtp_aes_gcm_openssl_set_aad (srtp_aes_gcm_ctx_t *c, const uint8_t *aad, uint32_t aad_len)
 {
     int rv;
 
@@ -255,7 +255,14 @@ static srtp_err_status_t srtp_aes_gcm_openssl_set_aad (srtp_aes_gcm_ctx_t *c, ui
      * Set dummy tag, OpenSSL requires the Tag to be set before
      * processing AAD
      */
-    EVP_CIPHER_CTX_ctrl(&c->ctx, EVP_CTRL_GCM_SET_TAG, c->tag_len, aad);
+
+    /*
+     * OpenSSL never write to address pointed by the last parameter of
+     * EVP_CIPHER_CTX_ctrl while EVP_CTRL_GCM_SET_TAG (in reality, 
+     * OpenSSL copy its content to the context), so we can make 
+     * aad read-only in this function and all its wrappers.
+     */
+    EVP_CIPHER_CTX_ctrl(&c->ctx, EVP_CTRL_GCM_SET_TAG, c->tag_len, (void*)aad);
 
     rv = EVP_Cipher(&c->ctx, NULL, aad, aad_len);
     if (rv != aad_len) {
@@ -361,8 +368,8 @@ static srtp_err_status_t srtp_aes_gcm_openssl_decrypt (srtp_aes_gcm_ctx_t *c, un
 /*
  * Name of this crypto engine
  */
-static char srtp_aes_gcm_128_openssl_description[] = "AES-128 GCM using openssl";
-static char srtp_aes_gcm_256_openssl_description[] = "AES-256 GCM using openssl";
+static const char srtp_aes_gcm_128_openssl_description[] = "AES-128 GCM using openssl";
+static const char srtp_aes_gcm_256_openssl_description[] = "AES-256 GCM using openssl";
 
 
 /*
@@ -370,19 +377,19 @@ static char srtp_aes_gcm_256_openssl_description[] = "AES-256 GCM using openssl"
  * values we're derived from independent test code
  * using OpenSSL.
  */
-static uint8_t srtp_aes_gcm_test_case_0_key[SRTP_AES_128_GCM_KEYSIZE_WSALT] = {
+static const uint8_t srtp_aes_gcm_test_case_0_key[SRTP_AES_128_GCM_KEYSIZE_WSALT] = {
     0xfe, 0xff, 0xe9, 0x92, 0x86, 0x65, 0x73, 0x1c,
     0x6d, 0x6a, 0x8f, 0x94, 0x67, 0x30, 0x83, 0x08,
     0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08,
     0x09, 0x0a, 0x0b, 0x0c,
 };
 
-static uint8_t srtp_aes_gcm_test_case_0_iv[12] = {
+static const uint8_t srtp_aes_gcm_test_case_0_iv[12] = {
     0xca, 0xfe, 0xba, 0xbe, 0xfa, 0xce, 0xdb, 0xad,
     0xde, 0xca, 0xf8, 0x88
 };
 
-static uint8_t srtp_aes_gcm_test_case_0_plaintext[60] =  {
+static const uint8_t srtp_aes_gcm_test_case_0_plaintext[60] =  {
     0xd9, 0x31, 0x32, 0x25, 0xf8, 0x84, 0x06, 0xe5,
     0xa5, 0x59, 0x09, 0xc5, 0xaf, 0xf5, 0x26, 0x9a,
     0x86, 0xa7, 0xa9, 0x53, 0x15, 0x34, 0xf7, 0xda,
@@ -393,13 +400,13 @@ static uint8_t srtp_aes_gcm_test_case_0_plaintext[60] =  {
     0xba, 0x63, 0x7b, 0x39
 };
 
-static uint8_t srtp_aes_gcm_test_case_0_aad[20] = {
+static const uint8_t srtp_aes_gcm_test_case_0_aad[20] = {
     0xfe, 0xed, 0xfa, 0xce, 0xde, 0xad, 0xbe, 0xef,
     0xfe, 0xed, 0xfa, 0xce, 0xde, 0xad, 0xbe, 0xef,
     0xab, 0xad, 0xda, 0xd2
 };
 
-static uint8_t srtp_aes_gcm_test_case_0_ciphertext[76] = {
+static const uint8_t srtp_aes_gcm_test_case_0_ciphertext[76] = {
     0x42, 0x83, 0x1e, 0xc2, 0x21, 0x77, 0x74, 0x24,
     0x4b, 0x72, 0x21, 0xb7, 0x84, 0xd0, 0xd4, 0x9c,
     0xe3, 0xaa, 0x21, 0x2f, 0x2c, 0x02, 0xa4, 0xe0,
@@ -413,7 +420,7 @@ static uint8_t srtp_aes_gcm_test_case_0_ciphertext[76] = {
     0x94, 0xfa, 0xe9, 0x5a, 0xe7, 0x12, 0x1a, 0x47,
 };
 
-static srtp_cipher_test_case_t srtp_aes_gcm_test_case_0a = {
+static const srtp_cipher_test_case_t srtp_aes_gcm_test_case_0a = {
     SRTP_AES_128_GCM_KEYSIZE_WSALT,      /* octets in key            */
     srtp_aes_gcm_test_case_0_key,        /* key                      */
     srtp_aes_gcm_test_case_0_iv,         /* packet index             */
@@ -427,7 +434,7 @@ static srtp_cipher_test_case_t srtp_aes_gcm_test_case_0a = {
     NULL                                 /* pointer to next testcase */
 };
 
-static srtp_cipher_test_case_t srtp_aes_gcm_test_case_0 = {
+static const srtp_cipher_test_case_t srtp_aes_gcm_test_case_0 = {
     SRTP_AES_128_GCM_KEYSIZE_WSALT,      /* octets in key            */
     srtp_aes_gcm_test_case_0_key,        /* key                      */
     srtp_aes_gcm_test_case_0_iv,         /* packet index             */
@@ -441,7 +448,7 @@ static srtp_cipher_test_case_t srtp_aes_gcm_test_case_0 = {
     &srtp_aes_gcm_test_case_0a           /* pointer to next testcase */
 };
 
-static uint8_t srtp_aes_gcm_test_case_1_key[SRTP_AES_256_GCM_KEYSIZE_WSALT] = {
+static const uint8_t srtp_aes_gcm_test_case_1_key[SRTP_AES_256_GCM_KEYSIZE_WSALT] = {
     0xfe, 0xff, 0xe9, 0x92, 0x86, 0x65, 0x73, 0x1c,
     0xa5, 0x59, 0x09, 0xc5, 0x54, 0x66, 0x93, 0x1c,
     0xaf, 0xf5, 0x26, 0x9a, 0x21, 0xd5, 0x14, 0xb2,
@@ -451,12 +458,12 @@ static uint8_t srtp_aes_gcm_test_case_1_key[SRTP_AES_256_GCM_KEYSIZE_WSALT] = {
 
 };
 
-static uint8_t srtp_aes_gcm_test_case_1_iv[12] = {
+static const uint8_t srtp_aes_gcm_test_case_1_iv[12] = {
     0xca, 0xfe, 0xba, 0xbe, 0xfa, 0xce, 0xdb, 0xad,
     0xde, 0xca, 0xf8, 0x88
 };
 
-static uint8_t srtp_aes_gcm_test_case_1_plaintext[60] =  {
+static const uint8_t srtp_aes_gcm_test_case_1_plaintext[60] =  {
     0xd9, 0x31, 0x32, 0x25, 0xf8, 0x84, 0x06, 0xe5,
     0xa5, 0x59, 0x09, 0xc5, 0xaf, 0xf5, 0x26, 0x9a,
     0x86, 0xa7, 0xa9, 0x53, 0x15, 0x34, 0xf7, 0xda,
@@ -467,13 +474,13 @@ static uint8_t srtp_aes_gcm_test_case_1_plaintext[60] =  {
     0xba, 0x63, 0x7b, 0x39
 };
 
-static uint8_t srtp_aes_gcm_test_case_1_aad[20] = {
+static const uint8_t srtp_aes_gcm_test_case_1_aad[20] = {
     0xfe, 0xed, 0xfa, 0xce, 0xde, 0xad, 0xbe, 0xef,
     0xfe, 0xed, 0xfa, 0xce, 0xde, 0xad, 0xbe, 0xef,
     0xab, 0xad, 0xda, 0xd2
 };
 
-static uint8_t srtp_aes_gcm_test_case_1_ciphertext[76] = {
+static const uint8_t srtp_aes_gcm_test_case_1_ciphertext[76] = {
     0x0b, 0x11, 0xcf, 0xaf, 0x68, 0x4d, 0xae, 0x46,
     0xc7, 0x90, 0xb8, 0x8e, 0xb7, 0x6a, 0x76, 0x2a,
     0x94, 0x82, 0xca, 0xab, 0x3e, 0x39, 0xd7, 0x86,
@@ -487,7 +494,7 @@ static uint8_t srtp_aes_gcm_test_case_1_ciphertext[76] = {
     0x81, 0xcb, 0x8e, 0x5b, 0x46, 0x65, 0x63, 0x1d,
 };
 
-static srtp_cipher_test_case_t srtp_aes_gcm_test_case_1a = {
+static const srtp_cipher_test_case_t srtp_aes_gcm_test_case_1a = {
     SRTP_AES_256_GCM_KEYSIZE_WSALT,      /* octets in key            */
     srtp_aes_gcm_test_case_1_key,        /* key                      */
     srtp_aes_gcm_test_case_1_iv,         /* packet index             */
@@ -501,7 +508,7 @@ static srtp_cipher_test_case_t srtp_aes_gcm_test_case_1a = {
     NULL                                 /* pointer to next testcase */
 };
 
-static srtp_cipher_test_case_t srtp_aes_gcm_test_case_1 = {
+static const srtp_cipher_test_case_t srtp_aes_gcm_test_case_1 = {
     SRTP_AES_256_GCM_KEYSIZE_WSALT,      /* octets in key            */
     srtp_aes_gcm_test_case_1_key,        /* key                      */
     srtp_aes_gcm_test_case_1_iv,         /* packet index             */
@@ -518,7 +525,7 @@ static srtp_cipher_test_case_t srtp_aes_gcm_test_case_1 = {
 /*
  * This is the vector function table for this crypto engine.
  */
-srtp_cipher_type_t srtp_aes_gcm_128_openssl = {
+const srtp_cipher_type_t srtp_aes_gcm_128_openssl = {
     (cipher_alloc_func_t)srtp_aes_gcm_openssl_alloc,
     (cipher_dealloc_func_t)srtp_aes_gcm_openssl_dealloc,
     (cipher_init_func_t)srtp_aes_gcm_openssl_context_init,
@@ -527,8 +534,8 @@ srtp_cipher_type_t srtp_aes_gcm_128_openssl = {
     (cipher_decrypt_func_t)srtp_aes_gcm_openssl_decrypt,
     (cipher_set_iv_func_t)srtp_aes_gcm_openssl_set_iv,
     (cipher_get_tag_func_t)srtp_aes_gcm_openssl_get_tag,
-    (char*)srtp_aes_gcm_128_openssl_description,
-    (srtp_cipher_test_case_t*)&srtp_aes_gcm_test_case_0,
+    (const char*)srtp_aes_gcm_128_openssl_description,
+    (const srtp_cipher_test_case_t*)&srtp_aes_gcm_test_case_0,
     (srtp_debug_module_t*)&srtp_mod_aes_gcm,
     (srtp_cipher_type_id_t)SRTP_AES_128_GCM
 };
@@ -545,8 +552,8 @@ srtp_cipher_type_t srtp_aes_gcm_256_openssl = {
     (cipher_decrypt_func_t)srtp_aes_gcm_openssl_decrypt,
     (cipher_set_iv_func_t)srtp_aes_gcm_openssl_set_iv,
     (cipher_get_tag_func_t)srtp_aes_gcm_openssl_get_tag,
-    (char*)srtp_aes_gcm_256_openssl_description,
-    (srtp_cipher_test_case_t*)&srtp_aes_gcm_test_case_1,
+    (const char*)srtp_aes_gcm_256_openssl_description,
+    (const srtp_cipher_test_case_t*)&srtp_aes_gcm_test_case_1,
     (srtp_debug_module_t*)&srtp_mod_aes_gcm,
     (srtp_cipher_type_id_t)SRTP_AES_256_GCM
 };

--- a/crypto/cipher/aes_icm.c
+++ b/crypto/cipher/aes_icm.c
@@ -94,7 +94,7 @@ srtp_debug_module_t srtp_mod_aes_icm = {
 
 static srtp_err_status_t srtp_aes_icm_alloc_ismacryp (srtp_cipher_t **c, int key_len, int forIsmacryp)
 {
-    extern srtp_cipher_type_t srtp_aes_icm;
+    extern const srtp_cipher_type_t srtp_aes_icm;
     srtp_aes_icm_ctx_t *icm;
 
     debug_print(srtp_mod_aes_icm,
@@ -424,35 +424,35 @@ static srtp_err_status_t srtp_aes_icm_encrypt (srtp_aes_icm_ctx_t *c, unsigned c
     return srtp_aes_icm_encrypt_ismacryp(c, buf, enc_len, 0);
 }
 
-static char srtp_aes_icm_description[] = "aes integer counter mode";
+static const char srtp_aes_icm_description[] = "aes integer counter mode";
 
-static uint8_t srtp_aes_icm_test_case_0_key[30] = {
+static const uint8_t srtp_aes_icm_test_case_0_key[30] = {
     0x2b, 0x7e, 0x15, 0x16, 0x28, 0xae, 0xd2, 0xa6,
     0xab, 0xf7, 0x15, 0x88, 0x09, 0xcf, 0x4f, 0x3c,
     0xf0, 0xf1, 0xf2, 0xf3, 0xf4, 0xf5, 0xf6, 0xf7,
     0xf8, 0xf9, 0xfa, 0xfb, 0xfc, 0xfd
 };
 
-static uint8_t srtp_aes_icm_test_case_0_nonce[16] = {
+static const uint8_t srtp_aes_icm_test_case_0_nonce[16] = {
     0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
     0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00
 };
 
-static uint8_t srtp_aes_icm_test_case_0_plaintext[32] =  {
+static const uint8_t srtp_aes_icm_test_case_0_plaintext[32] =  {
     0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
     0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
     0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
     0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
 };
 
-static uint8_t srtp_aes_icm_test_case_0_ciphertext[32] = {
+static const uint8_t srtp_aes_icm_test_case_0_ciphertext[32] = {
     0xe0, 0x3e, 0xad, 0x09, 0x35, 0xc9, 0x5e, 0x80,
     0xe1, 0x66, 0xb1, 0x6d, 0xd9, 0x2b, 0x4e, 0xb4,
     0xd2, 0x35, 0x13, 0x16, 0x2b, 0x02, 0xd0, 0xf7,
     0x2a, 0x43, 0xa2, 0xfe, 0x4a, 0x5f, 0x97, 0xab
 };
 
-static srtp_cipher_test_case_t srtp_aes_icm_test_case_0 = {
+static const srtp_cipher_test_case_t srtp_aes_icm_test_case_0 = {
     30,                                  /* octets in key            */
     srtp_aes_icm_test_case_0_key,        /* key                      */
     srtp_aes_icm_test_case_0_nonce,      /* packet index             */
@@ -466,7 +466,7 @@ static srtp_cipher_test_case_t srtp_aes_icm_test_case_0 = {
     NULL                                 /* pointer to next testcase */
 };
 
-static uint8_t srtp_aes_icm_test_case_1_key[46] = {
+static const uint8_t srtp_aes_icm_test_case_1_key[46] = {
     0x57, 0xf8, 0x2f, 0xe3, 0x61, 0x3f, 0xd1, 0x70,
     0xa8, 0x5e, 0xc9, 0x3c, 0x40, 0xb1, 0xf0, 0x92,
     0x2e, 0xc4, 0xcb, 0x0d, 0xc0, 0x25, 0xb5, 0x82,
@@ -475,26 +475,26 @@ static uint8_t srtp_aes_icm_test_case_1_key[46] = {
     0xf8, 0xf9, 0xfa, 0xfb, 0xfc, 0xfd
 };
 
-static uint8_t srtp_aes_icm_test_case_1_nonce[16] = {
+static const uint8_t srtp_aes_icm_test_case_1_nonce[16] = {
     0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
     0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00
 };
 
-static uint8_t srtp_aes_icm_test_case_1_plaintext[32] =  {
+static const uint8_t srtp_aes_icm_test_case_1_plaintext[32] =  {
     0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
     0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
     0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
     0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
 };
 
-static uint8_t srtp_aes_icm_test_case_1_ciphertext[32] = {
+static const uint8_t srtp_aes_icm_test_case_1_ciphertext[32] = {
     0x92, 0xbd, 0xd2, 0x8a, 0x93, 0xc3, 0xf5, 0x25,
     0x11, 0xc6, 0x77, 0xd0, 0x8b, 0x55, 0x15, 0xa4,
     0x9d, 0xa7, 0x1b, 0x23, 0x78, 0xa8, 0x54, 0xf6,
     0x70, 0x50, 0x75, 0x6d, 0xed, 0x16, 0x5b, 0xac
 };
 
-static srtp_cipher_test_case_t srtp_aes_icm_test_case_1 = {
+static const srtp_cipher_test_case_t srtp_aes_icm_test_case_1 = {
     46,                                  /* octets in key            */
     srtp_aes_icm_test_case_1_key,        /* key                      */
     srtp_aes_icm_test_case_1_nonce,      /* packet index             */
@@ -514,7 +514,7 @@ static srtp_cipher_test_case_t srtp_aes_icm_test_case_1 = {
  * note: the encrypt function is identical to the decrypt function
  */
 
-srtp_cipher_type_t srtp_aes_icm = {
+const srtp_cipher_type_t srtp_aes_icm = {
     (cipher_alloc_func_t)srtp_aes_icm_alloc,
     (cipher_dealloc_func_t)srtp_aes_icm_dealloc,
     (cipher_init_func_t)srtp_aes_icm_context_init,
@@ -523,8 +523,8 @@ srtp_cipher_type_t srtp_aes_icm = {
     (cipher_decrypt_func_t)srtp_aes_icm_encrypt,
     (cipher_set_iv_func_t)srtp_aes_icm_set_iv,
     (cipher_get_tag_func_t)0,
-    (char*)srtp_aes_icm_description,
-    (srtp_cipher_test_case_t*)&srtp_aes_icm_test_case_1,
+    (const char*)srtp_aes_icm_description,
+    (const srtp_cipher_test_case_t*)&srtp_aes_icm_test_case_1,
     (srtp_debug_module_t*)&srtp_mod_aes_icm,
     (srtp_cipher_type_id_t)SRTP_AES_ICM
 };

--- a/crypto/cipher/aes_icm_ossl.c
+++ b/crypto/cipher/aes_icm_ossl.c
@@ -63,11 +63,11 @@ srtp_debug_module_t srtp_mod_aes_icm = {
     0,               /* debugging is off by default */
     "aes icm ossl"   /* printable module name       */
 };
-extern srtp_cipher_type_t srtp_aes_icm;
+extern const srtp_cipher_type_t srtp_aes_icm;
 #ifndef SRTP_NO_AES192
-extern srtp_cipher_type_t srtp_aes_icm_192;
+extern const srtp_cipher_type_t srtp_aes_icm_192;
 #endif
-extern srtp_cipher_type_t srtp_aes_icm_256;
+extern const srtp_cipher_type_t srtp_aes_icm_256;
 
 /*
  * integer counter mode works as follows:
@@ -333,44 +333,44 @@ static srtp_err_status_t srtp_aes_icm_openssl_encrypt (srtp_aes_icm_ctx_t *c, un
 /*
  * Name of this crypto engine
  */
-static char srtp_aes_icm_openssl_description[] = "AES-128 counter mode using openssl";
+static const char srtp_aes_icm_openssl_description[] = "AES-128 counter mode using openssl";
 #ifndef SRTP_NO_AES192
-static char srtp_aes_icm_192_openssl_description[] = "AES-192 counter mode using openssl";
+static const char srtp_aes_icm_192_openssl_description[] = "AES-192 counter mode using openssl";
 #endif
-static char srtp_aes_icm_256_openssl_description[] = "AES-256 counter mode using openssl";
+static const char srtp_aes_icm_256_openssl_description[] = "AES-256 counter mode using openssl";
 
 
 /*
  * KAT values for AES self-test.  These
  * values came from the legacy libsrtp code.
  */
-static uint8_t srtp_aes_icm_test_case_0_key[SRTP_AES_128_KEYSIZE_WSALT] = {
+static const uint8_t srtp_aes_icm_test_case_0_key[SRTP_AES_128_KEYSIZE_WSALT] = {
     0x2b, 0x7e, 0x15, 0x16, 0x28, 0xae, 0xd2, 0xa6,
     0xab, 0xf7, 0x15, 0x88, 0x09, 0xcf, 0x4f, 0x3c,
     0xf0, 0xf1, 0xf2, 0xf3, 0xf4, 0xf5, 0xf6, 0xf7,
     0xf8, 0xf9, 0xfa, 0xfb, 0xfc, 0xfd
 };
 
-static uint8_t srtp_aes_icm_test_case_0_nonce[16] = {
+static const uint8_t srtp_aes_icm_test_case_0_nonce[16] = {
     0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
     0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00
 };
 
-static uint8_t srtp_aes_icm_test_case_0_plaintext[32] =  {
+static const uint8_t srtp_aes_icm_test_case_0_plaintext[32] =  {
     0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
     0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
     0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
     0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
 };
 
-static uint8_t srtp_aes_icm_test_case_0_ciphertext[32] = {
+static const uint8_t srtp_aes_icm_test_case_0_ciphertext[32] = {
     0xe0, 0x3e, 0xad, 0x09, 0x35, 0xc9, 0x5e, 0x80,
     0xe1, 0x66, 0xb1, 0x6d, 0xd9, 0x2b, 0x4e, 0xb4,
     0xd2, 0x35, 0x13, 0x16, 0x2b, 0x02, 0xd0, 0xf7,
     0x2a, 0x43, 0xa2, 0xfe, 0x4a, 0x5f, 0x97, 0xab
 };
 
-static srtp_cipher_test_case_t srtp_aes_icm_test_case_0 = {
+static const srtp_cipher_test_case_t srtp_aes_icm_test_case_0 = {
     SRTP_AES_128_KEYSIZE_WSALT,                 /* octets in key            */
     srtp_aes_icm_test_case_0_key,               /* key                      */
     srtp_aes_icm_test_case_0_nonce,             /* packet index             */
@@ -389,7 +389,7 @@ static srtp_cipher_test_case_t srtp_aes_icm_test_case_0 = {
  * KAT values for AES-192-CTR self-test.  These
  * values came from section 7 of RFC 6188.
  */
-static uint8_t srtp_aes_icm_192_test_case_1_key[SRTP_AES_192_KEYSIZE_WSALT] = {
+static const uint8_t srtp_aes_icm_192_test_case_1_key[SRTP_AES_192_KEYSIZE_WSALT] = {
     0xea, 0xb2, 0x34, 0x76, 0x4e, 0x51, 0x7b, 0x2d,
     0x3d, 0x16, 0x0d, 0x58, 0x7d, 0x8c, 0x86, 0x21,
     0x97, 0x40, 0xf6, 0x5f, 0x99, 0xb6, 0xbc, 0xf7,
@@ -397,26 +397,26 @@ static uint8_t srtp_aes_icm_192_test_case_1_key[SRTP_AES_192_KEYSIZE_WSALT] = {
     0xf8, 0xf9, 0xfa, 0xfb, 0xfc, 0xfd
 };
 
-static uint8_t srtp_aes_icm_192_test_case_1_nonce[16] = {
+static const uint8_t srtp_aes_icm_192_test_case_1_nonce[16] = {
     0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
     0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00
 };
 
-static uint8_t srtp_aes_icm_192_test_case_1_plaintext[32] =  {
+static const uint8_t srtp_aes_icm_192_test_case_1_plaintext[32] =  {
     0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
     0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
     0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
     0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
 };
 
-static uint8_t srtp_aes_icm_192_test_case_1_ciphertext[32] = {
+static const uint8_t srtp_aes_icm_192_test_case_1_ciphertext[32] = {
     0x35, 0x09, 0x6c, 0xba, 0x46, 0x10, 0x02, 0x8d,
     0xc1, 0xb5, 0x75, 0x03, 0x80, 0x4c, 0xe3, 0x7c,
     0x5d, 0xe9, 0x86, 0x29, 0x1d, 0xcc, 0xe1, 0x61,
     0xd5, 0x16, 0x5e, 0xc4, 0x56, 0x8f, 0x5c, 0x9a
 };
 
-static srtp_cipher_test_case_t srtp_aes_icm_192_test_case_1 = {
+static const srtp_cipher_test_case_t srtp_aes_icm_192_test_case_1 = {
     SRTP_AES_192_KEYSIZE_WSALT,                 /* octets in key            */
     srtp_aes_icm_192_test_case_1_key,           /* key                      */
     srtp_aes_icm_192_test_case_1_nonce,         /* packet index             */
@@ -435,7 +435,7 @@ static srtp_cipher_test_case_t srtp_aes_icm_192_test_case_1 = {
  * KAT values for AES-256-CTR self-test.  These
  * values came from section 7 of RFC 6188.
  */
-static uint8_t srtp_aes_icm_256_test_case_2_key[SRTP_AES_256_KEYSIZE_WSALT] = {
+static const uint8_t srtp_aes_icm_256_test_case_2_key[SRTP_AES_256_KEYSIZE_WSALT] = {
     0x57, 0xf8, 0x2f, 0xe3, 0x61, 0x3f, 0xd1, 0x70,
     0xa8, 0x5e, 0xc9, 0x3c, 0x40, 0xb1, 0xf0, 0x92,
     0x2e, 0xc4, 0xcb, 0x0d, 0xc0, 0x25, 0xb5, 0x82,
@@ -444,26 +444,26 @@ static uint8_t srtp_aes_icm_256_test_case_2_key[SRTP_AES_256_KEYSIZE_WSALT] = {
     0xf8, 0xf9, 0xfa, 0xfb, 0xfc, 0xfd
 };
 
-static uint8_t srtp_aes_icm_256_test_case_2_nonce[16] = {
+static const uint8_t srtp_aes_icm_256_test_case_2_nonce[16] = {
     0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
     0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00
 };
 
-static uint8_t srtp_aes_icm_256_test_case_2_plaintext[32] =  {
+static const uint8_t srtp_aes_icm_256_test_case_2_plaintext[32] =  {
     0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
     0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
     0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
     0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
 };
 
-static uint8_t srtp_aes_icm_256_test_case_2_ciphertext[32] = {
+static const uint8_t srtp_aes_icm_256_test_case_2_ciphertext[32] = {
     0x92, 0xbd, 0xd2, 0x8a, 0x93, 0xc3, 0xf5, 0x25,
     0x11, 0xc6, 0x77, 0xd0, 0x8b, 0x55, 0x15, 0xa4,
     0x9d, 0xa7, 0x1b, 0x23, 0x78, 0xa8, 0x54, 0xf6,
     0x70, 0x50, 0x75, 0x6d, 0xed, 0x16, 0x5b, 0xac
 };
 
-static srtp_cipher_test_case_t srtp_aes_icm_256_test_case_2 = {
+static const srtp_cipher_test_case_t srtp_aes_icm_256_test_case_2 = {
     SRTP_AES_256_KEYSIZE_WSALT,                 /* octets in key            */
     srtp_aes_icm_256_test_case_2_key,           /* key                      */
     srtp_aes_icm_256_test_case_2_nonce,         /* packet index             */
@@ -481,7 +481,7 @@ static srtp_cipher_test_case_t srtp_aes_icm_256_test_case_2 = {
  * This is the function table for this crypto engine.
  * note: the encrypt function is identical to the decrypt function
  */
-srtp_cipher_type_t srtp_aes_icm = {
+const srtp_cipher_type_t srtp_aes_icm = {
     (cipher_alloc_func_t)          srtp_aes_icm_openssl_alloc,
     (cipher_dealloc_func_t)        srtp_aes_icm_openssl_dealloc,
     (cipher_init_func_t)           srtp_aes_icm_openssl_context_init,
@@ -490,8 +490,8 @@ srtp_cipher_type_t srtp_aes_icm = {
     (cipher_decrypt_func_t)        srtp_aes_icm_openssl_encrypt,
     (cipher_set_iv_func_t)         srtp_aes_icm_openssl_set_iv,
     (cipher_get_tag_func_t)        0,
-    (char*)                        srtp_aes_icm_openssl_description,
-    (srtp_cipher_test_case_t*)          &srtp_aes_icm_test_case_0,
+    (const char*)                        srtp_aes_icm_openssl_description,
+    (const srtp_cipher_test_case_t*)          &srtp_aes_icm_test_case_0,
     (srtp_debug_module_t*)              &srtp_mod_aes_icm,
     (srtp_cipher_type_id_t)        SRTP_AES_ICM
 };
@@ -501,7 +501,7 @@ srtp_cipher_type_t srtp_aes_icm = {
  * This is the function table for this crypto engine.
  * note: the encrypt function is identical to the decrypt function
  */
-srtp_cipher_type_t srtp_aes_icm_192 = {
+const srtp_cipher_type_t srtp_aes_icm_192 = {
     (cipher_alloc_func_t)          srtp_aes_icm_openssl_alloc,
     (cipher_dealloc_func_t)        srtp_aes_icm_openssl_dealloc,
     (cipher_init_func_t)           srtp_aes_icm_openssl_context_init,
@@ -510,8 +510,8 @@ srtp_cipher_type_t srtp_aes_icm_192 = {
     (cipher_decrypt_func_t)        srtp_aes_icm_openssl_encrypt,
     (cipher_set_iv_func_t)         srtp_aes_icm_openssl_set_iv,
     (cipher_get_tag_func_t)        0,
-    (char*)                        srtp_aes_icm_192_openssl_description,
-    (srtp_cipher_test_case_t*)          &srtp_aes_icm_192_test_case_1,
+    (const char*)                        srtp_aes_icm_192_openssl_description,
+    (const srtp_cipher_test_case_t*)          &srtp_aes_icm_192_test_case_1,
     (srtp_debug_module_t*)              &srtp_mod_aes_icm,
     (srtp_cipher_type_id_t)        SRTP_AES_192_ICM
 };
@@ -521,7 +521,7 @@ srtp_cipher_type_t srtp_aes_icm_192 = {
  * This is the function table for this crypto engine.
  * note: the encrypt function is identical to the decrypt function
  */
-srtp_cipher_type_t srtp_aes_icm_256 = {
+const srtp_cipher_type_t srtp_aes_icm_256 = {
     (cipher_alloc_func_t)          srtp_aes_icm_openssl_alloc,
     (cipher_dealloc_func_t)        srtp_aes_icm_openssl_dealloc,
     (cipher_init_func_t)           srtp_aes_icm_openssl_context_init,
@@ -530,8 +530,8 @@ srtp_cipher_type_t srtp_aes_icm_256 = {
     (cipher_decrypt_func_t)        srtp_aes_icm_openssl_encrypt,
     (cipher_set_iv_func_t)         srtp_aes_icm_openssl_set_iv,
     (cipher_get_tag_func_t)        0,
-    (char*)                        srtp_aes_icm_256_openssl_description,
-    (srtp_cipher_test_case_t*)          &srtp_aes_icm_256_test_case_2,
+    (const char*)                        srtp_aes_icm_256_openssl_description,
+    (const srtp_cipher_test_case_t*)          &srtp_aes_icm_256_test_case_2,
     (srtp_debug_module_t*)              &srtp_mod_aes_icm,
     (srtp_cipher_type_id_t)        SRTP_AES_256_ICM
 };

--- a/crypto/cipher/cipher.c
+++ b/crypto/cipher/cipher.c
@@ -131,7 +131,7 @@ srtp_err_status_t srtp_cipher_get_tag (srtp_cipher_t *c, uint8_t *buffer, uint32
     return (((c)->type)->get_tag(((c)->state), buffer, tag_len));
 }
 
-srtp_err_status_t srtp_cipher_set_aad (srtp_cipher_t *c, uint8_t *aad, uint32_t aad_len)
+srtp_err_status_t srtp_cipher_set_aad (srtp_cipher_t *c, const uint8_t *aad, uint32_t aad_len)
 {
     if (!c || !c->type || !c->state) {
 	return (srtp_err_status_bad_param);

--- a/crypto/cipher/null_cipher.c
+++ b/crypto/cipher/null_cipher.c
@@ -58,7 +58,7 @@ extern srtp_debug_module_t srtp_mod_cipher;
 
 static srtp_err_status_t srtp_null_cipher_alloc (srtp_cipher_t **c, int key_len, int tlen)
 {
-    extern srtp_cipher_type_t srtp_null_cipher;
+    extern const srtp_cipher_type_t srtp_null_cipher;
 
     debug_print(srtp_mod_cipher,
                 "allocating cipher with key length %d", key_len);
@@ -84,7 +84,7 @@ static srtp_err_status_t srtp_null_cipher_alloc (srtp_cipher_t **c, int key_len,
 
 static srtp_err_status_t srtp_null_cipher_dealloc (srtp_cipher_t *c)
 {
-    extern srtp_cipher_type_t srtp_null_cipher;
+    extern const srtp_cipher_type_t srtp_null_cipher;
 
     /* zeroize entire state*/
     octet_string_set_to_zero((uint8_t*)c, sizeof(srtp_cipher_t));
@@ -115,9 +115,9 @@ static srtp_err_status_t srtp_null_cipher_encrypt (srtp_null_cipher_ctx_t *c,
     return srtp_err_status_ok;
 }
 
-static char srtp_null_cipher_description[] = "null cipher";
+static const char srtp_null_cipher_description[] = "null cipher";
 
-static srtp_cipher_test_case_t srtp_null_cipher_test_0 = {
+static const srtp_cipher_test_case_t srtp_null_cipher_test_0 = {
     0,    /* octets in key            */
     NULL, /* key                      */
     0,    /* packet index             */
@@ -136,7 +136,7 @@ static srtp_cipher_test_case_t srtp_null_cipher_test_0 = {
  * note: the decrypt function is idential to the encrypt function
  */
 
-srtp_cipher_type_t srtp_null_cipher = {
+const srtp_cipher_type_t srtp_null_cipher = {
     (cipher_alloc_func_t)srtp_null_cipher_alloc,
     (cipher_dealloc_func_t)srtp_null_cipher_dealloc,
     (cipher_init_func_t)srtp_null_cipher_init,
@@ -145,8 +145,8 @@ srtp_cipher_type_t srtp_null_cipher = {
     (cipher_decrypt_func_t)srtp_null_cipher_encrypt,
     (cipher_set_iv_func_t)srtp_null_cipher_set_iv,
     (cipher_get_tag_func_t)0,
-    (char*)srtp_null_cipher_description,
-    (srtp_cipher_test_case_t*)&srtp_null_cipher_test_0,
+    (const char*)srtp_null_cipher_description,
+    (const srtp_cipher_test_case_t*)&srtp_null_cipher_test_0,
     (srtp_debug_module_t*)NULL,
     (srtp_cipher_type_id_t)SRTP_NULL_CIPHER
 };

--- a/crypto/hash/hmac.c
+++ b/crypto/hash/hmac.c
@@ -59,7 +59,7 @@ srtp_debug_module_t srtp_mod_hmac = {
 
 static srtp_err_status_t srtp_hmac_alloc (srtp_auth_t **a, int key_len, int out_len)
 {
-    extern srtp_auth_type_t srtp_hmac;
+    extern const srtp_auth_type_t srtp_hmac;
     uint8_t *pointer;
 
     debug_print(srtp_mod_hmac, "allocating auth func with key length %d", key_len);
@@ -215,23 +215,23 @@ static srtp_err_status_t srtp_hmac_compute (srtp_hmac_ctx_t *state, const void *
 
 /* begin test case 0 */
 
-static uint8_t srtp_hmac_test_case_0_key[20] = {
+static const uint8_t srtp_hmac_test_case_0_key[20] = {
     0x0b, 0x0b, 0x0b, 0x0b, 0x0b, 0x0b, 0x0b, 0x0b,
     0x0b, 0x0b, 0x0b, 0x0b, 0x0b, 0x0b, 0x0b, 0x0b,
     0x0b, 0x0b, 0x0b, 0x0b
 };
 
-static uint8_t srtp_hmac_test_case_0_data[8] = {
+static const uint8_t srtp_hmac_test_case_0_data[8] = {
     0x48, 0x69, 0x20, 0x54, 0x68, 0x65, 0x72, 0x65 /* "Hi There" */
 };
 
-static uint8_t srtp_hmac_test_case_0_tag[20] = {
+static const uint8_t srtp_hmac_test_case_0_tag[20] = {
     0xb6, 0x17, 0x31, 0x86, 0x55, 0x05, 0x72, 0x64,
     0xe2, 0x8b, 0xc0, 0xb6, 0xfb, 0x37, 0x8c, 0x8e,
     0xf1, 0x46, 0xbe, 0x00
 };
 
-static srtp_auth_test_case_t srtp_hmac_test_case_0 = {
+static const srtp_auth_test_case_t srtp_hmac_test_case_0 = {
     20,                         /* octets in key            */
     srtp_hmac_test_case_0_key,  /* key                      */
     8,                          /* octets in data           */
@@ -243,21 +243,21 @@ static srtp_auth_test_case_t srtp_hmac_test_case_0 = {
 
 /* end test case 0 */
 
-static char srtp_hmac_description[] = "hmac sha-1 authentication function";
+static const char srtp_hmac_description[] = "hmac sha-1 authentication function";
 
 /*
  * srtp_auth_type_t hmac is the hmac metaobject
  */
 
-srtp_auth_type_t srtp_hmac  = {
+const srtp_auth_type_t srtp_hmac  = {
     (auth_alloc_func)srtp_hmac_alloc,
     (auth_dealloc_func)srtp_hmac_dealloc,
     (auth_init_func)srtp_hmac_init,
     (auth_compute_func)srtp_hmac_compute,
     (auth_update_func)srtp_hmac_update,
     (auth_start_func)srtp_hmac_start,
-    (char*)srtp_hmac_description,
-    (srtp_auth_test_case_t*)&srtp_hmac_test_case_0,
+    (const char*)srtp_hmac_description,
+    (const srtp_auth_test_case_t*)&srtp_hmac_test_case_0,
     (srtp_debug_module_t*)&srtp_mod_hmac,
     (srtp_auth_type_id_t)SRTP_HMAC_SHA1
 };

--- a/crypto/hash/hmac_ossl.c
+++ b/crypto/hash/hmac_ossl.c
@@ -62,7 +62,7 @@ srtp_debug_module_t srtp_mod_hmac = {
 
 static srtp_err_status_t srtp_hmac_alloc (srtp_auth_t **a, int key_len, int out_len)
 {
-    extern srtp_auth_type_t srtp_hmac;
+    extern const srtp_auth_type_t srtp_hmac;
     uint8_t *pointer;
     srtp_hmac_ctx_t *new_hmac_ctx;
 
@@ -234,23 +234,23 @@ static srtp_err_status_t srtp_hmac_compute (srtp_hmac_ctx_t *state, const void *
 
 /* begin test case 0 */
 
-static uint8_t srtp_hmac_test_case_0_key[HMAC_KEYLEN_MAX] = {
+static const uint8_t srtp_hmac_test_case_0_key[HMAC_KEYLEN_MAX] = {
     0x0b, 0x0b, 0x0b, 0x0b, 0x0b, 0x0b, 0x0b, 0x0b,
     0x0b, 0x0b, 0x0b, 0x0b, 0x0b, 0x0b, 0x0b, 0x0b,
     0x0b, 0x0b, 0x0b, 0x0b
 };
 
-static uint8_t srtp_hmac_test_case_0_data[8] = {
+static const uint8_t srtp_hmac_test_case_0_data[8] = {
     0x48, 0x69, 0x20, 0x54, 0x68, 0x65, 0x72, 0x65 /* "Hi There" */
 };
 
-static uint8_t srtp_hmac_test_case_0_tag[HMAC_KEYLEN_MAX] = {
+static const uint8_t srtp_hmac_test_case_0_tag[HMAC_KEYLEN_MAX] = {
     0xb6, 0x17, 0x31, 0x86, 0x55, 0x05, 0x72, 0x64,
     0xe2, 0x8b, 0xc0, 0xb6, 0xfb, 0x37, 0x8c, 0x8e,
     0xf1, 0x46, 0xbe, 0x00
 };
 
-static srtp_auth_test_case_t srtp_hmac_test_case_0 = {
+static const srtp_auth_test_case_t srtp_hmac_test_case_0 = {
     sizeof(srtp_hmac_test_case_0_key),    /* octets in key            */
     srtp_hmac_test_case_0_key,            /* key                      */
     sizeof(srtp_hmac_test_case_0_data),   /* octets in data           */
@@ -262,21 +262,21 @@ static srtp_auth_test_case_t srtp_hmac_test_case_0 = {
 
 /* end test case 0 */
 
-static char srtp_hmac_description[] = "hmac sha-1 authentication function";
+static const char srtp_hmac_description[] = "hmac sha-1 authentication function";
 
 /*
  * srtp_auth_type_t hmac is the hmac metaobject
  */
 
-srtp_auth_type_t srtp_hmac  = {
+const srtp_auth_type_t srtp_hmac  = {
     (auth_alloc_func)	srtp_hmac_alloc,
     (auth_dealloc_func)	srtp_hmac_dealloc,
     (auth_init_func)	srtp_hmac_init,
     (auth_compute_func)	srtp_hmac_compute,
     (auth_update_func)	srtp_hmac_update,
     (auth_start_func)	srtp_hmac_start,
-    (char*)		srtp_hmac_description,
-    (srtp_auth_test_case_t*)	&srtp_hmac_test_case_0,
+    (const char*)		srtp_hmac_description,
+    (const srtp_auth_test_case_t*)	&srtp_hmac_test_case_0,
     (srtp_debug_module_t*)	&srtp_mod_hmac,
     (srtp_auth_type_id_t) SRTP_HMAC_SHA1
 };

--- a/crypto/hash/null_auth.c
+++ b/crypto/hash/null_auth.c
@@ -57,7 +57,7 @@ extern srtp_debug_module_t srtp_mod_auth;
 
 static srtp_err_status_t srtp_null_auth_alloc (srtp_auth_t **a, int key_len, int out_len)
 {
-    extern srtp_auth_type_t srtp_null_auth;
+    extern const srtp_auth_type_t srtp_null_auth;
     uint8_t *pointer;
 
     debug_print(srtp_mod_auth, "allocating auth func with key length %d", key_len);
@@ -82,7 +82,7 @@ static srtp_err_status_t srtp_null_auth_alloc (srtp_auth_t **a, int key_len, int
 
 static srtp_err_status_t srtp_null_auth_dealloc (srtp_auth_t *a)
 {
-    extern srtp_auth_type_t srtp_null_auth;
+    extern const srtp_auth_type_t srtp_null_auth;
 
     /* zeroize entire state*/
     octet_string_set_to_zero((uint8_t*)a,
@@ -102,14 +102,14 @@ static srtp_err_status_t srtp_null_auth_init (srtp_null_auth_ctx_t *state, const
     return srtp_err_status_ok;
 }
 
-static srtp_err_status_t srtp_null_auth_compute (srtp_null_auth_ctx_t *state, uint8_t *message,
+static srtp_err_status_t srtp_null_auth_compute (srtp_null_auth_ctx_t *state, const uint8_t *message,
                                           int msg_octets, int tag_len, uint8_t *result)
 {
 
     return srtp_err_status_ok;
 }
 
-static srtp_err_status_t srtp_null_auth_update (srtp_null_auth_ctx_t *state, uint8_t *message,
+static srtp_err_status_t srtp_null_auth_update (srtp_null_auth_ctx_t *state, const uint8_t *message,
                                          int msg_octets)
 {
 
@@ -128,7 +128,7 @@ static srtp_err_status_t srtp_null_auth_start (srtp_null_auth_ctx_t *state)
 
 /* begin test case 0 */
 
-static srtp_auth_test_case_t srtp_null_auth_test_case_0 = {
+static const srtp_auth_test_case_t srtp_null_auth_test_case_0 = {
     0,                                     /* octets in key            */
     NULL,                                  /* key                      */
     0,                                     /* octets in data           */
@@ -140,17 +140,17 @@ static srtp_auth_test_case_t srtp_null_auth_test_case_0 = {
 
 /* end test case 0 */
 
-static char srtp_null_auth_description[] = "null authentication function";
+static const char srtp_null_auth_description[] = "null authentication function";
 
-srtp_auth_type_t srtp_null_auth  = {
+const srtp_auth_type_t srtp_null_auth  = {
     (auth_alloc_func)srtp_null_auth_alloc,
     (auth_dealloc_func)srtp_null_auth_dealloc,
     (auth_init_func)srtp_null_auth_init,
     (auth_compute_func)srtp_null_auth_compute,
     (auth_update_func)srtp_null_auth_update,
     (auth_start_func)srtp_null_auth_start,
-    (char*)srtp_null_auth_description,
-    (srtp_auth_test_case_t*)&srtp_null_auth_test_case_0,
+    (const char*)srtp_null_auth_description,
+    (const srtp_auth_test_case_t*)&srtp_null_auth_test_case_0,
     (srtp_debug_module_t*)NULL,
     (srtp_auth_type_id_t)SRTP_NULL_AUTH
 };

--- a/crypto/include/auth.h
+++ b/crypto/include/auth.h
@@ -51,7 +51,7 @@
 #include "err.h"                /* error codes    */
 #include "crypto_types.h"       /* for values of auth_type_id_t */
 
-typedef struct srtp_auth_type_t *auth_type_pointer;
+typedef const struct srtp_auth_type_t *auth_type_pointer;
 typedef struct srtp_auth_t      *auth_pointer_t;
 
 typedef srtp_err_status_t (*auth_alloc_func)
@@ -63,11 +63,11 @@ typedef srtp_err_status_t (*auth_init_func)
 typedef srtp_err_status_t (*auth_dealloc_func)(auth_pointer_t ap);
 
 typedef srtp_err_status_t (*auth_compute_func)
-    (void *state, uint8_t *buffer, int octets_to_auth,
+    (void *state, const uint8_t *buffer, int octets_to_auth,
     int tag_len, uint8_t *tag);
 
 typedef srtp_err_status_t (*auth_update_func)
-    (void *state, uint8_t *buffer, int octets_to_auth);
+    (void *state, const uint8_t *buffer, int octets_to_auth);
 
 typedef srtp_err_status_t (*auth_start_func)(void *state);
 
@@ -104,12 +104,12 @@ int srtp_auth_get_prefix_length(const struct srtp_auth_t *a);
  */
 typedef struct srtp_auth_test_case_t {
     int key_length_octets;                        /* octets in key            */
-    uint8_t *key;                                 /* key                      */
+    const uint8_t *key;                                 /* key                      */
     int data_length_octets;                       /* octets in data           */
-    uint8_t *data;                                /* data                     */
+    const uint8_t *data;                                /* data                     */
     int tag_length_octets;                        /* octets in tag            */
-    uint8_t *tag;                                 /* tag                      */
-    struct srtp_auth_test_case_t *next_test_case; /* pointer to next testcase */
+    const uint8_t *tag;                                 /* tag                      */
+    const struct srtp_auth_test_case_t *next_test_case; /* pointer to next testcase */
 } srtp_auth_test_case_t;
 
 /* srtp_auth_type_t */
@@ -120,14 +120,14 @@ typedef struct srtp_auth_type_t {
     auth_compute_func compute;
     auth_update_func update;
     auth_start_func start;
-    char                *description;
-    srtp_auth_test_case_t    *test_data;
+    const char                *description;
+    const srtp_auth_test_case_t    *test_data;
     srtp_debug_module_t      *debug;
     srtp_auth_type_id_t id;
 } srtp_auth_type_t;
 
 typedef struct srtp_auth_t {
-    srtp_auth_type_t *type;
+    const srtp_auth_type_t *type;
     void        *state;
     int out_len;                  /* length of output tag in octets */
     int key_len;                  /* length of key in octets        */

--- a/crypto/include/cipher.h
+++ b/crypto/include/cipher.h
@@ -129,16 +129,16 @@ typedef srtp_err_status_t (*cipher_get_tag_func_t)
  */
 typedef struct srtp_cipher_test_case_t {
     int key_length_octets;                          /* octets in key            */
-    uint8_t *key;                                   /* key                      */
-    uint8_t *idx;                                   /* packet index             */
+    const uint8_t *key;                                   /* key                      */
+    const uint8_t *idx;                                   /* packet index             */
     int plaintext_length_octets;                    /* octets in plaintext      */
-    uint8_t *plaintext;                             /* plaintext                */
+    const uint8_t *plaintext;                             /* plaintext                */
     int ciphertext_length_octets;                   /* octets in plaintext      */
-    uint8_t *ciphertext;                            /* ciphertext               */
+    const uint8_t *ciphertext;                            /* ciphertext               */
     int aad_length_octets;                          /* octets in AAD            */
-    uint8_t *aad;                                   /* AAD                      */
+    const uint8_t *aad;                                   /* AAD                      */
     int tag_length_octets;                          /* Length of AEAD tag       */
-    struct srtp_cipher_test_case_t *next_test_case; /* pointer to next testcase */
+    const struct srtp_cipher_test_case_t *next_test_case; /* pointer to next testcase */
 } srtp_cipher_test_case_t;
 
 /* cipher_type_t defines the 'metadata' for a particular cipher type */

--- a/crypto/include/cipher.h
+++ b/crypto/include/cipher.h
@@ -151,9 +151,9 @@ typedef struct srtp_cipher_type_t {
     cipher_encrypt_func_t decrypt;
     cipher_set_iv_func_t set_iv;
     cipher_get_tag_func_t get_tag;
-    char                       *description;
-    srtp_cipher_test_case_t         *test_data;
-    srtp_debug_module_t             *debug;
+    const char                       *description;
+    const srtp_cipher_test_case_t         *test_data;
+    const srtp_debug_module_t             *debug;
     srtp_cipher_type_id_t id;
 } srtp_cipher_type_t;
 
@@ -162,7 +162,7 @@ typedef struct srtp_cipher_type_t {
  * key length, key and salt values
  */
 typedef struct srtp_cipher_t {
-    srtp_cipher_type_t *type;
+    const srtp_cipher_type_t *type;
     void          *state;
     int key_len;
     int algorithm;

--- a/crypto/include/cipher.h
+++ b/crypto/include/cipher.h
@@ -95,7 +95,7 @@ typedef srtp_err_status_t (*cipher_set_segment_func_t)
  * a cipher_set_aad_func_t processes the AAD data for AEAD ciphers
  */
 typedef srtp_err_status_t (*cipher_set_aad_func_t)
-    (void *state, uint8_t *aad, uint32_t aad_len);
+    (void *state, const uint8_t *aad, uint32_t aad_len);
 
 
 /* a cipher_encrypt_func_t encrypts data in-place */
@@ -153,7 +153,7 @@ typedef struct srtp_cipher_type_t {
     cipher_get_tag_func_t get_tag;
     const char                       *description;
     const srtp_cipher_test_case_t         *test_data;
-    const srtp_debug_module_t             *debug;
+    srtp_debug_module_t             *debug;
     srtp_cipher_type_id_t id;
 } srtp_cipher_type_t;
 
@@ -208,6 +208,6 @@ srtp_err_status_t srtp_cipher_output(srtp_cipher_t *c, uint8_t *buffer, uint32_t
 srtp_err_status_t srtp_cipher_encrypt(srtp_cipher_t *c, uint8_t *buffer, uint32_t *num_octets_to_output); 
 srtp_err_status_t srtp_cipher_decrypt(srtp_cipher_t *c, uint8_t *buffer, uint32_t *num_octets_to_output); 
 srtp_err_status_t srtp_cipher_get_tag(srtp_cipher_t *c, uint8_t *buffer, uint32_t *tag_len);
-srtp_err_status_t srtp_cipher_set_aad(srtp_cipher_t *c, uint8_t *aad, uint32_t aad_len);
+srtp_err_status_t srtp_cipher_set_aad(srtp_cipher_t *c, const uint8_t *aad, uint32_t aad_len);
 
 #endif /* CIPHER_H */

--- a/crypto/include/crypto_kernel.h
+++ b/crypto/include/crypto_kernel.h
@@ -157,9 +157,9 @@ srtp_err_status_t srtp_crypto_kernel_list_debug_modules(void);
  * srtp_crypto_kernel_load_cipher_type()
  *
  */
-srtp_err_status_t srtp_crypto_kernel_load_cipher_type(srtp_cipher_type_t *ct, srtp_cipher_type_id_t id);
+srtp_err_status_t srtp_crypto_kernel_load_cipher_type(const srtp_cipher_type_t *ct, srtp_cipher_type_id_t id);
 
-srtp_err_status_t srtp_crypto_kernel_load_auth_type(srtp_auth_type_t *ct, srtp_auth_type_id_t id);
+srtp_err_status_t srtp_crypto_kernel_load_auth_type(const srtp_auth_type_t *ct, srtp_auth_type_id_t id);
 
 /*
  * srtp_crypto_kernel_replace_cipher_type(ct, id)
@@ -168,7 +168,7 @@ srtp_err_status_t srtp_crypto_kernel_load_auth_type(srtp_auth_type_t *ct, srtp_a
  * with a new one passed in externally.  The new cipher must pass all the
  * existing cipher_type's self tests as well as its own.
  */
-srtp_err_status_t srtp_crypto_kernel_replace_cipher_type(srtp_cipher_type_t *ct, srtp_cipher_type_id_t id);
+srtp_err_status_t srtp_crypto_kernel_replace_cipher_type(const srtp_cipher_type_t *ct, srtp_cipher_type_id_t id);
 
 
 /*
@@ -178,7 +178,7 @@ srtp_err_status_t srtp_crypto_kernel_replace_cipher_type(srtp_cipher_type_t *ct,
  * with a new one passed in externally.  The new auth type must pass all the
  * existing auth_type's self tests as well as its own.
  */
-srtp_err_status_t srtp_crypto_kernel_replace_auth_type(srtp_auth_type_t *ct, srtp_auth_type_id_t id);
+srtp_err_status_t srtp_crypto_kernel_replace_auth_type(const srtp_auth_type_t *ct, srtp_auth_type_id_t id);
 
 
 srtp_err_status_t srtp_crypto_kernel_load_debug_module(srtp_debug_module_t *new_dm);

--- a/crypto/include/crypto_kernel.h
+++ b/crypto/include/crypto_kernel.h
@@ -68,7 +68,7 @@ typedef enum {
  */
 typedef struct srtp_kernel_cipher_type {
     srtp_cipher_type_id_t id;
-    srtp_cipher_type_t    *cipher_type;
+    const srtp_cipher_type_t    *cipher_type;
     struct srtp_kernel_cipher_type *next;
 } srtp_kernel_cipher_type_t;
 
@@ -77,7 +77,7 @@ typedef struct srtp_kernel_cipher_type {
  */
 typedef struct srtp_kernel_auth_type {
     srtp_auth_type_id_t id;
-    srtp_auth_type_t    *auth_type;
+    const srtp_auth_type_t    *auth_type;
     struct srtp_kernel_auth_type *next;
 } srtp_kernel_auth_type_t;
 

--- a/crypto/kernel/crypto_kernel.c
+++ b/crypto/kernel/crypto_kernel.c
@@ -284,7 +284,7 @@ srtp_err_status_t srtp_crypto_kernel_shutdown ()
     return srtp_err_status_ok;
 }
 
-static inline srtp_err_status_t srtp_crypto_kernel_do_load_cipher_type (srtp_cipher_type_t *new_ct, srtp_cipher_type_id_t id, int replace)
+static inline srtp_err_status_t srtp_crypto_kernel_do_load_cipher_type (const srtp_cipher_type_t *new_ct, srtp_cipher_type_id_t id, int replace)
 {
     srtp_kernel_cipher_type_t *ctype, *new_ctype;
     srtp_err_status_t status;
@@ -349,17 +349,17 @@ static inline srtp_err_status_t srtp_crypto_kernel_do_load_cipher_type (srtp_cip
     return srtp_err_status_ok;
 }
 
-srtp_err_status_t srtp_crypto_kernel_load_cipher_type (srtp_cipher_type_t *new_ct, srtp_cipher_type_id_t id)
+srtp_err_status_t srtp_crypto_kernel_load_cipher_type (const srtp_cipher_type_t *new_ct, srtp_cipher_type_id_t id)
 {
     return srtp_crypto_kernel_do_load_cipher_type(new_ct, id, 0);
 }
 
-srtp_err_status_t srtp_crypto_kernel_replace_cipher_type (srtp_cipher_type_t *new_ct, srtp_cipher_type_id_t id)
+srtp_err_status_t srtp_crypto_kernel_replace_cipher_type (const srtp_cipher_type_t *new_ct, srtp_cipher_type_id_t id)
 {
     return srtp_crypto_kernel_do_load_cipher_type(new_ct, id, 1);
 }
 
-srtp_err_status_t srtp_crypto_kernel_do_load_auth_type (srtp_auth_type_t *new_at, srtp_auth_type_id_t id, int replace)
+srtp_err_status_t srtp_crypto_kernel_do_load_auth_type (const srtp_auth_type_t *new_at, srtp_auth_type_id_t id, int replace)
 {
     srtp_kernel_auth_type_t *atype, *new_atype;
     srtp_err_status_t status;
@@ -425,18 +425,18 @@ srtp_err_status_t srtp_crypto_kernel_do_load_auth_type (srtp_auth_type_t *new_at
 
 }
 
-srtp_err_status_t srtp_crypto_kernel_load_auth_type (srtp_auth_type_t *new_at, srtp_auth_type_id_t id)
+srtp_err_status_t srtp_crypto_kernel_load_auth_type (const srtp_auth_type_t *new_at, srtp_auth_type_id_t id)
 {
     return srtp_crypto_kernel_do_load_auth_type(new_at, id, 0);
 }
 
-srtp_err_status_t srtp_crypto_kernel_replace_auth_type (srtp_auth_type_t *new_at, srtp_auth_type_id_t id)
+srtp_err_status_t srtp_crypto_kernel_replace_auth_type (const srtp_auth_type_t *new_at, srtp_auth_type_id_t id)
 {
     return srtp_crypto_kernel_do_load_auth_type(new_at, id, 1);
 }
 
 
-srtp_cipher_type_t * srtp_crypto_kernel_get_cipher_type (srtp_cipher_type_id_t id)
+const srtp_cipher_type_t * srtp_crypto_kernel_get_cipher_type (srtp_cipher_type_id_t id)
 {
     srtp_kernel_cipher_type_t *ctype;
 
@@ -456,7 +456,7 @@ srtp_cipher_type_t * srtp_crypto_kernel_get_cipher_type (srtp_cipher_type_id_t i
 
 srtp_err_status_t srtp_crypto_kernel_alloc_cipher (srtp_cipher_type_id_t id, srtp_cipher_pointer_t *cp, int key_len, int tag_len)
 {
-    srtp_cipher_type_t *ct;
+    const srtp_cipher_type_t *ct;
 
     /*
      * if the crypto_kernel is not yet initialized, we refuse to allocate
@@ -476,7 +476,7 @@ srtp_err_status_t srtp_crypto_kernel_alloc_cipher (srtp_cipher_type_id_t id, srt
 
 
 
-srtp_auth_type_t * srtp_crypto_kernel_get_auth_type (srtp_auth_type_id_t id)
+const srtp_auth_type_t * srtp_crypto_kernel_get_auth_type (srtp_auth_type_id_t id)
 {
     srtp_kernel_auth_type_t *atype;
 
@@ -495,7 +495,7 @@ srtp_auth_type_t * srtp_crypto_kernel_get_auth_type (srtp_auth_type_id_t id)
 
 srtp_err_status_t srtp_crypto_kernel_alloc_auth (srtp_auth_type_id_t id, auth_pointer_t *ap, int key_len, int tag_len)
 {
-    srtp_auth_type_t *at;
+    const srtp_auth_type_t *at;
 
     /*
      * if the crypto_kernel is not yet initialized, we refuse to allocate


### PR DESCRIPTION
Many global data (e.g. tables for aes), test case objects and their data, "virtual tables" (srtp_cipher_type_t and srtp_auth_type_t, since they contain many function pointers able to override, just as virtual tables in C++), descriptions do and should not be changed during their lifetime, so I believe it is better to qualify them, as well as any pointers to them read-only (const). If so, compilers can put them into rodata segments and prevent any writing attempt to them. Anyone wants to override default functions should never modify those existing global "virtual tables", but make their own copies of the original, and adjust pointers to them.