### PR TITLE
* fix file references without $(srcdir) in Makefile.in.

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -175,13 +175,13 @@ test/rtp_decoder$(EXE): test/rtp_decoder.c test/rtp.c test/util.c test/getopt_s.
 endif
 
 crypto/test/aes_calc$(EXE): crypto/test/aes_calc.c test/util.c
-	$(COMPILE) -I./test $(LDFLAGS) -o $@ $^ $(LIBS) $(SRTPLIB)
+	$(COMPILE) -I$(srcdir)/test $(LDFLAGS) -o $@ $^ $(LIBS) $(SRTPLIB)
 
 crypto/test/datatypes_driver$(EXE): crypto/test/datatypes_driver.c test/util.c
-	$(COMPILE) -I./test $(LDFLAGS) -o $@ $^ $(LIBS) $(SRTPLIB)
+	$(COMPILE) -I$(srcdir)/test $(LDFLAGS) -o $@ $^ $(LIBS) $(SRTPLIB)
 
 crypto/test/sha1_driver$(EXE): crypto/test/sha1_driver.c test/util.c
-	$(COMPILE) -I./test $(LDFLAGS) -o $@ $^ $(LIBS) $(SRTPLIB)
+	$(COMPILE) -I$(srcdir)/test $(LDFLAGS) -o $@ $^ $(LIBS) $(SRTPLIB)
 
 test/srtp_driver$(EXE): test/srtp_driver.c test/util.c test/getopt_s.c
 	$(COMPILE) $(LDFLAGS) -o $@ $^ $(LIBS) $(SRTPLIB)

--- a/crypto/Makefile.in
+++ b/crypto/Makefile.in
@@ -81,8 +81,8 @@ endif
 %.o: %.c
 	$(COMPILE) -c $< -o $@
 
-%$(EXE): %.c ../test/getopt_s.c
-	$(COMPILE) $(LDFLAGS) $< ../test/getopt_s.c -o $@ $(CRYPTOLIB) $(LIBS)
+%$(EXE): %.c $(srcdir)/../test/getopt_s.c
+	$(COMPILE) $(LDFLAGS) $< $(srcdir)/../test/getopt_s.c -o $@ $(CRYPTOLIB) $(LIBS)
 
 all: $(testapp)
 


### PR DESCRIPTION
There are some file references without  $(srcdir) (mostly related to test cases) within  the two Makefile.in, which prevent building with an independent directory other than source directory, since such references will become invalid.