### PR TITLE
fixed ./configure --enable-syslog

### DIFF
--- a/config_in.h
+++ b/config_in.h
@@ -21,6 +21,9 @@
 /* Define to use logging to stdout. */
 #undef ERR_REPORTING_STDOUT
 
+/* Define to use syslog logging. */
+#undef ERR_REPORTING_SYSLOG
+
 /* Define this to use ISMAcryp code. */
 #undef GENERIC_AESICM
 
@@ -173,9 +176,6 @@
 
 /* Write errors to this file */
 #undef USE_ERR_REPORTING_FILE
-
-/* Define to use syslog logging. */
-#undef USE_SYSLOG
 
 /* Define WORDS_BIGENDIAN to 1 if your processor stores words with the most
    significant byte first (like Motorola and SPARC, unlike Intel). */

--- a/configure
+++ b/configure
@@ -5897,7 +5897,7 @@ fi
 
 if test "$enable_syslog" = "yes"; then
 
-$as_echo "#define USE_SYSLOG 1" >>confdefs.h
+$as_echo "#define ERR_REPORTING_SYSLOG 1" >>confdefs.h
 
 fi
 { $as_echo "$as_me:${as_lineno-$LINENO}: result: $enable_syslog" >&5

--- a/configure.in
+++ b/configure.in
@@ -196,7 +196,7 @@ AC_ARG_ENABLE(syslog,
   [AS_HELP_STRING([--enable-syslog], [use syslog for error reporting])],
   [], enable_syslog=no)
 if test "$enable_syslog" = "yes"; then
-   AC_DEFINE(USE_SYSLOG, 1, [Define to use syslog logging.])
+   AC_DEFINE(ERR_REPORTING_SYSLOG, 1, [Define to use syslog logging.])
 fi
 AC_MSG_RESULT($enable_syslog)
 

--- a/crypto/kernel/err.c
+++ b/crypto/kernel/err.c
@@ -101,13 +101,13 @@ err_report(int priority, const char *format, ...) {
 
   if (priority <= err_level) {
 
-    va_start(args, format);
     if (err_file != NULL) {
+      va_start(args, format);
       vfprintf(err_file, format, args);
-	  /*      fprintf(err_file, "\n"); */
+      va_end(args);
     }
 #ifdef ERR_REPORTING_SYSLOG
-    if (1) { /* FIXME: Make this a runtime option. */
+    {
       int syslogpri;
 
       switch (priority) {
@@ -139,9 +139,11 @@ err_report(int priority, const char *format, ...) {
 	break;
       }
 
-      vsyslog(syslogpri, format, args);
+      va_start(args, format);
+      vsyslog(LOG_MAKEPRI(LOG_SYSLOG, syslogpri), format, args);
+      va_end(args);
+    }
 #endif
-    va_end(args);
   }
 }
 #endif /* SRTP_KERNEL_LINUX */	


### PR DESCRIPTION
Yes, I know, this feature got removed with commit f063b90 in branch `2_0_x_throttle` and `master`. However, it was not removed in branch `1_5_x_throttle`. And released things should work. Furthermore, I needed this feature to debug an internal issue within libSRTP, while being compiled as a shared library. I could not use the API for this. I did not figure out, how logging to `stdout` or `/dev/console` works with a shared library. If this pull request gets rejected, please, someone explains how to use those alternatives instead.

Anyway, now logging to `LOG_SYSLOG` works when enabled via the configure script. Tested on Ubuntu 16.04 LTS. Please, consider this change for inclusion at least into the branch `1_5_x_throttle`. Additionally, please, consider to reintroduce this feature in the other branches again – undo commit f063b90.

resolves #48
