### PR TITLE
avoid error 'possibly undefined macro: AM_PROG_AR'

### DIFF
--- a/configure.in
+++ b/configure.in
@@ -8,7 +8,7 @@ if test -z "$CFLAGS"; then
 fi
 
 dnl Checks for programs.
-AM_PROG_AR
+m4_ifdef([AM_PROG_AR], [AM_PROG_AR])
 AC_PROG_RANLIB
 AC_PROG_CC
 AC_PROG_INSTALL


### PR DESCRIPTION
on `autoconf --warnings=all,no-cross`