### PR TITLE
Replace octet_string_is_eq with a constant-time implementation

### DIFF
--- a/crypto/include/datatypes.h
+++ b/crypto/include/datatypes.h
@@ -339,8 +339,10 @@ v128_set_bit_to(v128_t *x, int i, int y);
 #endif /* DATATYPES_USE_MACROS */
 
 /*
- * octet_string_is_eq(a,b, len) returns 1 if the length len strings a
- * and b are not equal, returns 0 otherwise
+ * octet_string_is_eq(a, b, len) returns 1 if the length len strings a
+ * and b are not equal. It returns 0 otherwise. The running time of the
+ * comparison depends only on len, making this safe to use for (e.g.)
+ * verifying authentication tags.
  */
 
 int

--- a/crypto/math/datatypes.c
+++ b/crypto/math/datatypes.c
@@ -440,14 +440,21 @@ bitvector_left_shift(bitvector_t *x, int shift) {
 
 }
 
-
 int
 octet_string_is_eq(uint8_t *a, uint8_t *b, int len) {
   uint8_t *end = b + len;
+  uint8_t accumulator = 0;
+
+  /*
+   * We use this somewhat obscure implementation to try to ensure the running
+   * time only depends on len, even accounting for compiler optimizations.
+   * The accumulator ends up zero iff the strings are equal.
+   */
   while (b < end)
-    if (*a++ != *b++)
-      return 1;
-  return 0;
+    accumulator |= (*a++ ^ *b++);
+
+  /* Return 1 if *not* equal. */
+  return accumulator != 0;
 }
 
 void


### PR DESCRIPTION
This function is used to check authentication tags in srtp_unprotect.
The current early-exit implementation might offer a timing sidechannel,
enabling attackers to brute-force a correct HMAC to a forged message.

Such attacks shouldn't be possible if replay protection is enabled, but
this is nonetheless good defense in depth.

The implementation is similar to CRYPTO_memcmp from OpenSSL/BoringSSL.