### PR TITLE
AES-GCM: Key Derivation broken because of shorter Master Salt

### DIFF
--- a/srtp/srtp.c
+++ b/srtp/srtp.c
@@ -539,12 +539,15 @@ srtp_stream_init_keys(srtp_stream_ctx_t *srtp, const void *key) {
   debug_print(mod_srtp, "rtp salt len: %d", rtp_salt_len);
 
   /* 
-   * Make sure the key given to us is 'zero' appended.  GCM
+   * Make sure the key given to us is 'zero' prepended. GCM
    * mode uses a shorter master SALT (96 bits), but still relies on 
    * the legacy CTR mode KDF, which uses a 112 bit master SALT.
    */
   memset(tmp_key, 0x0, MAX_SRTP_KEY_LEN);
-  memcpy(tmp_key, key, (rtp_base_key_len + rtp_salt_len));
+  memcpy(tmp_key, key, rtp_base_key_len);
+  memcpy(tmp_key + rtp_base_key_len + 14 - rtp_salt_len,
+         key + rtp_base_key_len,
+         rtp_salt_len);
 
   /* initialize KDF state     */
   stat = srtp_kdf_init(&kdf, AES_ICM, (const uint8_t *)tmp_key, kdf_keylen);


### PR DESCRIPTION
With SRTP, the key exchanged with the remote party is called the Master key, because six Session keys are derived from that Master key. For this, a Key-Derivation Function (KDF) is defined so both parties derive the same Session keys from that Master key. The KDF must be the same, otherwise different keys are used and the remote party would not be able to decrypt the encrypted RTP data anymore.

Furthermore, that Master Key is [salted](https://en.wikipedia.org/wiki/Salt_%28cryptography%29#Benefits) and that part is called Master Salt. Both the Master Key and Master Salt are used in KDF. In [RFC 3711](https://tools.ietf.org/html/rfc3711#section-4.3) from 2006, the salt was 112 bits = 14 octets long. [RFC 6188](https://tools.ietf.org/html/rfc6188#section-7.2) contains more details about this, for example test cases in its section 7.2. With [RFC 7714](https://tools.ietf.org/html/rfc7714#section-11), AES-GCM was introduced which uses the same key length but a two byte shorter salt (12 octets = 96 bits). Nevertheless, RFC 7714 mandates to re-use the same KDF as before.

In commit Cisco/libSRTP@8719f95, the decision was made to pad the Master Salt with two zero bytes. Actually in the source code of libSRTP, the concatenation of the Master Key and Master Salt was simply forwarded to KDF. This led to a padding of zeros not at the start (left) but at the end (right) of the Master Salt.

This issue was found via [Acrobits Groundwire](https://www.acrobits.net/products/retail/groundwire), which offers AES-GCM since April 2016. In the Apple iOS variant, you enable AES-GCM via Settings → Preferences → Security → (SRTP) SDES. According to the Acrobits support, they do not use libSRTP for this. My personal tests revealed, their implementation aligns the Master Salt to the right, see issue #179 for more details (found independently).

I expect this pull request be closed, because merging this request would make AES-GCM incompatible with existing libSRTP implementations. Although I am not aware of that many, yet. However, the purpose of this pull request was to document this issue. The attached commit (simply add `.patch` to the URL to get a diff) allows to test existing implementations for this issue. Reading through the related RFCs (7714, 6188, and 3711), yet, I was not able to find a single statement related to this. It looks like, whether to move right or left is undefined:
- RFC 6188 test cases show a right-alignment of `x`. However, there, `x` was known in size (112 bits).
- RFC 3711 mentions a right-alignment for `x`. However, again, this was not about the Master Salt but about the `key_id`.
- In RFC 7714, 6188, or 3711, I found nothing which got left-aligned – all I found was right-alignment. Furthermore, when one day, a larger salt is introduced, should AES-ICM be padded on the right as well?

Although I found no argument for left-alignment – as it is done by libSRTP – my current position is, that this is undefined in the RFCs itself. The author of those RFCs @DavidMcGrew, or the author of that commit @JFigus, or anyone else who sees a statement which justifies the left-aligment, please, comment. Before I raise an issue in the IETF Audio/Video Transport Core Maintenance Working Group ([AVTCore](https://tools.ietf.org/wg/avtcore/)), I would like to clarify this issue here in libSRTP. Because I could bet, I missed the sentence which clarifies this.

fixes #46
resolves #179, found independently
