### PR TITLE
AES-192 (ICM) approach A

### DIFF
--- a/crypto/cipher/aes_icm.c
+++ b/crypto/cipher/aes_icm.c
@@ -121,15 +121,13 @@ aes_icm_alloc_ismacryp(cipher_t **c, int key_len, int forIsmacryp) {
 
   /* set pointers */
   *c = (cipher_t *)pointer;
+  (*c)->algorithm = AES_ICM;
   switch (key_len) {
   case 46:
       (*c)->algorithm = AES_256_ICM;
       break;
   case 38:
       (*c)->algorithm = AES_192_ICM;
-      break;
-  default:
-      (*c)->algorithm = AES_128_ICM;
       break;
   }
   (*c)->type = &aes_icm;

--- a/crypto/cipher/aes_icm.c
+++ b/crypto/cipher/aes_icm.c
@@ -122,11 +122,6 @@ aes_icm_alloc_ismacryp(cipher_t **c, int key_len, int forIsmacryp) {
   /* set pointers */
   *c = (cipher_t *)pointer;
   (*c)->algorithm = AES_ICM;
-  switch (key_len) {
-  case 46:
-      (*c)->algorithm = AES_256_ICM;
-      break;
-  }
   (*c)->type = &aes_icm;
   (*c)->state = pointer + sizeof(cipher_t);
 

--- a/crypto/cipher/aes_icm.c
+++ b/crypto/cipher/aes_icm.c
@@ -126,9 +126,6 @@ aes_icm_alloc_ismacryp(cipher_t **c, int key_len, int forIsmacryp) {
   case 46:
       (*c)->algorithm = AES_256_ICM;
       break;
-  case 38:
-      (*c)->algorithm = AES_192_ICM;
-      break;
   }
   (*c)->type = &aes_icm;
   (*c)->state = pointer + sizeof(cipher_t);

--- a/crypto/cipher/aes_icm_ossl.c
+++ b/crypto/cipher/aes_icm_ossl.c
@@ -153,7 +153,6 @@ err_status_t aes_icm_openssl_alloc (cipher_t **c, int key_len, int tlen)
         break;
 #ifndef SRTP_NO_AES192
     case AES_192_KEYSIZE_WSALT:
-        (*c)->algorithm = AES_192_ICM;
         (*c)->type = &aes_icm_192;
         aes_icm_192.ref_count++;
         ((aes_icm_ctx_t*)(*c)->state)->key_size = AES_192_KEYSIZE;
@@ -537,7 +536,7 @@ cipher_type_t aes_icm_192 = {
     (int)                          0,                /* instance count */
     (cipher_test_case_t*)          &aes_icm_192_test_case_1,
     (debug_module_t*)              &mod_aes_icm,
-    (cipher_type_id_t)             AES_192_ICM
+    (cipher_type_id_t)             AES_ICM
 };
 #endif
 

--- a/crypto/cipher/aes_icm_ossl.c
+++ b/crypto/cipher/aes_icm_ossl.c
@@ -142,11 +142,11 @@ err_status_t aes_icm_openssl_alloc (cipher_t **c, int key_len, int tlen)
     *c = (cipher_t*)allptr;
     (*c)->state = allptr + sizeof(cipher_t);
     icm = (aes_icm_ctx_t*)(*c)->state;
+    (*c)->algorithm = AES_ICM;
 
     /* increment ref_count */
     switch (key_len) {
     case AES_128_KEYSIZE_WSALT:
-        (*c)->algorithm = AES_128_ICM;
         (*c)->type = &aes_icm;
         aes_icm.ref_count++;
         ((aes_icm_ctx_t*)(*c)->state)->key_size = AES_128_KEYSIZE;

--- a/crypto/cipher/aes_icm_ossl.c
+++ b/crypto/cipher/aes_icm_ossl.c
@@ -159,7 +159,6 @@ err_status_t aes_icm_openssl_alloc (cipher_t **c, int key_len, int tlen)
         break;
 #endif
     case AES_256_KEYSIZE_WSALT:
-        (*c)->algorithm = AES_256_ICM;
         (*c)->type = &aes_icm_256;
         aes_icm_256.ref_count++;
         ((aes_icm_ctx_t*)(*c)->state)->key_size = AES_256_KEYSIZE;
@@ -557,6 +556,6 @@ cipher_type_t aes_icm_256 = {
     (int)                          0,                /* instance count */
     (cipher_test_case_t*)          &aes_icm_256_test_case_2,
     (debug_module_t*)              &mod_aes_icm,
-    (cipher_type_id_t)             AES_256_ICM
+    (cipher_type_id_t)             AES_ICM
 };
 

--- a/srtp/srtp.c
+++ b/srtp/srtp.c
@@ -488,7 +488,7 @@ srtp_kdf_clear(srtp_kdf_t *kdf) {
 static inline int base_key_length(const cipher_type_t *cipher, int key_length)
 {
   switch (cipher->id) {
-  case AES_128_ICM:
+  case AES_ICM:
   case AES_192_ICM:
   case AES_256_ICM:
     /* The legacy modes are derived from

--- a/srtp/srtp.c
+++ b/srtp/srtp.c
@@ -489,7 +489,6 @@ static inline int base_key_length(const cipher_type_t *cipher, int key_length)
 {
   switch (cipher->id) {
   case AES_ICM:
-  case AES_256_ICM:
     /* The legacy modes are derived from
      * the configured key length on the policy */
     return key_length - 14;
@@ -1352,8 +1351,7 @@ srtp_unprotect_aead (srtp_ctx_t *ctx, srtp_stream_ctx_t *stream, int delta,
    /* 
     * if we're using rindael counter mode, set nonce and seq 
     */
-   if (stream->rtp_cipher->type->id == AES_ICM ||
-       stream->rtp_cipher->type->id == AES_256_ICM) {
+   if (stream->rtp_cipher->type->id == AES_ICM) {
      v128_t iv;
 
      iv.v32[0] = 0;
@@ -1544,8 +1542,7 @@ srtp_unprotect(srtp_ctx_t *ctx, void *srtp_hdr, int *pkt_octet_len) {
    * set the cipher's IV properly, depending on whatever cipher we
    * happen to be using
    */
-  if (stream->rtp_cipher->type->id == AES_ICM ||
-      stream->rtp_cipher->type->id == AES_256_ICM) {
+  if (stream->rtp_cipher->type->id == AES_ICM) {
 
     /* aes counter mode */
     iv.v32[0] = 0;

--- a/srtp/srtp.c
+++ b/srtp/srtp.c
@@ -489,7 +489,6 @@ static inline int base_key_length(const cipher_type_t *cipher, int key_length)
 {
   switch (cipher->id) {
   case AES_ICM:
-  case AES_192_ICM:
   case AES_256_ICM:
     /* The legacy modes are derived from
      * the configured key length on the policy */

--- a/test/srtp_driver.c
+++ b/test/srtp_driver.c
@@ -1543,7 +1543,7 @@ unsigned char test_key[46] = {
 const srtp_policy_t default_policy = {
   { ssrc_any_outbound, 0 },  /* SSRC                           */
   {                      /* SRTP policy                    */                  
-    AES_128_ICM,            /* cipher type                 */
+    AES_ICM,                /* cipher type                 */
     30,                     /* cipher key length in octets */
     HMAC_SHA1,              /* authentication func type    */
     16,                     /* auth key length in octets   */
@@ -1551,7 +1551,7 @@ const srtp_policy_t default_policy = {
     sec_serv_conf_and_auth  /* security services flag      */
   },
   {                      /* SRTCP policy                   */
-    AES_128_ICM,            /* cipher type                 */
+    AES_ICM,                /* cipher type                 */
     30,                     /* cipher key length in octets */
     HMAC_SHA1,              /* authentication func type    */
     16,                     /* auth key length in octets   */
@@ -1568,7 +1568,7 @@ const srtp_policy_t default_policy = {
 const srtp_policy_t aes_tmmh_policy = {
   { ssrc_any_outbound, 0 },     /* SSRC                        */
   { 
-    AES_128_ICM,            /* cipher type                 */
+    AES_ICM,                /* cipher type                 */
     30,                     /* cipher key length in octets */
     UST_TMMHv2,             /* authentication func type    */
     94,                     /* auth key length in octets   */
@@ -1576,7 +1576,7 @@ const srtp_policy_t aes_tmmh_policy = {
     sec_serv_conf_and_auth  /* security services flag      */
   },
   { 
-    AES_128_ICM,            /* cipher type                 */
+    AES_ICM,                /* cipher type                 */
     30,                     /* cipher key length in octets */
     UST_TMMHv2,             /* authentication func type    */
     94,                     /* auth key length in octets   */
@@ -1593,7 +1593,7 @@ const srtp_policy_t aes_tmmh_policy = {
 const srtp_policy_t tmmh_only_policy = {
   { ssrc_any_outbound, 0 },     /* SSRC                        */
   {
-    AES_128_ICM,            /* cipher type                 */
+    AES_ICM,                /* cipher type                 */
     30,                     /* cipher key length in octets */
     UST_TMMHv2,             /* authentication func type    */
     94,                     /* auth key length in octets   */
@@ -1601,7 +1601,7 @@ const srtp_policy_t tmmh_only_policy = {
     sec_serv_auth           /* security services flag      */
   },
   {
-    AES_128_ICM,            /* cipher type                 */
+    AES_ICM,                /* cipher type                 */
     30,                     /* cipher key length in octets */
     UST_TMMHv2,             /* authentication func type    */
     94,                     /* auth key length in octets   */
@@ -1618,7 +1618,7 @@ const srtp_policy_t tmmh_only_policy = {
 const srtp_policy_t aes_only_policy = {
   { ssrc_any_outbound, 0 },     /* SSRC                        */ 
   {
-    AES_128_ICM,            /* cipher type                 */
+    AES_ICM,                /* cipher type                 */
     30,                     /* cipher key length in octets */
     NULL_AUTH,              /* authentication func type    */
     0,                      /* auth key length in octets   */
@@ -1626,7 +1626,7 @@ const srtp_policy_t aes_only_policy = {
     sec_serv_conf           /* security services flag      */
   },
   {
-    AES_128_ICM,            /* cipher type                 */
+    AES_ICM,                /* cipher type                 */
     30,                     /* cipher key length in octets */
     NULL_AUTH,              /* authentication func type    */
     0,                      /* auth key length in octets   */
@@ -1905,7 +1905,7 @@ policy_array[] = {
 const srtp_policy_t wildcard_policy = {
   { ssrc_any_outbound, 0 }, /* SSRC                        */
   {                      /* SRTP policy                    */                  
-    AES_128_ICM,            /* cipher type                 */
+    AES_ICM,                /* cipher type                 */
     30,                     /* cipher key length in octets */
     HMAC_SHA1,              /* authentication func type    */
     16,                     /* auth key length in octets   */
@@ -1913,7 +1913,7 @@ const srtp_policy_t wildcard_policy = {
     sec_serv_conf_and_auth  /* security services flag      */
   },
   {                      /* SRTCP policy                   */
-    AES_128_ICM,            /* cipher type                 */
+    AES_ICM,                /* cipher type                 */
     30,                     /* cipher key length in octets */
     HMAC_SHA1,              /* authentication func type    */
     16,                     /* auth key length in octets   */


### PR DESCRIPTION
In the original libSRTP (without OpenSSL), support for AES-256 was added in May 2010 with commit 5df951a, but AES-192 was not implemented (see `crypto/cipher/aes.c:aes_expand_encryption_key`). Since 2013 with OpenSSL enabled (see pull request #34), libSRTP supports AES-192 as well. Or stated differently:

If you want the [crypto suite](https://www.iana.org/assignments/sdp-security-descriptions/sdp-security-descriptions.xhtml) `AES_192_CM_HMAC_SHA1_80` in your VoIP application, you have to go for
`./configure --enable-openssl`
otherwise, just AES-256 and AES-128 work. As a side-effect, you get AES-NI and AES-GCM.

Even with the current source code, AES-192 works only between VoIP applications which use the same library (for example locally on the same computer). This is because of one single `#if` clause in `srtp/srtp.c`. However, this pull request takes another approach and replaces all (deprecated) `AES_xxx_ICM` with the new `AES_ICM` from commit a5754a6. Those changes avoid this issue and enable AES-192 as a side-effect. A subsequent change could do the same for GCM and replace all `AES_xxx_GCM` with a new symbol called `AES_GCM`. Then, a subsequent change could remove `srtp_cipher_t->algorithm`and replace that with `srtp_cipher_t->type->id` which then matches `srtp_crypto_policy_t->cipher_type`. I did not squash the three commits (of this possible series of changes), hopefully to make the overall pull request easier to understand.

This is approach/alternative A to solve this issue. Because I do not know how to bundle one pull request for different branches, I started with branch 1.5.x. Instead, if you need the pull request for master or additionally a request for the master branch, please, say so.

Currently, this pull request is in conflict with the new feature ‘RTP header-extension encryption’ ce37ef6 on the 2.x branch. If this pull request is considered for inclusion, I think about that conflict.
