### PR TITLE
Update sha1_driver.c

### DIFF
--- a/crypto/test/sha1_driver.c
+++ b/crypto/test/sha1_driver.c
@@ -79,12 +79,16 @@ hash_test_case_add(hash_test_case_t **list_ptr,
   unsigned tmp_len;
 
   test_case = malloc(sizeof(hash_test_case_t));
-  if (test_case == NULL)
-    return srtp_err_status_alloc_fail;
-  
-  tmp_len = hex_string_to_octet_string((char *)test_case->data, hex_data, data_len*2);
-  if (tmp_len != data_len*2)
+  if (tmp_len != data_len*2) {
+    free(test_case);
     return srtp_err_status_parse_err;
+  }
+
+  tmp_len = hex_string_to_octet_string((char *)test_case->hash, hex_hash, hash_len*2);
+  if (tmp_len != hash_len*2) {
+    free(test_case);
+    return srtp_err_status_parse_err;
+  }
 
   tmp_len = hex_string_to_octet_string((char *)test_case->hash, hex_hash, hash_len*2);
   if (tmp_len != hash_len*2)

--- a/crypto/test/sha1_driver.c
+++ b/crypto/test/sha1_driver.c
@@ -79,6 +79,10 @@ hash_test_case_add(hash_test_case_t **list_ptr,
   unsigned tmp_len;
 
   test_case = malloc(sizeof(hash_test_case_t));
+  if (test_case == NULL)
+    return srtp_err_status_alloc_fail;
+  
+  tmp_len = hex_string_to_octet_string((char *)test_case->data, hex_data, data_len*2);
   if (tmp_len != data_len*2) {
     free(test_case);
     return srtp_err_status_parse_err;
@@ -89,10 +93,6 @@ hash_test_case_add(hash_test_case_t **list_ptr,
     free(test_case);
     return srtp_err_status_parse_err;
   }
-
-  tmp_len = hex_string_to_octet_string((char *)test_case->hash, hex_hash, hash_len*2);
-  if (tmp_len != hash_len*2)
-    return srtp_err_status_parse_err;
 
   test_case->data_len = data_len;
   test_case->hash_len = hash_len;


### PR DESCRIPTION
Our first patch was technically incorrect because it only patched one, or half, of the errors found by cppcheck. And instead of patching the other, second error, we inadvertently inserted a line of code that called `free()` on a NULL pointer. However, we believe it shouldn't have caused the test suites to fail because if `test_case` is NULL, then by definition no action occurs. We just didn't completely mitigate the risk.

Without seeing the test output it was difficult for us to debug this. Furthermore, we don't believe we have access to run the test suite locally. @paulej do you have any more insight that could lead us to find the cause of the crash. We'd like to rule out the possibility that it was our first patch that caused the test suites to fail.

For what its worth, we patched the correct two errors in this PR. And sorry we didn't get it right the first time 😁
