### PR TITLE
AES-192 (ICM) approach B

### DIFF
--- a/crypto/kernel/crypto_kernel.c
+++ b/crypto/kernel/crypto_kernel.c
@@ -76,6 +76,10 @@ extern cipher_type_t aes_icm;
 #ifndef OPENSSL
 extern cipher_type_t aes_cbc;
 #else
+#ifndef SRTP_NO_AES192
+extern cipher_type_t aes_icm_192;
+#endif
+extern cipher_type_t aes_icm_256;
 extern cipher_type_t aes_gcm_128_openssl;
 extern cipher_type_t aes_gcm_256_openssl;
 #endif
@@ -170,6 +174,16 @@ crypto_kernel_init() {
   if (status) 
     return status;
 #else
+#ifndef SRTP_NO_AES192
+  status = crypto_kernel_load_cipher_type(&aes_icm_192, AES_192_ICM);
+  if (status) {
+      return status;
+  }
+#endif
+  status = crypto_kernel_load_cipher_type(&aes_icm_256, AES_256_ICM);
+  if (status) {
+      return status;
+  }
   status = crypto_kernel_load_cipher_type(&aes_gcm_128_openssl, AES_128_GCM);
   if (status) {
       return status;

--- a/srtp/srtp.c
+++ b/srtp/srtp.c
@@ -1353,7 +1353,8 @@ srtp_unprotect_aead (srtp_ctx_t *ctx, srtp_stream_ctx_t *stream, int delta,
    /* 
     * if we're using rindael counter mode, set nonce and seq 
     */
-   if (stream->rtp_cipher->type->id == AES_ICM ||
+   if (stream->rtp_cipher->type->id == AES_128_ICM ||
+       stream->rtp_cipher->type->id == AES_192_ICM ||
        stream->rtp_cipher->type->id == AES_256_ICM) {
      v128_t iv;
 
@@ -1545,7 +1546,8 @@ srtp_unprotect(srtp_ctx_t *ctx, void *srtp_hdr, int *pkt_octet_len) {
    * set the cipher's IV properly, depending on whatever cipher we
    * happen to be using
    */
-  if (stream->rtp_cipher->type->id == AES_ICM ||
+  if (stream->rtp_cipher->type->id == AES_128_ICM ||
+      stream->rtp_cipher->type->id == AES_192_ICM ||
       stream->rtp_cipher->type->id == AES_256_ICM) {
 
     /* aes counter mode */
@@ -2738,7 +2740,9 @@ srtp_protect_rtcp(srtp_t ctx, void *rtcp_hdr, int *pkt_octet_len) {
   /* 
    * if we're using rindael counter mode, set nonce and seq 
    */
-  if (stream->rtcp_cipher->type->id == AES_ICM) {
+  if (stream->rtcp_cipher->type->id == AES_128_ICM ||
+      stream->rtcp_cipher->type->id == AES_192_ICM ||
+      stream->rtcp_cipher->type->id == AES_256_ICM) {
     v128_t iv;
     
     iv.v32[0] = 0;
@@ -2959,7 +2963,9 @@ srtp_unprotect_rtcp(srtp_t ctx, void *srtcp_hdr, int *pkt_octet_len) {
   /* 
    * if we're using aes counter mode, set nonce and seq 
    */
-  if (stream->rtcp_cipher->type->id == AES_ICM) {
+  if (stream->rtcp_cipher->type->id == AES_128_ICM ||
+      stream->rtcp_cipher->type->id == AES_192_ICM ||
+      stream->rtcp_cipher->type->id == AES_256_ICM) {
     v128_t iv;
 
     iv.v32[0] = 0;

--- a/test/srtp_driver.c
+++ b/test/srtp_driver.c
@@ -288,8 +288,7 @@ main (int argc, char *argv[]) {
        exit(1); 
     }
 
-//FIXME: need to get this working with the OpenSSL AES module
-#ifndef OPENSSL
+#ifdef OPENSSL
     /*
      * run validation test against the reference packets for
      * AES-256


### PR DESCRIPTION
In the original libSRTP (without OpenSSL), support for AES-256 was added in May 2010 with commit 5df951a, but AES-192 was not implemented (see `crypto/cipher/aes.c:aes_expand_encryption_key`). Since 2013 with OpenSSL enabled (see pull request #34), libSRTP supports AES-192 as well. Or stated differently:

If you want the [crypto suite](https://www.iana.org/assignments/sdp-security-descriptions/sdp-security-descriptions.xhtml) `AES_192_CM_HMAC_SHA1_80` in your VoIP application, you have to go for
`./configure --enable-openssl`
otherwise, just AES-256 and AES-128 work. As a side-effect, you get AES-NI and AES-GCM.

Even with the current source code, AES-192 works only between VoIP applications which use the same library (for example locally on the same computer). I did not squash the two commits on purpose, hopefully to make the overall pull request easier to understand.

This is approach/alternative B to solve this issue. Because I am just a contributor and not a member of the team, I cannot decide whether the approach A or B is the correct one. If you do not like the other approach A, please, consider this simpler change-set here for inclusion, especially because several VoIP/SIP clients leverage AES-192 already (like Acrobits Groundwire and Media5-fone).
