### PR TITLE
use PKG_PROG_PKG_CONFIG to find correct pkg-config

### DIFF
--- a/configure.in
+++ b/configure.in
@@ -110,6 +110,8 @@ if test "$enable_generic_aesicm" = "yes"; then
 fi
 AC_MSG_RESULT($enable_generic_aesicm)
 
+PKG_PROG_PKG_CONFIG
+
 AC_MSG_CHECKING(whether to leverage OpenSSL crypto)
 AC_ARG_ENABLE(openssl,
   [AS_HELP_STRING([--enable-openssl],
@@ -188,7 +190,6 @@ AC_MSG_RESULT($enable_console)
 
 AC_CONFIG_HEADER(crypto/include/config.h:config_in.h)
 
-AC_CHECK_PROG(PKG_CONFIG, pkg-config, yes)
 if test "x$PKG_CONFIG" != "x"; then
     HAVE_PKG_CONFIG=1
     AC_CONFIG_FILES([libsrtp2.pc])

--- a/configure.in
+++ b/configure.in
@@ -124,8 +124,8 @@ if test "$enable_openssl" = "yes"; then
       [AS_HELP_STRING([--with-openssl-dir], [Location of OpenSSL installation])],
       [openssl_dir="$withval"], openssl_dir="")
 
-   LDFLAGS="$LDFLAGS -L$openssl_dir/lib $(pkg-config --libs openssl)";
-   CFLAGS="$CFLAGS -I$openssl_dir/include $(pkg-config --cflags openssl)";
+   LDFLAGS="$LDFLAGS -L$openssl_dir/lib $($PKG_CONFIG --libs openssl)";
+   CFLAGS="$CFLAGS -I$openssl_dir/include $($PKG_CONFIG --cflags openssl)";
 
    AC_CHECK_LIB([dl], [dlopen], [],
              [AC_MSG_WARN([can't find libdl])])


### PR DESCRIPTION
In situation where cross compiling it may be necessary to use prefixed pkg-config executables