### PR TITLE
Store new master key when calling srtp_update

### DIFF
--- a/srtp/srtp.c
+++ b/srtp/srtp.c
@@ -3324,6 +3324,7 @@ update_template_streams(srtp_t session,
   srtp_err_status_t status;
   srtp_stream_t new_stream_template;
   srtp_stream_t new_stream_list = NULL;
+  int key_len;
 
   if (session->stream_template == NULL) {
     return srtp_err_status_bad_param;
@@ -3357,6 +3358,10 @@ update_template_streams(srtp_t session,
       return status;
     }
   }
+
+  /* Copy master key copy as provided by the application */
+  key_len = srtp_cipher_get_key_length(new_stream_template->rtp_cipher);
+  memcpy(new_stream_template->master_key, policy->key, key_len);
 
   /* initialize new template stream  */
   status = srtp_stream_init(new_stream_template, policy);

--- a/test/srtp_driver.c
+++ b/test/srtp_driver.c
@@ -2422,6 +2422,30 @@ srtp_test_update() {
 
   free(msg);
 
+  /* update send ctx with same test_key t verify update works*/
+  policy.ssrc.type = ssrc_any_outbound;
+  policy.key = test_key;
+  status = srtp_update(srtp_snd, &policy);
+  if (status)
+    return status;
+
+  msg = srtp_create_test_packet(msg_len_octets, ssrc);
+  if (msg == NULL)
+    return srtp_err_status_alloc_fail;
+  msg->seq = htons(2);
+
+  protected_msg_len_octets = msg_len_octets;
+  status = srtp_protect(srtp_snd, msg, &protected_msg_len_octets);
+  if (status)
+    return srtp_err_status_fail;
+
+  status = srtp_unprotect(srtp_recv, msg, &protected_msg_len_octets);
+  if (status)
+    return status;
+
+  free(msg);
+
+
   /* update send ctx to use test_alt_key */
   policy.ssrc.type = ssrc_any_outbound;
   policy.key = test_alt_key;
@@ -2433,7 +2457,7 @@ srtp_test_update() {
   msg = srtp_create_test_packet(msg_len_octets, ssrc);
   if (msg == NULL)
     return srtp_err_status_alloc_fail;
-  msg->seq = htons(2);
+  msg->seq = htons(3);
 
   protected_msg_len_octets = msg_len_octets;
   status = srtp_protect(srtp_snd, msg, &protected_msg_len_octets);


### PR DESCRIPTION
The master key now needs to be stored in srtp srtp_stream_ctx_t.
The update_srtp function was not doing this so master key was
effective all zeros after srpt_update was called.
The code that manages the creation of new streams in side of
srtp_update is basically a copy of what is done in srtp_add_stream,
this code should be re factored to be the same to avoid such
inconsistency errors.

Will cherry pick test to master