### PR TITLE
Initialize variable.

### DIFF
--- a/test/replay_driver.c
+++ b/test/replay_driver.c
@@ -233,7 +233,7 @@ rdb_check_adds_per_second(void) {
   uint32_t i;
   srtp_rdb_t rdb;
   clock_t timer;
-  int failures;                    /* count number of failures        */
+  int failures = 0;                    /* count number of failures        */
   
   if (srtp_rdb_init(&rdb) != srtp_err_status_ok) {
     printf("rdb_init failed\n");


### PR DESCRIPTION
Besides being the Right Thing (other than maybe to delete this write-only variable), it also fixes this clang warning:

    error: variable 'failures' is uninitialized when used here [-Werror,-Wuninitialized]