### PR TITLE
Support header extensions encryption (RFC 6904).

### DIFF
--- a/crypto/kernel/crypto_kernel.c
+++ b/crypto/kernel/crypto_kernel.c
@@ -74,6 +74,10 @@ extern srtp_debug_module_t mod_alloc;
 extern srtp_cipher_type_t srtp_null_cipher;
 extern srtp_cipher_type_t srtp_aes_icm;
 #ifdef OPENSSL
+#ifndef SRTP_NO_AES192
+extern srtp_cipher_type_t srtp_aes_icm_192;
+#endif
+extern srtp_cipher_type_t srtp_aes_icm_256;
 extern srtp_cipher_type_t srtp_aes_gcm_128_openssl;
 extern srtp_cipher_type_t srtp_aes_gcm_256_openssl;
 #endif
@@ -149,6 +153,16 @@ srtp_err_status_t srtp_crypto_kernel_init ()
         return status;
     }
 #ifdef OPENSSL
+#ifndef SRTP_NO_AES192
+    status = srtp_crypto_kernel_load_cipher_type(&srtp_aes_icm_192, SRTP_AES_192_ICM);
+    if (status) {
+        return status;
+    }
+#endif
+    status = srtp_crypto_kernel_load_cipher_type(&srtp_aes_icm_256, SRTP_AES_256_ICM);
+    if (status) {
+        return status;
+    }
     status = srtp_crypto_kernel_load_cipher_type(&srtp_aes_gcm_128_openssl, SRTP_AES_128_GCM);
     if (status) {
         return status;

--- a/include/srtp.h
+++ b/include/srtp.h
@@ -412,6 +412,8 @@ typedef struct srtp_policy_t {
 				*   transmissions must have the same RTP
 				*   payload, or a severe security weakness
 				*   is introduced!)                      */
+  int *enc_xtn_hdr;            /**< List of header ids to encrypt.       */
+  int enc_xtn_hdr_count;       /**< Number of entries in list of header ids. */
   struct srtp_policy_t *next;  /**< Pointer to next stream policy.       */
 } srtp_policy_t;
 

--- a/include/srtp_priv.h
+++ b/include/srtp_priv.h
@@ -104,6 +104,7 @@ typedef enum direction_t {
 typedef struct srtp_stream_ctx_t_ {
   uint32_t   ssrc;
   srtp_cipher_t  *rtp_cipher;
+  srtp_cipher_t  *rtp_xtn_hdr_cipher;
   srtp_auth_t    *rtp_auth;
   srtp_rdbx_t     rtp_rdbx;
   srtp_sec_serv_t rtp_services;
@@ -117,6 +118,8 @@ typedef struct srtp_stream_ctx_t_ {
   srtp_ekt_stream_t ekt; 
   uint8_t    salt[SRTP_AEAD_SALT_LEN];   /* used with GCM mode for SRTP */
   uint8_t    c_salt[SRTP_AEAD_SALT_LEN]; /* used with GCM mode for SRTCP */
+  int       *enc_xtn_hdr;
+  int        enc_xtn_hdr_count;
   struct srtp_stream_ctx_t_ *next;   /* linked list of streams */
 } strp_stream_ctx_t_;
 

--- a/srtp/srtp.c
+++ b/srtp/srtp.c
@@ -1102,6 +1102,9 @@ srtp_process_header_encryption(srtp_stream_ctx_t *stream, srtp_hdr_xtnd_t *xtn_h
       uint32_t xlen_with_header = 1+xlen;
       xtn_hdr_data++;
 
+      if (xtn_hdr_data + xlen > xtn_hdr_end)
+        return srtp_err_status_parse_err;
+
       if (xid == 15) {
         /* found header 15, stop further processing. */
         break;
@@ -1134,6 +1137,9 @@ srtp_process_header_encryption(srtp_stream_ctx_t *stream, srtp_hdr_xtnd_t *xtn_h
       unsigned int xlen = *(xtn_hdr_data+1);
       uint32_t xlen_with_header = 2+xlen;
       xtn_hdr_data += 2;
+
+      if (xtn_hdr_data + xlen > xtn_hdr_end)
+        return srtp_err_status_parse_err;
 
       status = srtp_cipher_output(stream->rtp_xtn_hdr_cipher, keystream, &xlen_with_header);
       if (status)

--- a/srtp/srtp.c
+++ b/srtp/srtp.c
@@ -233,6 +233,41 @@ srtp_stream_alloc(srtp_stream_ctx_t **str_ptr,
    return stat;    
   }
 
+  if (p->enc_xtn_hdr && p->enc_xtn_hdr_count > 0) {
+    str->enc_xtn_hdr = (int*) srtp_crypto_alloc(p->enc_xtn_hdr_count * sizeof(p->enc_xtn_hdr[0]));
+    if (!str->enc_xtn_hdr) {
+      auth_dealloc(str->rtcp_auth);
+      srtp_cipher_dealloc(str->rtcp_cipher);
+      auth_dealloc(str->rtp_auth);
+      srtp_cipher_dealloc(str->rtp_cipher);
+      srtp_crypto_free(str->limit);
+      srtp_crypto_free(str);
+      return srtp_err_status_alloc_fail;
+    }
+    memcpy(str->enc_xtn_hdr, p->enc_xtn_hdr, p->enc_xtn_hdr_count * sizeof(p->enc_xtn_hdr[0]));
+    str->enc_xtn_hdr_count = p->enc_xtn_hdr_count;
+
+    /* allocate cipher for extensions header encryption */
+    stat = srtp_crypto_kernel_alloc_cipher(p->rtp.cipher_type,
+              &str->rtp_xtn_hdr_cipher,
+              p->rtp.cipher_key_len,
+              p->rtp.auth_tag_len);
+    if (stat) {
+      srtp_crypto_free(str->enc_xtn_hdr);
+      auth_dealloc(str->rtcp_auth);
+      srtp_cipher_dealloc(str->rtcp_cipher);
+      auth_dealloc(str->rtp_auth);
+      srtp_cipher_dealloc(str->rtp_cipher);
+      srtp_crypto_free(str->limit);
+      srtp_crypto_free(str);
+      return stat;
+    }
+  } else {
+    str->rtp_xtn_hdr_cipher = NULL;
+    str->enc_xtn_hdr = NULL;
+    str->enc_xtn_hdr_count = 0;
+  }
+
   return srtp_err_status_ok;
 }
 
@@ -274,6 +309,15 @@ srtp_stream_dealloc(srtp_t session, srtp_stream_ctx_t *stream) {
     srtp_crypto_free(stream->limit);
   }   
 
+  if (session->stream_template
+      && stream->rtp_xtn_hdr_cipher == session->stream_template->rtp_xtn_hdr_cipher) {
+    /* do nothing */
+  } else if (stream->rtp_xtn_hdr_cipher) {
+    status = srtp_cipher_dealloc(stream->rtp_xtn_hdr_cipher);
+    if (status)
+      return status;
+  }
+
   /* 
    * deallocate rtcp cipher, if it is not the same as that in
    * template 
@@ -305,6 +349,13 @@ srtp_stream_dealloc(srtp_t session, srtp_stream_ctx_t *stream) {
     return status;
 
   /* DAM - need to deallocate EKT here */
+
+  if (session->stream_template
+      && stream->enc_xtn_hdr == session->stream_template->enc_xtn_hdr) {
+    /* do nothing */
+  } else if (stream->enc_xtn_hdr) {
+    srtp_crypto_free(stream->enc_xtn_hdr);
+  }
 
   /*
    * zeroize the salt value
@@ -346,6 +397,7 @@ srtp_stream_clone(const srtp_stream_ctx_t *stream_template,
   /* set cipher and auth pointers to those of the template */
   str->rtp_cipher  = stream_template->rtp_cipher;
   str->rtp_auth    = stream_template->rtp_auth;
+  str->rtp_xtn_hdr_cipher = stream_template->rtp_xtn_hdr_cipher;
   str->rtcp_cipher = stream_template->rtcp_cipher;
   str->rtcp_auth   = stream_template->rtcp_auth;
 
@@ -383,6 +435,10 @@ srtp_stream_clone(const srtp_stream_ctx_t *stream_template,
   memcpy(str->salt, stream_template->salt, SRTP_AEAD_SALT_LEN);
   memcpy(str->c_salt, stream_template->c_salt, SRTP_AEAD_SALT_LEN);
 
+  /* copy information about extensions header encryption */
+  str->enc_xtn_hdr = stream_template->enc_xtn_hdr;
+  str->enc_xtn_hdr_count = stream_template->enc_xtn_hdr_count;
+
   /* defensive coding */
   str->next = NULL;
 
@@ -412,7 +468,9 @@ typedef enum {
   label_rtp_salt        = 0x02,
   label_rtcp_encryption = 0x03,
   label_rtcp_msg_auth   = 0x04,
-  label_rtcp_salt       = 0x05
+  label_rtcp_salt       = 0x05,
+  label_rtp_header_encryption = 0x06,
+  label_rtp_header_salt = 0x07
 } srtp_prf_label;
 
 #define MAX_SRTP_KEY_LEN 256
@@ -665,6 +723,49 @@ srtp_stream_init_keys(srtp_stream_ctx_t *srtp, const void *key) {
     /* zeroize temp buffer */
     octet_string_set_to_zero(tmp_key, MAX_SRTP_KEY_LEN);
     return srtp_err_status_init_fail;
+  }
+
+  if (srtp->rtp_xtn_hdr_cipher) {
+    /* generate extensions header encryption key  */
+    stat = srtp_kdf_generate(&kdf, label_rtp_header_encryption,
+           tmp_key, rtp_base_key_len);
+    if (stat) {
+      /* zeroize temp buffer */
+      octet_string_set_to_zero(tmp_key, MAX_SRTP_KEY_LEN);
+      return srtp_err_status_init_fail;
+    }
+    debug_print(mod_srtp, "extensions cipher key: %s",
+          srtp_octet_string_hex_string(tmp_key, rtp_base_key_len));
+
+    /*
+     * if the cipher in the srtp context uses a salt, then we need
+     * to generate the salt value
+     */
+    if (rtp_salt_len > 0) {
+      debug_print(mod_srtp, "found rtp_salt_len > 0, generating salt", NULL);
+
+      /* generate encryption salt, put after encryption key */
+      stat = srtp_kdf_generate(&kdf, label_rtp_header_salt,
+             tmp_key + rtp_base_key_len, rtp_salt_len);
+      if (stat) {
+        /* zeroize temp buffer */
+        octet_string_set_to_zero(tmp_key, MAX_SRTP_KEY_LEN);
+        return srtp_err_status_init_fail;
+      }
+      memcpy(srtp->salt, tmp_key + rtp_base_key_len, SRTP_AEAD_SALT_LEN);
+    }
+    if (rtp_salt_len > 0) {
+      debug_print(mod_srtp, "extensions cipher salt: %s",
+      srtp_octet_string_hex_string(tmp_key + rtp_base_key_len, rtp_salt_len));
+    }
+
+    /* initialize extensions header cipher */
+    stat = srtp_cipher_init(srtp->rtp_xtn_hdr_cipher, tmp_key);
+    if (stat) {
+      /* zeroize temp buffer */
+      octet_string_set_to_zero(tmp_key, MAX_SRTP_KEY_LEN);
+      return srtp_err_status_init_fail;
+    }
   }
 
   /* generate authentication key */
@@ -1262,6 +1363,110 @@ srtp_unprotect_aead (srtp_ctx_t *ctx, srtp_stream_ctx_t *stream, int delta,
 }
 
 
+/*
+ * Check if the given extension header id is / should be encrypted.
+ * Returns 1 if yes, otherwise 0.
+ */
+static int
+srtp_protect_extension_header(srtp_stream_ctx_t *stream, int id) {
+  int* enc_xtn_hdr = stream->enc_xtn_hdr;
+  int count = stream->enc_xtn_hdr_count;
+
+  if (!enc_xtn_hdr || count <= 0) {
+    return 0;
+  }
+
+  while (count > 0) {
+    if (*enc_xtn_hdr == id) {
+      return 1;
+    }
+
+    enc_xtn_hdr++;
+    count--;
+  }
+  return 0;
+}
+
+
+/*
+ * extensions header encryption RFC 6904
+ */
+static srtp_err_status_t
+srtp_process_header_encryption(srtp_stream_ctx_t *stream, srtp_hdr_xtnd_t *xtn_hdr) {
+  srtp_err_status_t status;
+  uint8_t keystream[257];  /* Maximum 2 bytes header + 255 bytes data. */
+  int keystream_pos;
+  uint8_t* xtn_hdr_data = ((uint8_t *)xtn_hdr) + octets_in_rtp_extn_hdr;
+  uint8_t* xtn_hdr_end = xtn_hdr_data + (ntohs(xtn_hdr->length) * sizeof(uint32_t));
+
+  if (ntohs(xtn_hdr->profile_specific) == 0xbede) {
+    /* RFC 5285, section 4.2. One-Byte Header */
+    while (xtn_hdr_data < xtn_hdr_end) {
+      uint8_t xid = (*xtn_hdr_data & 0xf0) >> 4;
+      unsigned int xlen = (*xtn_hdr_data & 0x0f) + 1;
+      uint32_t xlen_with_header = 1+xlen;
+      xtn_hdr_data++;
+
+      if (xid == 15) {
+        /* found header 15, stop further processing. */
+        break;
+      }
+
+      status = srtp_cipher_output(stream->rtp_xtn_hdr_cipher, keystream, &xlen_with_header);
+      if (status)
+        return srtp_err_status_cipher_fail;
+
+      if (srtp_protect_extension_header(stream, xid)) {
+        keystream_pos = 1;
+        while (xlen > 0) {
+          *xtn_hdr_data ^= keystream[keystream_pos++];
+          xtn_hdr_data++;
+          xlen--;
+        }
+      } else {
+        xtn_hdr_data += xlen;
+      }
+
+      /* skip padding bytes. */
+      while (xtn_hdr_data < xtn_hdr_end && *xtn_hdr_data == 0) {
+        xtn_hdr_data++;
+      }
+    }
+  } else if ((ntohs(xtn_hdr->profile_specific) & 0x1fff) == 0x100) {
+    /* RFC 5285, section 4.3. Two-Byte Header */
+    while (xtn_hdr_data + 1 < xtn_hdr_end) {
+      uint8_t xid = *xtn_hdr_data;
+      unsigned int xlen = *(xtn_hdr_data+1);
+      uint32_t xlen_with_header = 2+xlen;
+      xtn_hdr_data += 2;
+
+      status = srtp_cipher_output(stream->rtp_xtn_hdr_cipher, keystream, &xlen_with_header);
+      if (status)
+        return srtp_err_status_cipher_fail;
+
+      if (xlen > 0 && srtp_protect_extension_header(stream, xid)) {
+        keystream_pos = 2;
+        while (xlen > 0) {
+          *xtn_hdr_data ^= keystream[keystream_pos++];
+          xtn_hdr_data++;
+          xlen--;
+        }
+      } else {
+        xtn_hdr_data += xlen;
+      }
+
+      /* skip padding bytes. */
+      while (xtn_hdr_data < xtn_hdr_end && *xtn_hdr_data == 0) {
+        xtn_hdr_data++;
+      }
+    }
+  } else {
+    /* unsupported extension header format. */
+    return srtp_err_status_parse_err;
+  }
+
+  return srtp_err_status_ok;
+}
 
 
  srtp_err_status_t
@@ -1277,6 +1482,7 @@ srtp_unprotect_aead (srtp_ctx_t *ctx, srtp_stream_ctx_t *stream, int delta,
    int tag_len;
    srtp_stream_ctx_t *stream;
    uint32_t prefix_len;
+   srtp_hdr_xtnd_t *xtn_hdr = NULL;
 
    debug_print(mod_srtp, "function srtp_protect", NULL);
 
@@ -1379,7 +1585,7 @@ srtp_unprotect_aead (srtp_ctx_t *ctx, srtp_stream_ctx_t *stream, int delta,
    if (stream->rtp_services & sec_serv_conf) {
      enc_start = (uint32_t *)hdr + uint32s_in_rtp_header + hdr->cc;  
      if (hdr->x == 1) {
-       srtp_hdr_xtnd_t *xtn_hdr = (srtp_hdr_xtnd_t *)enc_start;
+       xtn_hdr = (srtp_hdr_xtnd_t *)enc_start;
        enc_start += (ntohs(xtn_hdr->length) + 1);
      }
      /* note: the passed size is without the auth tag */
@@ -1440,7 +1646,9 @@ srtp_unprotect_aead (srtp_ctx_t *ctx, srtp_stream_ctx_t *stream, int delta,
      iv.v64[1] = be64_to_cpu(est << 16);
 #endif
      status = srtp_cipher_set_iv(stream->rtp_cipher, (uint8_t*)&iv, direction_encrypt);
-
+     if (!status && stream->rtp_xtn_hdr_cipher) {
+       status = srtp_cipher_set_iv(stream->rtp_xtn_hdr_cipher, (uint8_t*)&iv, direction_encrypt);
+     }
    } else {  
      v128_t iv;
 
@@ -1453,6 +1661,9 @@ srtp_unprotect_aead (srtp_ctx_t *ctx, srtp_stream_ctx_t *stream, int delta,
 #endif
      iv.v64[1] = be64_to_cpu(est);
      status = srtp_cipher_set_iv(stream->rtp_cipher, (uint8_t*)&iv, direction_encrypt);
+     if (!status && stream->rtp_xtn_hdr_cipher) {
+       status = srtp_cipher_set_iv(stream->rtp_xtn_hdr_cipher, (uint8_t*)&iv, direction_encrypt);
+     }
    }
    if (status)
      return srtp_err_status_cipher_fail;
@@ -1479,6 +1690,16 @@ srtp_unprotect_aead (srtp_ctx_t *ctx, srtp_stream_ctx_t *stream, int delta,
 	return srtp_err_status_cipher_fail;
       debug_print(mod_srtp, "keystream prefix: %s", 
 		  srtp_octet_string_hex_string(auth_tag, prefix_len));
+    }
+  }
+
+  if (xtn_hdr && stream->rtp_xtn_hdr_cipher) {
+    /*
+     * extensions header encryption RFC 6904
+     */
+    status = srtp_process_header_encryption(stream, xtn_hdr);
+    if (status) {
+      return status;
     }
   }
 
@@ -1539,6 +1760,7 @@ srtp_unprotect(srtp_ctx_t *ctx, void *srtp_hdr, int *pkt_octet_len) {
   srtp_stream_ctx_t *stream;
   uint8_t tmp_tag[SRTP_MAX_TAG_LEN];
   uint32_t tag_len, prefix_len;
+  srtp_hdr_xtnd_t *xtn_hdr = NULL;
 
   debug_print(mod_srtp, "function srtp_unprotect", NULL);
 
@@ -1632,6 +1854,9 @@ srtp_unprotect(srtp_ctx_t *ctx, void *srtp_hdr, int *pkt_octet_len) {
     iv.v64[1] = be64_to_cpu(est << 16);
 #endif
     status = srtp_cipher_set_iv(stream->rtp_cipher, (uint8_t*)&iv, direction_decrypt);
+    if (!status && stream->rtp_xtn_hdr_cipher) {
+      status = srtp_cipher_set_iv(stream->rtp_xtn_hdr_cipher, (uint8_t*)&iv, direction_decrypt);
+    }
   } else {  
     
     /* no particular format - set the iv to the pakcet index */  
@@ -1643,6 +1868,9 @@ srtp_unprotect(srtp_ctx_t *ctx, void *srtp_hdr, int *pkt_octet_len) {
 #endif
     iv.v64[1] = be64_to_cpu(est);
     status = srtp_cipher_set_iv(stream->rtp_cipher, (uint8_t*)&iv, direction_decrypt);
+    if (!status && stream->rtp_xtn_hdr_cipher) {
+      status = srtp_cipher_set_iv(stream->rtp_xtn_hdr_cipher, (uint8_t*)&iv, direction_decrypt);
+    }
   }
   if (status)
     return srtp_err_status_cipher_fail;
@@ -1667,7 +1895,7 @@ srtp_unprotect(srtp_ctx_t *ctx, void *srtp_hdr, int *pkt_octet_len) {
   if (stream->rtp_services & sec_serv_conf) {
     enc_start = (uint32_t *)hdr + uint32s_in_rtp_header + hdr->cc;  
     if (hdr->x == 1) {
-      srtp_hdr_xtnd_t *xtn_hdr = (srtp_hdr_xtnd_t *)enc_start;
+      xtn_hdr = (srtp_hdr_xtnd_t *)enc_start;
       enc_start += (ntohs(xtn_hdr->length) + 1);
     }  
     if (!((uint8_t*)enc_start < (uint8_t*)hdr + (*pkt_octet_len - tag_len)))
@@ -1752,6 +1980,16 @@ srtp_unprotect(srtp_ctx_t *ctx, void *srtp_hdr, int *pkt_octet_len) {
     return srtp_err_status_key_expired;
   default:
     break;
+  }
+
+  if (xtn_hdr && stream->rtp_xtn_hdr_cipher) {
+    /*
+     * extensions header encryption RFC 6904
+     */
+    status = srtp_process_header_encryption(stream, xtn_hdr);
+    if (status) {
+      return status;
+    }
   }
 
   /* if we're decrypting, add keystream into ciphertext */

--- a/srtp/srtp.c
+++ b/srtp/srtp.c
@@ -1492,6 +1492,13 @@ srtp_unprotect_aead (srtp_ctx_t *ctx, srtp_stream_ctx_t *stream, int delta,
         return ( srtp_err_status_cipher_fail);
     }
 
+    /* Decrypt the ciphertext.  This also checks the auth tag based
+     * on the AAD we just specified above */
+    status = srtp_cipher_decrypt(stream->rtp_cipher, (uint8_t*)enc_start, &enc_octet_len);
+    if (status) {
+        return status;
+    }
+
     if (xtn_hdr && stream->rtp_xtn_hdr_cipher) {
       /*
        * extensions header encryption RFC 6904
@@ -1500,13 +1507,6 @@ srtp_unprotect_aead (srtp_ctx_t *ctx, srtp_stream_ctx_t *stream, int delta,
       if (status) {
         return status;
       }
-    }
-
-    /* Decrypt the ciphertext.  This also checks the auth tag based 
-     * on the AAD we just specified above */
-    status = srtp_cipher_decrypt(stream->rtp_cipher, (uint8_t*)enc_start, &enc_octet_len);
-    if (status) {
-        return status;
     }
 
     /*

--- a/test/srtp_driver.c
+++ b/test/srtp_driver.c
@@ -64,6 +64,9 @@ srtp_err_status_t
 srtp_validate(void);
 
 srtp_err_status_t
+srtp_validate_encrypted_extensions_headers(void);
+
+srtp_err_status_t
 srtp_validate_aes_256(void);
 
 srtp_err_status_t
@@ -88,7 +91,7 @@ void
 srtp_do_rejection_timing(const srtp_policy_t *policy);
 
 srtp_err_status_t
-srtp_test(const srtp_policy_t *policy);
+srtp_test(const srtp_policy_t *policy, int extension_header);
 
 srtp_err_status_t
 srtcp_test(const srtp_policy_t *policy);
@@ -235,7 +238,14 @@ main (int argc, char *argv[])
         /* loop over policy array, testing srtp and srtcp for each policy */
         while (*policy != NULL) {
             printf("testing srtp_protect and srtp_unprotect\n");
-            if (srtp_test(*policy) == srtp_err_status_ok) {
+            if (srtp_test(*policy, 0) == srtp_err_status_ok) {
+                printf("passed\n\n");
+            } else{
+                printf("failed\n");
+                exit(1);
+            }
+            printf("testing srtp_protect and srtp_unprotect with encrypted extensions headers\n");
+            if (srtp_test(*policy, 1) == srtp_err_status_ok) {
                 printf("passed\n\n");
             } else{
                 printf("failed\n");
@@ -258,7 +268,14 @@ main (int argc, char *argv[])
             exit(1);
         }
         printf("testing srtp_protect and srtp_unprotect with big policy\n");
-        if (srtp_test(big_policy) == srtp_err_status_ok) {
+        if (srtp_test(big_policy, 0) == srtp_err_status_ok) {
+            printf("passed\n\n");
+        } else{
+            printf("failed\n");
+            exit(1);
+        }
+        printf("testing srtp_protect and srtp_unprotect with big policy and encrypted extensions headers\n");
+        if (srtp_test(big_policy, 1) == srtp_err_status_ok) {
             printf("passed\n\n");
         } else{
             printf("failed\n");
@@ -273,7 +290,15 @@ main (int argc, char *argv[])
         /* run test on wildcard policy */
         printf("testing srtp_protect and srtp_unprotect on "
                "wildcard ssrc policy\n");
-        if (srtp_test(&wildcard_policy) == srtp_err_status_ok) {
+        if (srtp_test(&wildcard_policy, 0) == srtp_err_status_ok) {
+            printf("passed\n\n");
+        } else{
+            printf("failed\n");
+            exit(1);
+        }
+        printf("testing srtp_protect and srtp_unprotect on "
+               "wildcard ssrc policy and encrypted extensions headers\n");
+        if (srtp_test(&wildcard_policy, 1) == srtp_err_status_ok) {
             printf("passed\n\n");
         } else{
             printf("failed\n");
@@ -289,6 +314,14 @@ main (int argc, char *argv[])
         if (srtp_validate() == srtp_err_status_ok) {
             printf("passed\n\n");
         } else{
+            printf("failed\n");
+            exit(1);
+        }
+        printf("testing srtp_protect and srtp_unprotect against "
+               "reference packets with encrypted extensions headers\n");
+        if (srtp_validate_encrypted_extensions_headers() == srtp_err_status_ok)
+            printf("passed\n\n");
+        else {
             printf("failed\n");
             exit(1);
         }
@@ -348,6 +381,7 @@ main (int argc, char *argv[])
         int ignore;
         double mips = mips_estimate(1000000000, &ignore);
 
+        memset(&policy, 0, sizeof(policy));
         srtp_crypto_policy_set_rtp_default(&policy.rtp);
         srtp_crypto_policy_set_rtcp_default(&policy.rtcp);
         policy.ssrc.type  = ssrc_specific;
@@ -451,6 +485,66 @@ srtp_create_test_packet (int pkt_octet_len, uint32_t ssrc)
     }
 
     return hdr;
+}
+
+srtp_hdr_t *
+srtp_create_test_packet_ext_hdr(int pkt_octet_len, uint32_t ssrc) {
+  int i;
+  uint8_t *buffer;
+  srtp_hdr_t *hdr;
+  int bytes_in_hdr = 12;
+  uint8_t extension_header[12] = {
+    /* one-byte header */
+    0xbe, 0xde,
+    /* size */
+    0x00, 0x02,
+    /* id 1, length 1 (i.e. 2 bytes) */
+    0x11,
+    /* payload */
+    0xca,
+    0xfe,
+    /* padding */
+    0x00,
+    /* id 2, length 0 (i.e. 1 byte) */
+    0x20,
+    /* payload */
+    0xba,
+    /* padding */
+    0x00,
+    0x00
+  };
+
+  /* allocate memory for test packet */
+  hdr = (srtp_hdr_t*) malloc(pkt_octet_len + bytes_in_hdr
+           + sizeof(extension_header) + SRTP_MAX_TRAILER_LEN + 4);
+  if (!hdr)
+    return NULL;
+
+  hdr->version = 2;              /* RTP version two     */
+  hdr->p    = 0;                 /* no padding needed   */
+  hdr->x    = 1;                 /* no header extension */
+  hdr->cc   = 0;                 /* no CSRCs            */
+  hdr->m    = 0;                 /* marker bit          */
+  hdr->pt   = 0xf;               /* payload type        */
+  hdr->seq  = htons(0x1234);     /* sequence number     */
+  hdr->ts   = htonl(0xdecafbad); /* timestamp           */
+  hdr->ssrc = htonl(ssrc);       /* synch. source       */
+
+  buffer = (uint8_t *)hdr;
+  buffer += bytes_in_hdr;
+
+  memcpy(buffer, extension_header, sizeof(extension_header));
+  buffer += sizeof(extension_header);
+
+  /* set RTP data to 0xab */
+  for (i=0; i < pkt_octet_len; i++)
+    *buffer++ = 0xab;
+
+  /* set post-data value to 0xffff to enable overrun checking */
+  for (i=0; i < SRTP_MAX_TRAILER_LEN+4; i++)
+    *buffer++ = 0xff;
+
+  return hdr;
 }
 
 void
@@ -633,7 +727,7 @@ err_check (srtp_err_status_t s)
 }
 
 srtp_err_status_t
-srtp_test (const srtp_policy_t *policy)
+srtp_test (const srtp_policy_t *policy, int extension_header)
 {
     int i;
     srtp_t srtp_sender;
@@ -647,8 +741,17 @@ srtp_test (const srtp_policy_t *policy)
     int tag_length = policy->rtp.auth_tag_len;
     uint32_t ssrc;
     srtp_policy_t *rcvr_policy;
+    srtp_policy_t tmp_policy;
+    int header = 1;
 
-    err_check(srtp_create(&srtp_sender, policy));
+    if (extension_header) {
+        memcpy(&tmp_policy, policy, sizeof(srtp_policy_t));
+        tmp_policy.enc_xtn_hdr = &header;
+        tmp_policy.enc_xtn_hdr_count = 1;
+        err_check(srtp_create(&srtp_sender, &tmp_policy));
+    } else {
+        err_check(srtp_create(&srtp_sender, policy));
+    }
 
     /* print out policy */
     err_check(srtp_session_print_policy(srtp_sender));
@@ -664,12 +767,18 @@ srtp_test (const srtp_policy_t *policy)
         ssrc = policy->ssrc.value;
     }
     msg_len_octets = 28;
-    hdr = srtp_create_test_packet(msg_len_octets, ssrc);
+    if (extension_header) {
+        hdr = srtp_create_test_packet_ext_hdr(msg_len_octets, ssrc);
+        hdr2 = srtp_create_test_packet_ext_hdr(msg_len_octets, ssrc);
+    } else {
+        hdr = srtp_create_test_packet(msg_len_octets, ssrc);
+        hdr2 = srtp_create_test_packet(msg_len_octets, ssrc);
+    }
 
     if (hdr == NULL) {
+        free(hdr2);
         return srtp_err_status_alloc_fail;
     }
-    hdr2 = srtp_create_test_packet(msg_len_octets, ssrc);
     if (hdr2 == NULL) {
         free(hdr);
         return srtp_err_status_alloc_fail;
@@ -677,6 +786,9 @@ srtp_test (const srtp_policy_t *policy)
 
     /* set message length */
     len = msg_len_octets;
+    if (extension_header) {
+        len += 12;
+    }
 
     debug_print(mod_driver, "before protection:\n%s",
                 srtp_packet_to_string(hdr, len));
@@ -707,6 +819,9 @@ srtp_test (const srtp_policy_t *policy)
      */
     pkt_end = (uint8_t*)hdr + sizeof(srtp_hdr_t)
               + msg_len_octets + tag_length;
+    if (extension_header) {
+        pkt_end += 12;
+    }
     for (i = 0; i < 4; i++) {
         if (pkt_end[i] != 0xff) {
             fprintf(stdout, "overwrite in srtp_protect() function "
@@ -757,9 +872,16 @@ srtp_test (const srtp_policy_t *policy)
         free(hdr2);
         return srtp_err_status_alloc_fail;
     }
-    memcpy(rcvr_policy, policy, sizeof(srtp_policy_t));
-    if (policy->ssrc.type == ssrc_any_outbound) {
-        rcvr_policy->ssrc.type = ssrc_any_inbound;
+    if (extension_header) {
+        memcpy(rcvr_policy, &tmp_policy, sizeof(srtp_policy_t));
+        if (tmp_policy.ssrc.type == ssrc_any_outbound) {
+            rcvr_policy->ssrc.type = ssrc_any_inbound;
+        }
+    } else {
+        memcpy(rcvr_policy, policy, sizeof(srtp_policy_t));
+        if (policy->ssrc.type == ssrc_any_outbound) {
+            rcvr_policy->ssrc.type = ssrc_any_inbound;
+        }
     }
 
     err_check(srtp_create(&srtp_rcvr, rcvr_policy));
@@ -813,6 +935,9 @@ srtp_test (const srtp_policy_t *policy)
 
         /* set message length */
         len = msg_len_octets;
+        if (extension_header) {
+            len += 12;
+        }
 
         /* apply protection */
         err_check(srtp_protect(srtp_sender, hdr, &len));
@@ -1096,6 +1221,20 @@ srtp_session_print_policy (srtp_t srtp)
                serv_descr[stream->rtcp_services],
                srtp_rdbx_get_window_size(&stream->rtp_rdbx),
                stream->allow_repeat_tx ? "true" : "false");
+
+        printf("# Encrypted extension headers: ");
+        if (stream->enc_xtn_hdr && stream->enc_xtn_hdr_count > 0) {
+            int* enc_xtn_hdr = stream->enc_xtn_hdr;
+            int count = stream->enc_xtn_hdr_count;
+            while (count > 0) {
+                printf("%d ", *enc_xtn_hdr);
+                enc_xtn_hdr++;
+                count--;
+            }
+            printf("\n");
+        } else {
+            printf("none\n");
+        }
     }
 
     /* loop over streams in session, printing the policy of each */
@@ -1123,6 +1262,20 @@ srtp_session_print_policy (srtp_t srtp)
                serv_descr[stream->rtcp_services],
                srtp_rdbx_get_window_size(&stream->rtp_rdbx),
                stream->allow_repeat_tx ? "true" : "false");
+
+        printf("# Encrypted extension headers: ");
+        if (stream->enc_xtn_hdr && stream->enc_xtn_hdr_count > 0) {
+            int* enc_xtn_hdr = stream->enc_xtn_hdr;
+            int count = stream->enc_xtn_hdr_count;
+            while (count > 0) {
+                printf("%d ", *enc_xtn_hdr);
+                enc_xtn_hdr++;
+                count--;
+            }
+            printf("\n");
+        } else {
+            printf("none\n");
+        }
 
         /* advance to next stream in the list */
         stream = stream->next;
@@ -1274,6 +1427,7 @@ srtp_validate ()
      * create a session with a single stream using the default srtp
      * policy and with the SSRC value 0xcafebabe
      */
+    memset(&policy, 0, sizeof(policy));
     srtp_crypto_policy_set_rtp_default(&policy.rtp);
     srtp_crypto_policy_set_rtcp_default(&policy.rtcp);
     policy.ssrc.type  = ssrc_specific;
@@ -1342,6 +1496,121 @@ srtp_validate ()
     return srtp_err_status_ok;
 }
 
+/*
+ * Test vectors taken from RFC 6904, Appendix A
+ */
+srtp_err_status_t
+srtp_validate_encrypted_extensions_headers() {
+    unsigned char test_key_ext_headers[30] = {
+        0xe1, 0xf9, 0x7a, 0x0d, 0x3e, 0x01, 0x8b, 0xe0,
+        0xd6, 0x4f, 0xa3, 0x2c, 0x06, 0xde, 0x41, 0x39,
+        0x0e, 0xc6, 0x75, 0xad, 0x49, 0x8a, 0xfe, 0xeb,
+        0xb6, 0x96, 0x0b, 0x3a, 0xab, 0xe6
+    };
+    uint8_t srtp_plaintext_ref[56] = {
+        0x90, 0x0f, 0x12, 0x34, 0xde, 0xca, 0xfb, 0xad,
+        0xca, 0xfe, 0xba, 0xbe, 0xBE, 0xDE, 0x00, 0x06,
+        0x17, 0x41, 0x42, 0x73, 0xA4, 0x75, 0x26, 0x27,
+        0x48, 0x22, 0x00, 0x00, 0xC8, 0x30, 0x8E, 0x46,
+        0x55, 0x99, 0x63, 0x86, 0xB3, 0x95, 0xFB, 0x00,
+        0xab, 0xab, 0xab, 0xab, 0xab, 0xab, 0xab, 0xab,
+        0xab, 0xab, 0xab, 0xab, 0xab, 0xab, 0xab, 0xab
+    };
+    uint8_t srtp_plaintext[66] = {
+        0x90, 0x0f, 0x12, 0x34, 0xde, 0xca, 0xfb, 0xad,
+        0xca, 0xfe, 0xba, 0xbe, 0xBE, 0xDE, 0x00, 0x06,
+        0x17, 0x41, 0x42, 0x73, 0xA4, 0x75, 0x26, 0x27,
+        0x48, 0x22, 0x00, 0x00, 0xC8, 0x30, 0x8E, 0x46,
+        0x55, 0x99, 0x63, 0x86, 0xB3, 0x95, 0xFB, 0x00,
+        0xab, 0xab, 0xab, 0xab, 0xab, 0xab, 0xab, 0xab,
+        0xab, 0xab, 0xab, 0xab, 0xab, 0xab, 0xab, 0xab,
+        0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+        0x00, 0x00
+    };
+    uint8_t srtp_ciphertext[66] = {
+        0x90, 0x0f, 0x12, 0x34, 0xde, 0xca, 0xfb, 0xad,
+        0xca, 0xfe, 0xba, 0xbe, 0xBE, 0xDE, 0x00, 0x06,
+        0x17, 0x58, 0x8A, 0x92, 0x70, 0xF4, 0xE1, 0x5E,
+        0x1C, 0x22, 0x00, 0x00, 0xC8, 0x30, 0x95, 0x46,
+        0xA9, 0x94, 0xF0, 0xBC, 0x54, 0x78, 0x97, 0x00,
+        0x4e, 0x55, 0xdc, 0x4c, 0xe7, 0x99, 0x78, 0xd8,
+        0x8c, 0xa4, 0xd2, 0x15, 0x94, 0x9d, 0x24, 0x02,
+        0x5a, 0x46, 0xb3, 0xca, 0x35, 0xc5, 0x35, 0xa8,
+        0x91, 0xc7
+    };
+    srtp_t srtp_snd, srtp_recv;
+    srtp_err_status_t status;
+    int len;
+    srtp_policy_t policy;
+    int headers[3] = {1, 3, 4};
+
+    /*
+     * create a session with a single stream using the default srtp
+     * policy and with the SSRC value 0xcafebabe
+     */
+    memset(&policy, 0, sizeof(policy));
+    srtp_crypto_policy_set_rtp_default(&policy.rtp);
+    srtp_crypto_policy_set_rtcp_default(&policy.rtcp);
+    policy.ssrc.type  = ssrc_specific;
+    policy.ssrc.value = 0xcafebabe;
+    policy.key  = test_key_ext_headers;
+    policy.ekt = NULL;
+    policy.window_size = 128;
+    policy.allow_repeat_tx = 0;
+    policy.enc_xtn_hdr = headers;
+    policy.enc_xtn_hdr_count = sizeof(headers) / sizeof(headers[0]);
+    policy.next = NULL;
+
+    status = srtp_create(&srtp_snd, &policy);
+    if (status)
+        return status;
+
+    /*
+     * protect plaintext, then compare with ciphertext
+     */
+    len = sizeof(srtp_plaintext_ref);
+    status = srtp_protect(srtp_snd, srtp_plaintext, &len);
+    if (status || (len != sizeof(srtp_plaintext)))
+        return srtp_err_status_fail;
+
+    debug_print(mod_driver, "ciphertext:\n  %s",
+                srtp_octet_string_hex_string(srtp_plaintext, len));
+    debug_print(mod_driver, "ciphertext reference:\n  %s",
+                srtp_octet_string_hex_string(srtp_ciphertext, len));
+
+    if (octet_string_is_eq(srtp_plaintext, srtp_ciphertext, len))
+        return srtp_err_status_fail;
+
+    /*
+     * create a receiver session context comparable to the one created
+     * above - we need to do this so that the replay checking doesn't
+     * complain
+     */
+    status = srtp_create(&srtp_recv, &policy);
+    if (status)
+        return status;
+
+    /*
+     * unprotect ciphertext, then compare with plaintext
+     */
+    status = srtp_unprotect(srtp_recv, srtp_ciphertext, &len);
+    if (status || (len != 28))
+        return status;
+
+    if (octet_string_is_eq(srtp_ciphertext, srtp_plaintext_ref, len))
+        return srtp_err_status_fail;
+
+    status = srtp_dealloc(srtp_snd);
+    if (status)
+        return status;
+
+    status = srtp_dealloc(srtp_recv);
+    if (status)
+        return status;
+
+    return srtp_err_status_ok;
+}
+
 
 /*
  * srtp_validate_aes_256() verifies the correctness of libsrtp by comparing
@@ -1391,6 +1660,7 @@ srtp_validate_aes_256 ()
      * create a session with a single stream using the default srtp
      * policy and with the SSRC value 0xcafebabe
      */
+    memset(&policy, 0, sizeof(policy));
     srtp_crypto_policy_set_aes_cm_256_hmac_sha1_80(&policy.rtp);
     srtp_crypto_policy_set_aes_cm_256_hmac_sha1_80(&policy.rtcp);
     policy.ssrc.type  = ssrc_specific;
@@ -1572,6 +1842,7 @@ srtp_test_remove_stream ()
     }
 
     /* Now test adding and removing a single stream */
+    memset(&policy, 0, sizeof(policy));
     srtp_crypto_policy_set_rtp_default(&policy.rtp);
     srtp_crypto_policy_set_rtcp_default(&policy.rtcp);
     policy.ssrc.type  = ssrc_specific;
@@ -1641,6 +1912,8 @@ const srtp_policy_t default_policy = {
     NULL,      /* indicates that EKT is not in use */
     128,       /* replay window size */
     0,         /* retransmission not allowed */
+    NULL,      /* no encrypted extension headers */
+    0,         /* list of encrypted extension headers is empty */
     NULL
 };
 
@@ -1666,6 +1939,8 @@ const srtp_policy_t aes_only_policy = {
     NULL,      /* indicates that EKT is not in use */
     128,       /* replay window size */
     0,         /* retransmission not allowed */
+    NULL,      /* no encrypted extension headers */
+    0,         /* list of encrypted extension headers is empty */
     NULL
 };
 
@@ -1691,6 +1966,8 @@ const srtp_policy_t hmac_only_policy = {
     NULL,      /* indicates that EKT is not in use */
     128,       /* replay window size */
     0,         /* retransmission not allowed */
+    NULL,      /* no encrypted extension headers */
+    0,         /* list of encrypted extension headers is empty */
     NULL
 };
 
@@ -1717,6 +1994,8 @@ const srtp_policy_t aes128_gcm_8_policy = {
     NULL,        /* indicates that EKT is not in use */
     128,         /* replay window size */
     0,           /* retransmission not allowed */
+    NULL,        /* no encrypted extension headers */
+    0,           /* list of encrypted extension headers is empty */
     NULL
 };
 
@@ -1742,6 +2021,8 @@ const srtp_policy_t aes128_gcm_8_cauth_policy = {
     NULL,        /* indicates that EKT is not in use */
     128,         /* replay window size */
     0,           /* retransmission not allowed */
+    NULL,        /* no encrypted extension headers */
+    0,           /* list of encrypted extension headers is empty */
     NULL
 };
 
@@ -1767,6 +2048,8 @@ const srtp_policy_t aes256_gcm_8_policy = {
     NULL,        /* indicates that EKT is not in use */
     128,         /* replay window size */
     0,           /* retransmission not allowed */
+    NULL,        /* no encrypted extension headers */
+    0,           /* list of encrypted extension headers is empty */
     NULL
 };
 
@@ -1792,6 +2075,8 @@ const srtp_policy_t aes256_gcm_8_cauth_policy = {
     NULL,        /* indicates that EKT is not in use */
     128,         /* replay window size */
     0,           /* retransmission not allowed */
+    NULL,        /* no encrypted extension headers */
+    0,           /* list of encrypted extension headers is empty */
     NULL
 };
 #endif
@@ -1818,6 +2103,8 @@ const srtp_policy_t null_policy = {
     NULL,      /* indicates that EKT is not in use */
     128,       /* replay window size */
     0,         /* retransmission not allowed */
+    NULL,      /* no encrypted extension headers */
+    0,         /* list of encrypted extension headers is empty */
     NULL
 };
 
@@ -1853,6 +2140,8 @@ const srtp_policy_t aes_256_hmac_policy = {
     NULL,      /* indicates that EKT is not in use */
     128,       /* replay window size */
     0,         /* retransmission not allowed */
+    NULL,      /* no encrypted extension headers */
+    0,         /* list of encrypted extension headers is empty */
     NULL
 };
 
@@ -1892,6 +2181,8 @@ const srtp_policy_t hmac_only_with_ekt_policy = {
     &ekt_test_policy,      /* indicates that EKT is not in use */
     128,                   /* replay window size */
     0,                     /* retransmission not allowed */
+    NULL,                  /* no encrypted extension headers */
+    0,                     /* list of encrypted extension headers is empty */
     NULL
 };
 
@@ -1945,5 +2236,7 @@ const srtp_policy_t wildcard_policy = {
     NULL,
     128,                 /* replay window size */
     0,                   /* retransmission not allowed */
+    NULL,                /* no encrypted extension headers */
+    0,                   /* list of encrypted extension headers is empty */
     NULL
 };

--- a/test/srtp_driver.c
+++ b/test/srtp_driver.c
@@ -326,8 +326,7 @@ main (int argc, char *argv[])
             exit(1);
         }
 
-//FIXME: need to get this working with the OpenSSL AES module
-#ifndef OPENSSL
+#ifdef OPENSSL
         /*
          * run validation test against the reference packets for
          * AES-256

--- a/test/srtp_driver.c
+++ b/test/srtp_driver.c
@@ -66,8 +66,10 @@ srtp_validate(void);
 srtp_err_status_t
 srtp_validate_encrypted_extensions_headers(void);
 
+#ifdef OPENSSL
 srtp_err_status_t
 srtp_validate_encrypted_extensions_headers_gcm(void);
+#endif
 
 srtp_err_status_t
 srtp_validate_aes_256(void);
@@ -338,6 +340,7 @@ main (int argc, char *argv[])
             printf("failed\n");
             exit(1);
         }
+#endif
 
         /*
          * run validation test against the reference packets for
@@ -351,7 +354,6 @@ main (int argc, char *argv[])
             printf("failed\n");
             exit(1);
         }
-#endif
 
         /*
          * test the function srtp_remove_stream()
@@ -1623,6 +1625,7 @@ srtp_validate_encrypted_extensions_headers() {
 }
 
 
+#ifdef OPENSSL
 /*
  * Headers of test vectors taken from RFC 6904, Appendix A
  */
@@ -1735,7 +1738,7 @@ srtp_validate_encrypted_extensions_headers_gcm() {
 
     return srtp_err_status_ok;
 }
-
+#endif
 
 /*
  * srtp_validate_aes_256() verifies the correctness of libsrtp by comparing


### PR DESCRIPTION
Header ids to encrypt can be specified through the "srtp_policy_t".
Added validation testcase using test vectors from RFC. Implements issue #124.