### PR TITLE
Add missing __cplusplus header guards.

### DIFF
--- a/crypto/include/aes.h
+++ b/crypto/include/aes.h
@@ -49,6 +49,10 @@
 #include "datatypes.h"
 #include "err.h"
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 /* aes internals */
 
 typedef struct {
@@ -69,5 +73,9 @@ srtp_err_status_t srtp_aes_expand_decryption_key(
 void srtp_aes_encrypt(v128_t *plaintext, const srtp_aes_expanded_key_t *exp_key);
 
 void srtp_aes_decrypt(v128_t *plaintext, const srtp_aes_expanded_key_t *exp_key);
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif /* _AES_H */

--- a/crypto/include/alloc.h
+++ b/crypto/include/alloc.h
@@ -48,8 +48,16 @@
 
 #include "datatypes.h"
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 void * srtp_crypto_alloc(size_t size);
 
 void srtp_crypto_free(void *ptr);
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif /* CRYPTO_ALLOC_H */

--- a/crypto/include/auth.h
+++ b/crypto/include/auth.h
@@ -51,6 +51,10 @@
 #include "err.h"                /* error codes    */
 #include "crypto_types.h"       /* for values of auth_type_id_t */
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 typedef const struct srtp_auth_type_t *auth_type_pointer;
 typedef struct srtp_auth_t      *auth_pointer_t;
 
@@ -148,5 +152,9 @@ srtp_err_status_t srtp_auth_type_self_test(const srtp_auth_type_t *at);
  */
 srtp_err_status_t srtp_auth_type_test(const srtp_auth_type_t *at, 
 	const srtp_auth_test_case_t *test_data);
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif /* AUTH_H */

--- a/crypto/include/cipher.h
+++ b/crypto/include/cipher.h
@@ -53,6 +53,10 @@
 #include "crypto_types.h"       /* for values of cipher_type_id_t */
 
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 /*
  * cipher_direction_t defines a particular cipher operation.
  *
@@ -209,5 +213,9 @@ srtp_err_status_t srtp_cipher_encrypt(srtp_cipher_t *c, uint8_t *buffer, uint32_
 srtp_err_status_t srtp_cipher_decrypt(srtp_cipher_t *c, uint8_t *buffer, uint32_t *num_octets_to_output); 
 srtp_err_status_t srtp_cipher_get_tag(srtp_cipher_t *c, uint8_t *buffer, uint32_t *tag_len);
 srtp_err_status_t srtp_cipher_set_aad(srtp_cipher_t *c, const uint8_t *aad, uint32_t aad_len);
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif /* CIPHER_H */

--- a/crypto/include/crypto_kernel.h
+++ b/crypto/include/crypto_kernel.h
@@ -52,6 +52,10 @@
 #include "crypto_types.h"
 #include "key.h"
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 /*
  * crypto_kernel_state_t defines the possible states:
  *
@@ -218,5 +222,9 @@ srtp_err_status_t srtp_crypto_kernel_alloc_auth(srtp_auth_type_id_t id, auth_poi
  * returns srtp_err_status_ok on success, srtp_err_status_fail otherwise
  */
 srtp_err_status_t srtp_crypto_kernel_set_debug_module(char *mod_name, int v);
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif /* CRYPTO_KERNEL */

--- a/crypto/include/crypto_math.h
+++ b/crypto/include/crypto_math.h
@@ -47,6 +47,10 @@
 
 #include "datatypes.h"
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 unsigned char
 v32_weight(v32_t a);
 
@@ -232,6 +236,10 @@ octet_string_is_eq(uint8_t *a, uint8_t *b, int len);
 void
 octet_string_set_to_zero(uint8_t *s, int len);
 
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif /* MATH_H */
 

--- a/crypto/include/datatypes.h
+++ b/crypto/include/datatypes.h
@@ -61,6 +61,10 @@
 # include <winsock2.h>
 #endif
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 
 /* if DATATYPES_USE_MACROS is defined, then little functions are macros */
 #define DATATYPES_USE_MACROS  
@@ -475,5 +479,9 @@ bitvector_left_shift(bitvector_t *x, int index);
 
 char *
 bitvector_bit_string(bitvector_t *x, char* buf, int len);
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif /* _DATATYPES_H */

--- a/crypto/include/err.h
+++ b/crypto/include/err.h
@@ -50,6 +50,10 @@
 #include <stdarg.h>
 #include "srtp.h"
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 /**
  * @defgroup Error Error Codes
  *
@@ -129,6 +133,10 @@ typedef struct {
 
 #define debug_off(mod)
 
+#endif
+
+#ifdef __cplusplus
+}
 #endif
 
 #endif /* ERR_H */

--- a/crypto/include/integers.h
+++ b/crypto/include/integers.h
@@ -68,6 +68,10 @@
 # include <machine/types.h>
 #endif
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 /* Can we do 64 bit integers? */
 #if !defined(HAVE_UINT64_T)
 # if SIZEOF_UNSIGNED_LONG == 8
@@ -134,6 +138,10 @@ extern uint32_t low32(uint64_t value);
 #else
 #define PUT_32(addr,value) *(((uint32_t *) (addr)) = (value)
 #define GET_32(addr) (*(((uint32_t *) (addr)))
+#endif
+
+#ifdef __cplusplus
+}
 #endif
 
 #endif /* INTEGERS_H */

--- a/crypto/include/key.h
+++ b/crypto/include/key.h
@@ -48,6 +48,10 @@
 #include "rdbx.h"   /* for srtp_xtd_seq_num_t */
 #include "err.h"
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 typedef struct srtp_key_limit_ctx_t *srtp_key_limit_t;
 
 typedef enum {
@@ -74,5 +78,9 @@ typedef struct srtp_key_limit_ctx_t {
     srtp_xtd_seq_num_t num_left;
     srtp_key_state_t state;
 } srtp_key_limit_ctx_t;
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif /* KEY_H */

--- a/crypto/include/null_auth.h
+++ b/crypto/include/null_auth.h
@@ -47,6 +47,10 @@
 
 #include "auth.h"
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 typedef struct {
     char foo;
 } srtp_null_auth_ctx_t;
@@ -60,6 +64,10 @@ srtp_err_status_t srtp_null_auth_init(srtp_null_auth_ctx_t *state, const uint8_t
 
 srtp_err_status_t srtp_null_auth_compute(srtp_null_auth_ctx_t *state, uint8_t *message, int msg_octets, int tag_len, uint8_t *result);
 
+#endif
+
+#ifdef __cplusplus
+}
 #endif
 
 #endif /* NULL_AUTH_H */

--- a/crypto/include/rdb.h
+++ b/crypto/include/rdb.h
@@ -51,6 +51,10 @@
 #include "datatypes.h"        /* for v128_t       */
 #include "err.h"              /* for srtp_err_status_t */
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 /*
  * if the ith least significant bit is one, then the packet index
  * window_end-i is in the database
@@ -117,5 +121,9 @@ srtp_err_status_t srtp_rdb_increment(srtp_rdb_t *rdb);
  */
 uint32_t srtp_rdb_get_value(const srtp_rdb_t *rdb);
 
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif /* REPLAY_DB_H */

--- a/crypto/include/rdbx.h
+++ b/crypto/include/rdbx.h
@@ -50,6 +50,10 @@
 #include "datatypes.h"
 #include "err.h"
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 /* #define ROC_TEST */
 
 #ifndef ROC_TEST
@@ -182,13 +186,8 @@ void srtp_index_advance(srtp_xtd_seq_num_t *pi, srtp_sequence_number_t s);
 int srtp_index_guess(const srtp_xtd_seq_num_t *local, srtp_xtd_seq_num_t *guess, srtp_sequence_number_t s);
 
 
+#ifdef __cplusplus
+}
+#endif
+
 #endif /* RDBX_H */
-
-
-
-
-
-
-
-
-

--- a/crypto/include/sha1.h
+++ b/crypto/include/sha1.h
@@ -55,6 +55,15 @@
 #ifdef OPENSSL
 #include <openssl/evp.h>
 #include <stdint.h>
+#else
+#include "datatypes.h"
+#endif
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#ifdef OPENSSL
 
 typedef EVP_MD_CTX srtp_sha1_ctx_t;
 
@@ -90,7 +99,6 @@ static inline void srtp_sha1_final (srtp_sha1_ctx_t *ctx, uint32_t *output)
     EVP_DigestFinal(ctx, (unsigned char*)output, &len);
 }
 #else
-#include "datatypes.h"
 
 typedef struct {
     uint32_t H[5];            /* state vector                    */
@@ -133,5 +141,9 @@ void srtp_sha1_final(srtp_sha1_ctx_t * ctx, uint32_t output[5]);
 void srtp_sha1_core(const uint32_t M[16], uint32_t hash_value[5]);
 
 #endif /* else OPENSSL */
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif /* SHA1_H */

--- a/crypto/include/stat.h
+++ b/crypto/include/stat.h
@@ -50,10 +50,18 @@
 #include "datatypes.h"       /* for uint8_t                       */
 #include "err.h"             /* for srtp_err_status_t             */
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 srtp_err_status_t stat_test_monobit(uint8_t *data);
 
 srtp_err_status_t stat_test_poker(uint8_t *data);
 
 srtp_err_status_t stat_test_runs(uint8_t *data);
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif /* STAT_H */

--- a/include/ekt.h
+++ b/include/ekt.h
@@ -62,11 +62,11 @@
 #ifndef EKT_H
 #define EKT_H
 
+#include "srtp_priv.h"
+
 #ifdef __cplusplus
 extern "C" {
 #endif
-
-#include "srtp_priv.h"
 
 #define SRTP_EKT_CIPHER_DEFAULT           1
 #define SRTP_EKT_CIPHER_AES_128_ECB       1

--- a/include/getopt_s.h
+++ b/include/getopt_s.h
@@ -45,6 +45,10 @@
 #ifndef GETOPT_S_H
 #define GETOPT_S_H
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 /* 
  * getopt_s(), optarg_s, and optind_s are small, locally defined
  * versions of the POSIX standard getopt() interface.
@@ -56,5 +60,9 @@ getopt_s(int argc, char * const argv[], const char *optstring);
 extern char *optarg_s;    /* defined in getopt.c */
 
 extern int optind_s;      /* defined in getopt.c */
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif /* GETOPT_S_H */

--- a/include/rtp.h
+++ b/include/rtp.h
@@ -62,6 +62,11 @@
 
 //#include "srtp_priv.h"
 #include "srtp.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 /*
  * RTP_HEADER_LEN indicates the size of an RTP header
  */
@@ -158,5 +163,8 @@ void
 rtp_receiver_dealloc(rtp_receiver_t rtp_ctx);
 
 
+#ifdef __cplusplus
+}
+#endif
 
 #endif /* RTP_H */

--- a/include/srtp.h
+++ b/include/srtp.h
@@ -46,11 +46,11 @@
 #ifndef SRTP_H
 #define SRTP_H
 
+#include <stdint.h>
+
 #ifdef __cplusplus
 extern "C" {
 #endif
-
-#include <stdint.h>
 
 /**
  * @defgroup SRTP Secure RTP

--- a/include/srtp_priv.h
+++ b/include/srtp_priv.h
@@ -56,6 +56,10 @@
 #include "key.h"
 #include "crypto_kernel.h"
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 #define SRTP_VER_STRING	    PACKAGE_STRING
 #define SRTP_VERSION        PACKAGE_VERSION
 
@@ -153,5 +157,8 @@ typedef struct srtp_ctx_t_ {
       srtp_event_handler(&data);                    \
 }   
 
+#ifdef __cplusplus
+}
+#endif
 
 #endif /* SRTP_PRIV_H */

--- a/include/ut_sim.h
+++ b/include/ut_sim.h
@@ -51,6 +51,10 @@
 
 #include "integers.h"  /* for uint32_t */
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 #define UT_BUF 160      /* maximum amount of packet reorder */
 
 typedef struct {
@@ -76,5 +80,8 @@ ut_init(ut_connection *utc);
 uint32_t
 ut_next_index(ut_connection *utc);
 
+#ifdef __cplusplus
+}
+#endif
 
 #endif /* UT_SIM_H */


### PR DESCRIPTION
Avoid requiring consumers to wrap headers in extern "C". See, e.g.,
https://chromium.googlesource.com/external/webrtc/+/43e15bb9f01476114cf85be8a47922df2fd7dcf5/webrtc/pc/externalhmac.cc#17