### PR TITLE
Some fixes as follow-up on #128

### DIFF
--- a/srtp/srtp.c
+++ b/srtp/srtp.c
@@ -822,6 +822,15 @@ srtp_stream_init_keys(srtp_stream_ctx_t *srtp, const void *key) {
       octet_string_set_to_zero(tmp_key, MAX_SRTP_KEY_LEN);
       return srtp_err_status_init_fail;
     }
+
+    if (xtn_hdr_kdf != &kdf) {
+      /* release memory for custom header extension encryption kdf */
+      stat = srtp_kdf_clear(xtn_hdr_kdf);
+      if (stat) {
+        octet_string_set_to_zero(tmp_key, MAX_SRTP_KEY_LEN);
+        return srtp_err_status_init_fail;
+      }
+    }
   }
 
   /* generate authentication key */

--- a/test/srtp_driver.c
+++ b/test/srtp_driver.c
@@ -1621,8 +1621,11 @@ srtp_validate_encrypted_extensions_headers() {
      * unprotect ciphertext, then compare with plaintext
      */
     status = srtp_unprotect(srtp_recv, srtp_ciphertext, &len);
-    if (status || (len != 28))
+    if (status) {
         return status;
+    } else if (len != sizeof(srtp_plaintext_ref)) {
+        return srtp_err_status_fail;
+    }
 
     if (octet_string_is_eq(srtp_ciphertext, srtp_plaintext_ref, len))
         return srtp_err_status_fail;
@@ -1640,6 +1643,7 @@ srtp_validate_encrypted_extensions_headers() {
 
 
 #ifdef OPENSSL
+
 /*
  * Headers of test vectors taken from RFC 6904, Appendix A
  */
@@ -1736,8 +1740,11 @@ srtp_validate_encrypted_extensions_headers_gcm() {
      * unprotect ciphertext, then compare with plaintext
      */
     status = srtp_unprotect(srtp_recv, srtp_ciphertext, &len);
-    if (status || (len != 28))
+    if (status) {
         return status;
+    } else if (len != sizeof(srtp_plaintext_ref)) {
+        return srtp_err_status_fail;
+    }
 
     if (octet_string_is_eq(srtp_ciphertext, srtp_plaintext_ref, len))
         return srtp_err_status_fail;

--- a/test/srtp_driver.c
+++ b/test/srtp_driver.c
@@ -2046,6 +2046,7 @@ srtp_test_update() {
   srtp_t srtp_snd, srtp_recv;
   srtp_policy_t policy;
 
+  memset(&policy, 0, sizeof(policy));
   srtp_crypto_policy_set_rtp_default(&policy.rtp);
   srtp_crypto_policy_set_rtcp_default(&policy.rtcp);
   policy.ekt = NULL;


### PR DESCRIPTION
As a follow-up to #128 I simplified some code and fixed a few issues:
- Releasing of partially allocated streams now happens in a single function, thus reducing duplicated code.
- One test didn't zero-initialize the `srtp_policy_t` struct, causing random crashes.
- Updated two new tests to properly fail if `srtp_unprotect` returns `srtp_err_status_ok` but not the complete data.
- Fixed a small memory leak if header extensions encryption was used with GCM ciphers.