### PR TITLE
convenience methods for all crypto suites

### DIFF
--- a/include/srtp.h
+++ b/include/srtp.h
@@ -617,6 +617,97 @@ crypto_policy_set_null_cipher_hmac_sha1_80(crypto_policy_t *p);
 
 
 /**
+ * @brief crypto_policy_set_aes_cm_192_hmac_sha1_80() sets a crypto
+ * policy structure to a encryption and authentication policy using AES-192
+ * for RTP protection.
+ *
+ * @param p is a pointer to the policy structure to be set
+ *
+ * The function call crypto_policy_set_aes_cm_192_hmac_sha1_80(&p)
+ * sets the crypto_policy_t at location p to use policy
+ * AES_CM_192_HMAC_SHA1_80 as defined in
+ * draft-ietf-avt-srtp-big-aes-03.txt.  This policy uses AES-192
+ * Counter Mode encryption and HMAC-SHA1 authentication, with an 80 bit
+ * authentication tag.
+ *
+ * This function is a convenience that helps to avoid dealing directly
+ * with the policy data structure.  You are encouraged to initialize
+ * policy elements with this function call.  Doing so may allow your
+ * code to be forward compatible with later versions of libSRTP that
+ * include more elements in the crypto_policy_t datatype.
+ *
+ * @return void.
+ *
+ */
+
+void crypto_policy_set_aes_cm_192_hmac_sha1_80(crypto_policy_t *p);
+
+
+/**
+ * @brief crypto_policy_set_aes_cm_192_hmac_sha1_32() sets a crypto
+ * policy structure to a short-authentication tag policy using AES-192
+ * encryption.
+ *
+ * @param p is a pointer to the policy structure to be set
+ *
+ * The function call crypto_policy_set_aes_cm_192_hmac_sha1_32(&p)
+ * sets the crypto_policy_t at location p to use policy
+ * AES_CM_192_HMAC_SHA1_32 as defined in
+ * draft-ietf-avt-srtp-big-aes-03.txt.  This policy uses AES-192
+ * Counter Mode encryption and HMAC-SHA1 authentication, with an
+ * authentication tag that is only 32 bits long.  This length is
+ * considered adequate only for protecting audio and video media that
+ * use a stateless playback function.  See Section 7.5 of RFC 3711
+ * (http://www.ietf.org/rfc/rfc3711.txt).
+ *
+ * This function is a convenience that helps to avoid dealing directly
+ * with the policy data structure.  You are encouraged to initialize
+ * policy elements with this function call.  Doing so may allow your
+ * code to be forward compatible with later versions of libSRTP that
+ * include more elements in the crypto_policy_t datatype.
+ *
+ * @warning This crypto policy is intended for use in SRTP, but not in
+ * SRTCP.  It is recommended that a policy that uses longer
+ * authentication tags be used for SRTCP.  See Section 7.5 of RFC 3711
+ * (http://www.ietf.org/rfc/rfc3711.txt).
+ *
+ * @return void.
+ *
+ */
+
+void
+crypto_policy_set_aes_cm_192_hmac_sha1_32(crypto_policy_t *p);
+
+/**
+ * @brief crypto_policy_set_aes_cm_192_null_auth() sets a crypto
+ * policy structure to an encryption-only policy
+ *
+ * @param p is a pointer to the policy structure to be set
+ *
+ * The function call crypto_policy_set_aes_cm_192_null_auth(&p) sets
+ * the crypto_policy_t at location p to use the SRTP default cipher
+ * (AES-192 Counter Mode), but to use no authentication method.  This
+ * policy is NOT RECOMMENDED unless it is unavoidable; see Section 7.5
+ * of RFC 3711 (http://www.ietf.org/rfc/rfc3711.txt).
+ *
+ * This function is a convenience that helps to avoid dealing directly
+ * with the policy data structure.  You are encouraged to initialize
+ * policy elements with this function call.  Doing so may allow your
+ * code to be forward compatible with later versions of libSRTP that
+ * include more elements in the crypto_policy_t datatype.
+ *
+ * @warning This policy is NOT RECOMMENDED for SRTP unless it is
+ * unavoidable, and it is NOT RECOMMENDED at all for SRTCP; see
+ * Section 7.5 of RFC 3711 (http://www.ietf.org/rfc/rfc3711.txt).
+ *
+ * @return void.
+ *
+ */
+void
+crypto_policy_set_aes_cm_192_null_auth(crypto_policy_t *p);
+
+
+/**
  * @brief crypto_policy_set_aes_cm_256_hmac_sha1_80() sets a crypto
  * policy structure to a encryption and authentication policy using AES-256 
  * for RTP protection.

--- a/srtp/srtp.c
+++ b/srtp/srtp.c
@@ -2094,6 +2094,55 @@ crypto_policy_set_null_cipher_hmac_sha1_80(crypto_policy_t *p) {
   
 }
 
+/* AES-192 requires --enable-openssl, see crypto/cipher/aes.c:aes_expand_encryption_key */
+/* furthermore, OpenSSL forks like BoringSSL do not support AES-192 either */
+#if defined(OPENSSL) && !defined(SRTP_NO_AES192)
+void
+crypto_policy_set_aes_cm_192_hmac_sha1_80(crypto_policy_t *p) {
+
+  /*
+   * corresponds to RFC 6188
+   */
+
+  p->cipher_type     = AES_ICM;
+  p->cipher_key_len  = 38;
+  p->auth_type       = HMAC_SHA1;
+  p->auth_key_len    = 20;
+  p->auth_tag_len    = 10;
+  p->sec_serv        = sec_serv_conf_and_auth;
+}
+
+void
+crypto_policy_set_aes_cm_192_hmac_sha1_32(crypto_policy_t *p) {
+
+  /*
+   * corresponds to RFC 6188
+   *
+   * note that this crypto policy is intended for SRTP, but not SRTCP
+   */
+
+  p->cipher_type     = AES_ICM;
+  p->cipher_key_len  = 38;
+  p->auth_type       = HMAC_SHA1;
+  p->auth_key_len    = 20;
+  p->auth_tag_len    = 4;
+  p->sec_serv        = sec_serv_conf_and_auth;
+}
+
+void
+crypto_policy_set_aes_cm_192_null_auth (crypto_policy_t *p)
+{
+  /*
+   * AES-192 with no authentication.
+   */
+  p->cipher_type     = AES_ICM;
+  p->cipher_key_len  = 38;
+  p->auth_type       = NULL_AUTH;
+  p->auth_key_len    = 0;
+  p->auth_tag_len    = 0;
+  p->sec_serv        = sec_serv_conf;
+}
+#endif
 
 void
 crypto_policy_set_aes_cm_256_hmac_sha1_80(crypto_policy_t *p) {


### PR DESCRIPTION
- depends on the inclusion of the request #170 or request #171
- adds the convenience methods for last remaining crypto suite AES-192 (ICM), for the sake of symmetry

Without those methods, downstream projects have to deal with the internals of `srtp_crypto_policy_t`. The `#ifdefs` are chosen to allow downstream projects to detect AES-192 capability plus (if added with #170 or #171) whether `-lsrtp` is a version of the library which allows a working AES-192 crypto suite.

I am not sure, whether I met the current coding style guides. Furthermore, the comments might need an update to link to the latest RFC rather than its draft. If I should update/change anything, please, say so. Please, consider this change for inclusion because I find it quite handy when it comes to detect the features of libSRTP automatically.
