### PR TITLE
Prevent stack-buffer-overflow with gcc -fsanitize=address

### DIFF
--- a/crypto/cipher/aes_gcm_ossl.c
+++ b/crypto/cipher/aes_gcm_ossl.c
@@ -262,7 +262,9 @@ static srtp_err_status_t srtp_aes_gcm_openssl_set_aad (srtp_aes_gcm_ctx_t *c, co
      * OpenSSL copy its content to the context), so we can make 
      * aad read-only in this function and all its wrappers.
      */
-    EVP_CIPHER_CTX_ctrl(&c->ctx, EVP_CTRL_GCM_SET_TAG, c->tag_len, (void*)aad);
+    unsigned char dummy_tag[GCM_AUTH_TAG_LEN];
+    memset(dummy_tag, 0x0, GCM_AUTH_TAG_LEN);
+    EVP_CIPHER_CTX_ctrl(&c->ctx, EVP_CTRL_GCM_SET_TAG, c->tag_len, &dummy_tag);
 
     rv = EVP_Cipher(&c->ctx, NULL, aad, aad_len);
     if (rv != aad_len) {


### PR DESCRIPTION
The value passed to srtp_aes_gcm_openssl_set_aad is not guarantied
to be >= c->tag_len. Since the call to EVP_CIPHER_CTX_ctrl is a
dummy call pass it a dummy tag that is large enough.

Resubmition of https://github.com/cisco/libsrtp/pull/117