### PR TITLE
configure Travis CI to build with gcc and clang compilers under osx and linux platforms

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,10 @@
+sudo: false
+language: c
+compiler:
+  - clang
+  - gcc
+os:
+  - linux
+  - osx
+script:
+  - ./configure && make && make runtest


### PR DESCRIPTION

The configuration would have been simpler but the target to run the tests is 'runtest' instead of the standard 'test'.  If you change it to test, the script line can be removed as that is the default in Travis.

Sample travis output:
https://travis-ci.org/j4y/libsrtp
