### PR TITLE
Make srtp_driver compile for MIPS.

### DIFF
--- a/test/srtp_driver.c
+++ b/test/srtp_driver.c
@@ -436,7 +436,7 @@ main (int argc, char *argv[])
     if (do_codec_timing) {
         srtp_policy_t policy;
         int ignore;
-        double mips = mips_estimate(1000000000, &ignore);
+        double mips_value = mips_estimate(1000000000, &ignore);
 
         memset(&policy, 0, sizeof(policy));
         srtp_crypto_policy_set_rtp_default(&policy.rtp);
@@ -449,33 +449,33 @@ main (int argc, char *argv[])
         policy.allow_repeat_tx = 0;
         policy.next = NULL;
 
-        printf("mips estimate: %e\n", mips);
+        printf("mips estimate: %e\n", mips_value);
 
         printf("testing srtp processing time for voice codecs:\n");
         printf("codec\t\tlength (octets)\t\tsrtp instructions/second\n");
         printf("G.711\t\t%d\t\t\t%e\n", 80,
-               (double)mips * (80 * 8) /
+               (double)mips_value * (80 * 8) /
                srtp_bits_per_second(80, &policy) / .01 );
         printf("G.711\t\t%d\t\t\t%e\n", 160,
-               (double)mips * (160 * 8) /
+               (double)mips_value * (160 * 8) /
                srtp_bits_per_second(160, &policy) / .02);
         printf("G.726-32\t%d\t\t\t%e\n", 40,
-               (double)mips * (40 * 8) /
+               (double)mips_value * (40 * 8) /
                srtp_bits_per_second(40, &policy) / .01 );
         printf("G.726-32\t%d\t\t\t%e\n", 80,
-               (double)mips * (80 * 8) /
+               (double)mips_value * (80 * 8) /
                srtp_bits_per_second(80, &policy) / .02);
         printf("G.729\t\t%d\t\t\t%e\n", 10,
-               (double)mips * (10 * 8) /
+               (double)mips_value * (10 * 8) /
                srtp_bits_per_second(10, &policy) / .01 );
         printf("G.729\t\t%d\t\t\t%e\n", 20,
-               (double)mips * (20 * 8) /
+               (double)mips_value * (20 * 8) /
                srtp_bits_per_second(20, &policy) / .02 );
         printf("Wideband\t%d\t\t\t%e\n", 320,
-               (double)mips * (320 * 8) /
+               (double)mips_value * (320 * 8) /
                srtp_bits_per_second(320, &policy) / .01 );
         printf("Wideband\t%d\t\t\t%e\n", 640,
-               (double)mips * (640 * 8) /
+               (double)mips_value * (640 * 8) /
                srtp_bits_per_second(640, &policy) / .02 );
     }
 


### PR DESCRIPTION
Rename local variable 'mips' to 'mips_value' as 'mips' is already defined by MIPS version of gcc.

This is a backport of https://crrev.com/9cc4f2f799887e5d64bd28c159ea34b413f6be31 to help making future updates in Chromium easier.