### PR TITLE
Make replace_cipher and replace_auth public again

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -244,6 +244,9 @@ install:
 	cp $(srcdir)/include/srtp.h $(DESTDIR)$(includedir)/srtp2  
 	cp $(srcdir)/include/ekt.h $(DESTDIR)$(includedir)/srtp2  
 	cp $(srcdir)/include/rtp.h $(DESTDIR)$(includedir)/srtp2  
+	cp $(srcdir)/crypto/include/cipher.h $(DESTDIR)$(includedir)/srtp2
+	cp $(srcdir)/crypto/include/auth.h $(DESTDIR)$(includedir)/srtp2
+	cp $(srcdir)/crypto/include/crypto_types.h $(DESTDIR)$(includedir)/srtp2
 	if [ -f libsrtp2.a ]; then cp libsrtp2.a $(DESTDIR)$(libdir)/; fi
 	if [ -f libsrtp2.dll.a ]; then cp libsrtp2.dll.a $(DESTDIR)$(libdir)/; fi
 	if [ -f libsrtp2.$(SHAREDLIBSUFFIX) ]; then \

--- a/crypto/cipher/aes_gcm_ossl.c
+++ b/crypto/cipher/aes_gcm_ossl.c
@@ -175,7 +175,7 @@ static srtp_err_status_t srtp_aes_gcm_openssl_dealloc (srtp_cipher_t *c)
 static srtp_err_status_t srtp_aes_gcm_openssl_context_init (void* cv, const uint8_t *key)
 {
     srtp_aes_gcm_ctx_t *c = (srtp_aes_gcm_ctx_t *)cv;
-    c->dir = direction_any;
+    c->dir = srtp_direction_any;
 
     /* copy key to be used later when CiscoSSL crypto context is created */
     v128_copy_octet_string((v128_t*)&c->key, key);
@@ -204,7 +204,7 @@ static srtp_err_status_t srtp_aes_gcm_openssl_set_iv (void *cv, uint8_t *iv, srt
     srtp_aes_gcm_ctx_t *c = (srtp_aes_gcm_ctx_t *)cv;
     const EVP_CIPHER *evp;
 
-    if (direction != direction_encrypt && direction != direction_decrypt) {
+    if (direction != srtp_direction_encrypt && direction != srtp_direction_decrypt) {
         return (srtp_err_status_bad_param);
     }
     c->dir = direction;
@@ -224,7 +224,7 @@ static srtp_err_status_t srtp_aes_gcm_openssl_set_iv (void *cv, uint8_t *iv, srt
     }
 
     if (!EVP_CipherInit_ex(&c->ctx, evp, NULL, (const unsigned char*)&c->key.v8,
-                           NULL, (c->dir == direction_encrypt ? 1 : 0))) {
+                           NULL, (c->dir == srtp_direction_encrypt ? 1 : 0))) {
         return (srtp_err_status_init_fail);
     }
 
@@ -289,7 +289,7 @@ static srtp_err_status_t srtp_aes_gcm_openssl_set_aad (void *cv, const uint8_t *
 static srtp_err_status_t srtp_aes_gcm_openssl_encrypt (void *cv, unsigned char *buf, unsigned int *enc_len)
 {
     srtp_aes_gcm_ctx_t *c = (srtp_aes_gcm_ctx_t *)cv;
-    if (c->dir != direction_encrypt && c->dir != direction_decrypt) {
+    if (c->dir != srtp_direction_encrypt && c->dir != srtp_direction_decrypt) {
         return (srtp_err_status_bad_param);
     }
 
@@ -345,7 +345,7 @@ static srtp_err_status_t srtp_aes_gcm_openssl_get_tag (void *cv, uint8_t *buf, u
 static srtp_err_status_t srtp_aes_gcm_openssl_decrypt (void *cv, unsigned char *buf, unsigned int *enc_len)
 {
     srtp_aes_gcm_ctx_t *c = (srtp_aes_gcm_ctx_t *)cv;
-    if (c->dir != direction_encrypt && c->dir != direction_decrypt) {
+    if (c->dir != srtp_direction_encrypt && c->dir != srtp_direction_decrypt) {
         return (srtp_err_status_bad_param);
     }
 

--- a/crypto/cipher/aes_gcm_ossl.c
+++ b/crypto/cipher/aes_gcm_ossl.c
@@ -538,7 +538,6 @@ const srtp_cipher_type_t srtp_aes_gcm_128_openssl = {
     (cipher_get_tag_func_t)srtp_aes_gcm_openssl_get_tag,
     (const char*)srtp_aes_gcm_128_openssl_description,
     (const srtp_cipher_test_case_t*)&srtp_aes_gcm_test_case_0,
-    (srtp_debug_module_t*)&srtp_mod_aes_gcm,
     (srtp_cipher_type_id_t)SRTP_AES_128_GCM
 };
 
@@ -556,7 +555,6 @@ const srtp_cipher_type_t srtp_aes_gcm_256_openssl = {
     (cipher_get_tag_func_t)srtp_aes_gcm_openssl_get_tag,
     (const char*)srtp_aes_gcm_256_openssl_description,
     (const srtp_cipher_test_case_t*)&srtp_aes_gcm_test_case_1,
-    (srtp_debug_module_t*)&srtp_mod_aes_gcm,
     (srtp_cipher_type_id_t)SRTP_AES_256_GCM
 };
 

--- a/crypto/cipher/aes_gcm_ossl.c
+++ b/crypto/cipher/aes_gcm_ossl.c
@@ -172,8 +172,9 @@ static srtp_err_status_t srtp_aes_gcm_openssl_dealloc (srtp_cipher_t *c)
  *
  * the key is the secret key
  */
-static srtp_err_status_t srtp_aes_gcm_openssl_context_init (srtp_aes_gcm_ctx_t *c, const uint8_t *key)
+static srtp_err_status_t srtp_aes_gcm_openssl_context_init (void* cv, const uint8_t *key)
 {
+    srtp_aes_gcm_ctx_t *c = (srtp_aes_gcm_ctx_t *)cv;
     c->dir = direction_any;
 
     /* copy key to be used later when CiscoSSL crypto context is created */
@@ -198,8 +199,9 @@ static srtp_err_status_t srtp_aes_gcm_openssl_context_init (srtp_aes_gcm_ctx_t *
  * aes_gcm_openssl_set_iv(c, iv) sets the counter value to the exor of iv with
  * the offset
  */
-static srtp_err_status_t srtp_aes_gcm_openssl_set_iv (srtp_aes_gcm_ctx_t *c, uint8_t *iv, int direction)
+static srtp_err_status_t srtp_aes_gcm_openssl_set_iv (void *cv, uint8_t *iv, srtp_cipher_direction_t direction)
 {
+    srtp_aes_gcm_ctx_t *c = (srtp_aes_gcm_ctx_t *)cv;
     const EVP_CIPHER *evp;
 
     if (direction != direction_encrypt && direction != direction_decrypt) {
@@ -248,8 +250,9 @@ static srtp_err_status_t srtp_aes_gcm_openssl_set_iv (srtp_aes_gcm_ctx_t *c, uin
  *	aad	Additional data to process for AEAD cipher suites
  *	aad_len	length of aad buffer
  */
-static srtp_err_status_t srtp_aes_gcm_openssl_set_aad (srtp_aes_gcm_ctx_t *c, const uint8_t *aad, uint32_t aad_len)
+static srtp_err_status_t srtp_aes_gcm_openssl_set_aad (void *cv, const uint8_t *aad, uint32_t aad_len)
 {
+    srtp_aes_gcm_ctx_t *c = (srtp_aes_gcm_ctx_t *)cv;
     int rv;
 
     /*
@@ -283,8 +286,9 @@ static srtp_err_status_t srtp_aes_gcm_openssl_set_aad (srtp_aes_gcm_ctx_t *c, co
  *	buf	data to encrypt
  *	enc_len	length of encrypt buffer
  */
-static srtp_err_status_t srtp_aes_gcm_openssl_encrypt (srtp_aes_gcm_ctx_t *c, unsigned char *buf, unsigned int *enc_len)
+static srtp_err_status_t srtp_aes_gcm_openssl_encrypt (void *cv, unsigned char *buf, unsigned int *enc_len)
 {
+    srtp_aes_gcm_ctx_t *c = (srtp_aes_gcm_ctx_t *)cv;
     if (c->dir != direction_encrypt && c->dir != direction_decrypt) {
         return (srtp_err_status_bad_param);
     }
@@ -308,8 +312,9 @@ static srtp_err_status_t srtp_aes_gcm_openssl_encrypt (srtp_aes_gcm_ctx_t *c, un
  *	buf	data to encrypt
  *	len	length of encrypt buffer
  */
-static srtp_err_status_t srtp_aes_gcm_openssl_get_tag (srtp_aes_gcm_ctx_t *c, uint8_t *buf, uint32_t *len)
+static srtp_err_status_t srtp_aes_gcm_openssl_get_tag (void *cv, uint8_t *buf, uint32_t *len)
 {
+    srtp_aes_gcm_ctx_t *c = (srtp_aes_gcm_ctx_t *)cv;
     /*
      * Calculate the tag
      */
@@ -337,8 +342,9 @@ static srtp_err_status_t srtp_aes_gcm_openssl_get_tag (srtp_aes_gcm_ctx_t *c, ui
  *	buf	data to encrypt
  *	enc_len	length of encrypt buffer
  */
-static srtp_err_status_t srtp_aes_gcm_openssl_decrypt (srtp_aes_gcm_ctx_t *c, unsigned char *buf, unsigned int *enc_len)
+static srtp_err_status_t srtp_aes_gcm_openssl_decrypt (void *cv, unsigned char *buf, unsigned int *enc_len)
 {
+    srtp_aes_gcm_ctx_t *c = (srtp_aes_gcm_ctx_t *)cv;
     if (c->dir != direction_encrypt && c->dir != direction_decrypt) {
         return (srtp_err_status_bad_param);
     }
@@ -529,33 +535,33 @@ static const srtp_cipher_test_case_t srtp_aes_gcm_test_case_1 = {
  * This is the vector function table for this crypto engine.
  */
 const srtp_cipher_type_t srtp_aes_gcm_128_openssl = {
-    (cipher_alloc_func_t)srtp_aes_gcm_openssl_alloc,
-    (cipher_dealloc_func_t)srtp_aes_gcm_openssl_dealloc,
-    (cipher_init_func_t)srtp_aes_gcm_openssl_context_init,
-    (cipher_set_aad_func_t)srtp_aes_gcm_openssl_set_aad,
-    (cipher_encrypt_func_t)srtp_aes_gcm_openssl_encrypt,
-    (cipher_decrypt_func_t)srtp_aes_gcm_openssl_decrypt,
-    (cipher_set_iv_func_t)srtp_aes_gcm_openssl_set_iv,
-    (cipher_get_tag_func_t)srtp_aes_gcm_openssl_get_tag,
-    (const char*)srtp_aes_gcm_128_openssl_description,
-    (const srtp_cipher_test_case_t*)&srtp_aes_gcm_test_case_0,
-    (srtp_cipher_type_id_t)SRTP_AES_128_GCM
+    srtp_aes_gcm_openssl_alloc,
+    srtp_aes_gcm_openssl_dealloc,
+    srtp_aes_gcm_openssl_context_init,
+    srtp_aes_gcm_openssl_set_aad,
+    srtp_aes_gcm_openssl_encrypt,
+    srtp_aes_gcm_openssl_decrypt,
+    srtp_aes_gcm_openssl_set_iv,
+    srtp_aes_gcm_openssl_get_tag,
+    srtp_aes_gcm_128_openssl_description,
+    &srtp_aes_gcm_test_case_0,
+    SRTP_AES_128_GCM
 };
 
 /*
  * This is the vector function table for this crypto engine.
  */
 const srtp_cipher_type_t srtp_aes_gcm_256_openssl = {
-    (cipher_alloc_func_t)srtp_aes_gcm_openssl_alloc,
-    (cipher_dealloc_func_t)srtp_aes_gcm_openssl_dealloc,
-    (cipher_init_func_t)srtp_aes_gcm_openssl_context_init,
-    (cipher_set_aad_func_t)srtp_aes_gcm_openssl_set_aad,
-    (cipher_encrypt_func_t)srtp_aes_gcm_openssl_encrypt,
-    (cipher_decrypt_func_t)srtp_aes_gcm_openssl_decrypt,
-    (cipher_set_iv_func_t)srtp_aes_gcm_openssl_set_iv,
-    (cipher_get_tag_func_t)srtp_aes_gcm_openssl_get_tag,
-    (const char*)srtp_aes_gcm_256_openssl_description,
-    (const srtp_cipher_test_case_t*)&srtp_aes_gcm_test_case_1,
-    (srtp_cipher_type_id_t)SRTP_AES_256_GCM
+    srtp_aes_gcm_openssl_alloc,
+    srtp_aes_gcm_openssl_dealloc,
+    srtp_aes_gcm_openssl_context_init,
+    srtp_aes_gcm_openssl_set_aad,
+    srtp_aes_gcm_openssl_encrypt,
+    srtp_aes_gcm_openssl_decrypt,
+    srtp_aes_gcm_openssl_set_iv,
+    srtp_aes_gcm_openssl_get_tag,
+    srtp_aes_gcm_256_openssl_description,
+    &srtp_aes_gcm_test_case_1,
+    SRTP_AES_256_GCM
 };
 

--- a/crypto/cipher/aes_gcm_ossl.c
+++ b/crypto/cipher/aes_gcm_ossl.c
@@ -52,6 +52,7 @@
 #include "aes_icm_ossl.h"
 #include "aes_gcm_ossl.h"
 #include "alloc.h"
+#include "err.h"                /* for srtp_debug */
 #include "crypto_types.h"
 
 

--- a/crypto/cipher/aes_icm.c
+++ b/crypto/cipher/aes_icm.c
@@ -525,7 +525,6 @@ const srtp_cipher_type_t srtp_aes_icm = {
     (cipher_get_tag_func_t)0,
     (const char*)srtp_aes_icm_description,
     (const srtp_cipher_test_case_t*)&srtp_aes_icm_test_case_1,
-    (srtp_debug_module_t*)&srtp_mod_aes_icm,
     (srtp_cipher_type_id_t)SRTP_AES_ICM
 };
 

--- a/crypto/cipher/aes_icm.c
+++ b/crypto/cipher/aes_icm.c
@@ -187,8 +187,9 @@ static srtp_err_status_t srtp_aes_icm_dealloc (srtp_cipher_t *c)
  * randomizes the starting point in the keystream
  */
 
-static srtp_err_status_t srtp_aes_icm_context_init (srtp_aes_icm_ctx_t *c, const uint8_t *key)
+static srtp_err_status_t srtp_aes_icm_context_init (void *cv, const uint8_t *key)
 {
+    srtp_aes_icm_ctx_t *c = (srtp_aes_icm_ctx_t *)cv;
     srtp_err_status_t status;
     int base_key_len, copy_len;
 
@@ -240,8 +241,9 @@ static srtp_err_status_t srtp_aes_icm_context_init (srtp_aes_icm_ctx_t *c, const
  * the offset
  */
 
-static srtp_err_status_t srtp_aes_icm_set_iv (srtp_aes_icm_ctx_t *c, uint8_t *iv, int direction)
+static srtp_err_status_t srtp_aes_icm_set_iv (void *cv, uint8_t *iv, srtp_cipher_direction_t direction)
 {
+    srtp_aes_icm_ctx_t *c = (srtp_aes_icm_ctx_t *)cv;
     v128_t nonce;
 
     /* set nonce (for alignment) */
@@ -419,8 +421,9 @@ static srtp_err_status_t srtp_aes_icm_encrypt_ismacryp (srtp_aes_icm_ctx_t *c,
     return srtp_err_status_ok;
 }
 
-static srtp_err_status_t srtp_aes_icm_encrypt (srtp_aes_icm_ctx_t *c, unsigned char *buf, unsigned int *enc_len)
+static srtp_err_status_t srtp_aes_icm_encrypt (void *cv, unsigned char *buf, unsigned int *enc_len)
 {
+    srtp_aes_icm_ctx_t *c = (srtp_aes_icm_ctx_t *)cv;
     return srtp_aes_icm_encrypt_ismacryp(c, buf, enc_len, 0);
 }
 
@@ -515,16 +518,16 @@ static const srtp_cipher_test_case_t srtp_aes_icm_test_case_1 = {
  */
 
 const srtp_cipher_type_t srtp_aes_icm = {
-    (cipher_alloc_func_t)srtp_aes_icm_alloc,
-    (cipher_dealloc_func_t)srtp_aes_icm_dealloc,
-    (cipher_init_func_t)srtp_aes_icm_context_init,
-    (cipher_set_aad_func_t)0,
-    (cipher_encrypt_func_t)srtp_aes_icm_encrypt,
-    (cipher_decrypt_func_t)srtp_aes_icm_encrypt,
-    (cipher_set_iv_func_t)srtp_aes_icm_set_iv,
-    (cipher_get_tag_func_t)0,
-    (const char*)srtp_aes_icm_description,
-    (const srtp_cipher_test_case_t*)&srtp_aes_icm_test_case_1,
-    (srtp_cipher_type_id_t)SRTP_AES_ICM
+    srtp_aes_icm_alloc,
+    srtp_aes_icm_dealloc,
+    srtp_aes_icm_context_init,
+    0,                          /* set_aad */
+    srtp_aes_icm_encrypt,
+    srtp_aes_icm_encrypt,
+    srtp_aes_icm_set_iv,
+    0,                          /* get_tag */
+    srtp_aes_icm_description,
+    &srtp_aes_icm_test_case_1,
+    SRTP_AES_ICM
 };
 

--- a/crypto/cipher/aes_icm_ossl.c
+++ b/crypto/cipher/aes_icm_ossl.c
@@ -487,7 +487,6 @@ const srtp_cipher_type_t srtp_aes_icm = {
     (cipher_get_tag_func_t)        0,
     (const char*)                        srtp_aes_icm_openssl_description,
     (const srtp_cipher_test_case_t*)          &srtp_aes_icm_test_case_0,
-    (srtp_debug_module_t*)              &srtp_mod_aes_icm,
     (srtp_cipher_type_id_t)        SRTP_AES_ICM
 };
 
@@ -507,7 +506,6 @@ const srtp_cipher_type_t srtp_aes_icm_192 = {
     (cipher_get_tag_func_t)        0,
     (const char*)                        srtp_aes_icm_192_openssl_description,
     (const srtp_cipher_test_case_t*)          &srtp_aes_icm_192_test_case_1,
-    (srtp_debug_module_t*)              &srtp_mod_aes_icm,
     (srtp_cipher_type_id_t)        SRTP_AES_192_ICM
 };
 #endif
@@ -527,7 +525,6 @@ const srtp_cipher_type_t srtp_aes_icm_256 = {
     (cipher_get_tag_func_t)        0,
     (const char*)                        srtp_aes_icm_256_openssl_description,
     (const srtp_cipher_test_case_t*)          &srtp_aes_icm_256_test_case_2,
-    (srtp_debug_module_t*)              &srtp_mod_aes_icm,
     (srtp_cipher_type_id_t)        SRTP_AES_256_ICM
 };
 

--- a/crypto/cipher/aes_icm_ossl.c
+++ b/crypto/cipher/aes_icm_ossl.c
@@ -55,8 +55,8 @@
 #include <openssl/evp.h>
 #include "aes_icm_ossl.h"
 #include "crypto_types.h"
+#include "err.h"                /* for srtp_debug */
 #include "alloc.h"
-#include "crypto_types.h"
 
 
 srtp_debug_module_t srtp_mod_aes_icm = {

--- a/crypto/cipher/aes_icm_ossl.c
+++ b/crypto/cipher/aes_icm_ossl.c
@@ -212,8 +212,9 @@ static srtp_err_status_t srtp_aes_icm_openssl_dealloc (srtp_cipher_t *c)
  * the salt is unpredictable (but not necessarily secret) data which
  * randomizes the starting point in the keystream
  */
-static srtp_err_status_t srtp_aes_icm_openssl_context_init (srtp_aes_icm_ctx_t *c, const uint8_t *key)
+static srtp_err_status_t srtp_aes_icm_openssl_context_init (void* cv, const uint8_t *key)
 {
+    srtp_aes_icm_ctx_t *c = (srtp_aes_icm_ctx_t *)cv;
     /*
      * set counter and initial values to 'offset' value, being careful not to
      * go past the end of the key buffer
@@ -259,8 +260,9 @@ static srtp_err_status_t srtp_aes_icm_openssl_context_init (srtp_aes_icm_ctx_t *
  * aes_icm_set_iv(c, iv) sets the counter value to the exor of iv with
  * the offset
  */
-static srtp_err_status_t srtp_aes_icm_openssl_set_iv (srtp_aes_icm_ctx_t *c, uint8_t *iv, int dir)
+static srtp_err_status_t srtp_aes_icm_openssl_set_iv (void *cv, uint8_t *iv, srtp_cipher_direction_t dir)
 {
+    srtp_aes_icm_ctx_t *c = (srtp_aes_icm_ctx_t *)cv;
     const EVP_CIPHER *evp;
     v128_t nonce;
 
@@ -306,8 +308,9 @@ static srtp_err_status_t srtp_aes_icm_openssl_set_iv (srtp_aes_icm_ctx_t *c, uin
  *	buf	data to encrypt
  *	enc_len	length of encrypt buffer
  */
-static srtp_err_status_t srtp_aes_icm_openssl_encrypt (srtp_aes_icm_ctx_t *c, unsigned char *buf, unsigned int *enc_len)
+static srtp_err_status_t srtp_aes_icm_openssl_encrypt (void *cv, unsigned char *buf, unsigned int *enc_len)
 {
+    srtp_aes_icm_ctx_t *c = (srtp_aes_icm_ctx_t *)cv;
     int len = 0;
 
     debug_print(srtp_mod_aes_icm, "rs0: %s", v128_hex_string(&c->counter));
@@ -477,17 +480,17 @@ static const srtp_cipher_test_case_t srtp_aes_icm_256_test_case_2 = {
  * note: the encrypt function is identical to the decrypt function
  */
 const srtp_cipher_type_t srtp_aes_icm = {
-    (cipher_alloc_func_t)          srtp_aes_icm_openssl_alloc,
-    (cipher_dealloc_func_t)        srtp_aes_icm_openssl_dealloc,
-    (cipher_init_func_t)           srtp_aes_icm_openssl_context_init,
-    (cipher_set_aad_func_t)        0,
-    (cipher_encrypt_func_t)        srtp_aes_icm_openssl_encrypt,
-    (cipher_decrypt_func_t)        srtp_aes_icm_openssl_encrypt,
-    (cipher_set_iv_func_t)         srtp_aes_icm_openssl_set_iv,
-    (cipher_get_tag_func_t)        0,
-    (const char*)                        srtp_aes_icm_openssl_description,
-    (const srtp_cipher_test_case_t*)          &srtp_aes_icm_test_case_0,
-    (srtp_cipher_type_id_t)        SRTP_AES_ICM
+    srtp_aes_icm_openssl_alloc,
+    srtp_aes_icm_openssl_dealloc,
+    srtp_aes_icm_openssl_context_init,
+    0,                           /* set_aad */
+    srtp_aes_icm_openssl_encrypt,
+    srtp_aes_icm_openssl_encrypt,
+    srtp_aes_icm_openssl_set_iv,
+    0,                           /* get_tag */
+    srtp_aes_icm_openssl_description,
+    &srtp_aes_icm_test_case_0,
+    SRTP_AES_ICM
 };
 
 #ifndef SRTP_NO_AES192
@@ -496,17 +499,17 @@ const srtp_cipher_type_t srtp_aes_icm = {
  * note: the encrypt function is identical to the decrypt function
  */
 const srtp_cipher_type_t srtp_aes_icm_192 = {
-    (cipher_alloc_func_t)          srtp_aes_icm_openssl_alloc,
-    (cipher_dealloc_func_t)        srtp_aes_icm_openssl_dealloc,
-    (cipher_init_func_t)           srtp_aes_icm_openssl_context_init,
-    (cipher_set_aad_func_t)        0,
-    (cipher_encrypt_func_t)        srtp_aes_icm_openssl_encrypt,
-    (cipher_decrypt_func_t)        srtp_aes_icm_openssl_encrypt,
-    (cipher_set_iv_func_t)         srtp_aes_icm_openssl_set_iv,
-    (cipher_get_tag_func_t)        0,
-    (const char*)                        srtp_aes_icm_192_openssl_description,
-    (const srtp_cipher_test_case_t*)          &srtp_aes_icm_192_test_case_1,
-    (srtp_cipher_type_id_t)        SRTP_AES_192_ICM
+    srtp_aes_icm_openssl_alloc,
+    srtp_aes_icm_openssl_dealloc,
+    srtp_aes_icm_openssl_context_init,
+    0,                           /* set_aad */
+    srtp_aes_icm_openssl_encrypt,
+    srtp_aes_icm_openssl_encrypt,
+    srtp_aes_icm_openssl_set_iv,
+    0,                           /* get_tag */
+    srtp_aes_icm_192_openssl_description,
+    &srtp_aes_icm_192_test_case_1,
+    SRTP_AES_192_ICM
 };
 #endif
 
@@ -515,16 +518,16 @@ const srtp_cipher_type_t srtp_aes_icm_192 = {
  * note: the encrypt function is identical to the decrypt function
  */
 const srtp_cipher_type_t srtp_aes_icm_256 = {
-    (cipher_alloc_func_t)          srtp_aes_icm_openssl_alloc,
-    (cipher_dealloc_func_t)        srtp_aes_icm_openssl_dealloc,
-    (cipher_init_func_t)           srtp_aes_icm_openssl_context_init,
-    (cipher_set_aad_func_t)        0,
-    (cipher_encrypt_func_t)        srtp_aes_icm_openssl_encrypt,
-    (cipher_decrypt_func_t)        srtp_aes_icm_openssl_encrypt,
-    (cipher_set_iv_func_t)         srtp_aes_icm_openssl_set_iv,
-    (cipher_get_tag_func_t)        0,
-    (const char*)                        srtp_aes_icm_256_openssl_description,
-    (const srtp_cipher_test_case_t*)          &srtp_aes_icm_256_test_case_2,
-    (srtp_cipher_type_id_t)        SRTP_AES_256_ICM
+    srtp_aes_icm_openssl_alloc,
+    srtp_aes_icm_openssl_dealloc,
+    srtp_aes_icm_openssl_context_init,
+    0,                           /* set_aad */
+    srtp_aes_icm_openssl_encrypt,
+    srtp_aes_icm_openssl_encrypt,
+    srtp_aes_icm_openssl_set_iv,
+    0,                           /* get_tag */
+    srtp_aes_icm_256_openssl_description,
+    &srtp_aes_icm_256_test_case_2,
+    SRTP_AES_256_ICM
 };
 

--- a/crypto/cipher/cipher.c
+++ b/crypto/cipher/cipher.c
@@ -255,7 +255,7 @@ srtp_err_status_t srtp_cipher_type_test (const srtp_cipher_type_t *ct, const srt
                                                  test_case->plaintext_length_octets));
 
         /* set the initialization vector */
-        status = srtp_cipher_set_iv(c, (uint8_t*)test_case->idx, direction_encrypt);
+        status = srtp_cipher_set_iv(c, (uint8_t*)test_case->idx, srtp_direction_encrypt);
         if (status) {
             srtp_cipher_dealloc(c);
             return status;
@@ -354,7 +354,7 @@ srtp_err_status_t srtp_cipher_type_test (const srtp_cipher_type_t *ct, const srt
                                                  test_case->plaintext_length_octets));
 
         /* set the initialization vector */
-        status = srtp_cipher_set_iv(c, (uint8_t*)test_case->idx, direction_decrypt);
+        status = srtp_cipher_set_iv(c, (uint8_t*)test_case->idx, srtp_direction_decrypt);
         if (status) {
             srtp_cipher_dealloc(c);
             return status;
@@ -479,7 +479,7 @@ srtp_err_status_t srtp_cipher_type_test (const srtp_cipher_type_t *ct, const srt
         }
 
         /* set initialization vector */
-        status = srtp_cipher_set_iv(c, (uint8_t*)test_case->idx, direction_encrypt);
+        status = srtp_cipher_set_iv(c, (uint8_t*)test_case->idx, srtp_direction_encrypt);
         if (status) {
             srtp_cipher_dealloc(c);
             return status;
@@ -529,7 +529,7 @@ srtp_err_status_t srtp_cipher_type_test (const srtp_cipher_type_t *ct, const srt
             srtp_cipher_dealloc(c);
             return status;
         }
-        status = srtp_cipher_set_iv(c, (uint8_t*)test_case->idx, direction_decrypt);
+        status = srtp_cipher_set_iv(c, (uint8_t*)test_case->idx, srtp_direction_decrypt);
         if (status) {
             srtp_cipher_dealloc(c);
             return status;
@@ -620,7 +620,7 @@ uint64_t srtp_cipher_bits_per_second (srtp_cipher_t *c, int octets_in_buffer, in
     v128_set_to_zero(&nonce);
     timer = clock();
     for (i = 0; i < num_trials; i++, nonce.v32[3] = i) {
-        srtp_cipher_set_iv(c, (uint8_t*)&nonce, direction_encrypt);
+        srtp_cipher_set_iv(c, (uint8_t*)&nonce, srtp_direction_encrypt);
         srtp_cipher_encrypt(c, enc_buf, &len);
     }
     timer = clock() - timer;

--- a/crypto/cipher/cipher.c
+++ b/crypto/cipher/cipher.c
@@ -50,6 +50,7 @@
 
 #include "cipher.h"
 #include "crypto_types.h"
+#include "err.h"                /* for srtp_debug */
 #include "alloc.h"              /* for crypto_alloc(), crypto_free()  */
 
 srtp_debug_module_t srtp_mod_cipher = {

--- a/crypto/cipher/null_cipher.c
+++ b/crypto/cipher/null_cipher.c
@@ -147,7 +147,6 @@ const srtp_cipher_type_t srtp_null_cipher = {
     (cipher_get_tag_func_t)0,
     (const char*)srtp_null_cipher_description,
     (const srtp_cipher_test_case_t*)&srtp_null_cipher_test_0,
-    (srtp_debug_module_t*)NULL,
     (srtp_cipher_type_id_t)SRTP_NULL_CIPHER
 };
 

--- a/crypto/cipher/null_cipher.c
+++ b/crypto/cipher/null_cipher.c
@@ -50,6 +50,7 @@
 
 #include "datatypes.h"
 #include "null_cipher.h"
+#include "err.h"                /* for srtp_debug */
 #include "alloc.h"
 
 /* the null_cipher uses the cipher debug module  */

--- a/crypto/cipher/null_cipher.c
+++ b/crypto/cipher/null_cipher.c
@@ -97,22 +97,25 @@ static srtp_err_status_t srtp_null_cipher_dealloc (srtp_cipher_t *c)
 
 }
 
-static srtp_err_status_t srtp_null_cipher_init (srtp_null_cipher_ctx_t *ctx, const uint8_t *key)
+static srtp_err_status_t srtp_null_cipher_init (void *cv, const uint8_t *key)
 {
+	/* srtp_null_cipher_ctx_t *c = (srtp_null_cipher_ctx_t *)cv; */
 
     debug_print(srtp_mod_cipher, "initializing null cipher", NULL);
 
     return srtp_err_status_ok;
 }
 
-static srtp_err_status_t srtp_null_cipher_set_iv (srtp_null_cipher_ctx_t *c, uint8_t *iv, int dir)
+static srtp_err_status_t srtp_null_cipher_set_iv (void *cv, uint8_t *iv, srtp_cipher_direction_t dir)
 {
+	/* srtp_null_cipher_ctx_t *c = (srtp_null_cipher_ctx_t *)cv; */
     return srtp_err_status_ok;
 }
 
-static srtp_err_status_t srtp_null_cipher_encrypt (srtp_null_cipher_ctx_t *c,
+static srtp_err_status_t srtp_null_cipher_encrypt (void *cv,
                                             unsigned char *buf, unsigned int *bytes_to_encr)
 {
+	/* srtp_null_cipher_ctx_t *c = (srtp_null_cipher_ctx_t *)cv; */
     return srtp_err_status_ok;
 }
 
@@ -138,16 +141,16 @@ static const srtp_cipher_test_case_t srtp_null_cipher_test_0 = {
  */
 
 const srtp_cipher_type_t srtp_null_cipher = {
-    (cipher_alloc_func_t)srtp_null_cipher_alloc,
-    (cipher_dealloc_func_t)srtp_null_cipher_dealloc,
-    (cipher_init_func_t)srtp_null_cipher_init,
-    (cipher_set_aad_func_t)0,
-    (cipher_encrypt_func_t)srtp_null_cipher_encrypt,
-    (cipher_decrypt_func_t)srtp_null_cipher_encrypt,
-    (cipher_set_iv_func_t)srtp_null_cipher_set_iv,
-    (cipher_get_tag_func_t)0,
-    (const char*)srtp_null_cipher_description,
-    (const srtp_cipher_test_case_t*)&srtp_null_cipher_test_0,
-    (srtp_cipher_type_id_t)SRTP_NULL_CIPHER
+    srtp_null_cipher_alloc,
+    srtp_null_cipher_dealloc,
+    srtp_null_cipher_init,
+    0,                     /* set_aad */
+    srtp_null_cipher_encrypt,
+    srtp_null_cipher_encrypt,
+    srtp_null_cipher_set_iv,
+    0,                     /* get_tag */
+    srtp_null_cipher_description,
+    &srtp_null_cipher_test_0,
+    SRTP_NULL_CIPHER
 };
 

--- a/crypto/hash/auth.c
+++ b/crypto/hash/auth.c
@@ -112,25 +112,25 @@ srtp_auth_type_test (const srtp_auth_type_t *at, const srtp_auth_test_case_t *te
         }
 
         /* allocate auth */
-        status = auth_type_alloc(at, &a, test_case->key_length_octets,
+        status = srtp_auth_type_alloc(at, &a, test_case->key_length_octets,
                                  test_case->tag_length_octets);
         if (status) {
             return status;
         }
 
         /* initialize auth */
-        status = auth_init(a, test_case->key);
+        status = srtp_auth_init(a, test_case->key);
         if (status) {
-            auth_dealloc(a);
+            srtp_auth_dealloc(a);
             return status;
         }
 
         /* zeroize tag then compute */
         octet_string_set_to_zero(tag, test_case->tag_length_octets);
-        status = auth_compute(a, test_case->data,
+        status = srtp_auth_compute(a, test_case->data,
                               test_case->data_length_octets, tag);
         if (status) {
-            auth_dealloc(a);
+            srtp_auth_dealloc(a);
             return status;
         }
 
@@ -156,12 +156,12 @@ srtp_auth_type_test (const srtp_auth_type_t *at, const srtp_auth_test_case_t *te
             }
         }
         if (status) {
-            auth_dealloc(a);
+            srtp_auth_dealloc(a);
             return srtp_err_status_algo_fail;
         }
 
         /* deallocate the auth function */
-        status = auth_dealloc(a);
+        status = srtp_auth_dealloc(a);
         if (status) {
             return status;
         }

--- a/crypto/hash/auth.c
+++ b/crypto/hash/auth.c
@@ -48,6 +48,8 @@
 #endif
 
 #include "auth.h"
+#include "err.h"                /* for srtp_debug */
+#include "datatypes.h"          /* for octet_string */
 
 /* the debug module for authentiation */
 

--- a/crypto/hash/hmac.c
+++ b/crypto/hash/hmac.c
@@ -258,7 +258,6 @@ const srtp_auth_type_t srtp_hmac  = {
     (auth_start_func)srtp_hmac_start,
     (const char*)srtp_hmac_description,
     (const srtp_auth_test_case_t*)&srtp_hmac_test_case_0,
-    (srtp_debug_module_t*)&srtp_mod_hmac,
     (srtp_auth_type_id_t)SRTP_HMAC_SHA1
 };
 

--- a/crypto/hash/hmac.c
+++ b/crypto/hash/hmac.c
@@ -107,8 +107,9 @@ static srtp_err_status_t srtp_hmac_dealloc (srtp_auth_t *a)
     return srtp_err_status_ok;
 }
 
-static srtp_err_status_t srtp_hmac_init (srtp_hmac_ctx_t *state, const uint8_t *key, int key_len)
+static srtp_err_status_t srtp_hmac_init (void *statev, const uint8_t *key, int key_len)
 {
+    srtp_hmac_ctx_t *state = (srtp_hmac_ctx_t *)statev;
     int i;
     uint8_t ipad[64];
 
@@ -146,16 +147,18 @@ static srtp_err_status_t srtp_hmac_init (srtp_hmac_ctx_t *state, const uint8_t *
     return srtp_err_status_ok;
 }
 
-static srtp_err_status_t srtp_hmac_start (srtp_hmac_ctx_t *state)
+static srtp_err_status_t srtp_hmac_start (void *statev)
 {
+    srtp_hmac_ctx_t *state = (srtp_hmac_ctx_t *)statev;
 
     memcpy(&state->ctx, &state->init_ctx, sizeof(srtp_sha1_ctx_t));
 
     return srtp_err_status_ok;
 }
 
-static srtp_err_status_t srtp_hmac_update (srtp_hmac_ctx_t *state, const uint8_t *message, int msg_octets)
+static srtp_err_status_t srtp_hmac_update (void *statev, const uint8_t *message, int msg_octets)
 {
+    srtp_hmac_ctx_t *state = (srtp_hmac_ctx_t *)statev;
 
     debug_print(srtp_mod_hmac, "input: %s",
                 srtp_octet_string_hex_string(message, msg_octets));
@@ -166,9 +169,10 @@ static srtp_err_status_t srtp_hmac_update (srtp_hmac_ctx_t *state, const uint8_t
     return srtp_err_status_ok;
 }
 
-static srtp_err_status_t srtp_hmac_compute (srtp_hmac_ctx_t *state, const void *message,
+static srtp_err_status_t srtp_hmac_compute (void *statev, const uint8_t *message,
                                             int msg_octets, int tag_len, uint8_t *result)
 {
+    srtp_hmac_ctx_t *state = (srtp_hmac_ctx_t *)statev;
     uint32_t hash_value[5];
     uint32_t H[5];
     int i;
@@ -179,7 +183,7 @@ static srtp_err_status_t srtp_hmac_compute (srtp_hmac_ctx_t *state, const void *
     }
 
     /* hash message, copy output into H */
-    srtp_hmac_update(state, (const uint8_t*)message, msg_octets);
+    srtp_hmac_update(state, message, msg_octets);
     srtp_sha1_final(&state->ctx, H);
 
     /*
@@ -250,14 +254,14 @@ static const char srtp_hmac_description[] = "hmac sha-1 authentication function"
  */
 
 const srtp_auth_type_t srtp_hmac  = {
-    (auth_alloc_func)srtp_hmac_alloc,
-    (auth_dealloc_func)srtp_hmac_dealloc,
-    (auth_init_func)srtp_hmac_init,
-    (auth_compute_func)srtp_hmac_compute,
-    (auth_update_func)srtp_hmac_update,
-    (auth_start_func)srtp_hmac_start,
-    (const char*)srtp_hmac_description,
-    (const srtp_auth_test_case_t*)&srtp_hmac_test_case_0,
-    (srtp_auth_type_id_t)SRTP_HMAC_SHA1
+    srtp_hmac_alloc,
+    srtp_hmac_dealloc,
+    srtp_hmac_init,
+    srtp_hmac_compute,
+    srtp_hmac_update,
+    srtp_hmac_start,
+    srtp_hmac_description,
+    &srtp_hmac_test_case_0,
+    SRTP_HMAC_SHA1
 };
 

--- a/crypto/hash/hmac_ossl.c
+++ b/crypto/hash/hmac_ossl.c
@@ -277,7 +277,6 @@ const srtp_auth_type_t srtp_hmac  = {
     (auth_start_func)	srtp_hmac_start,
     (const char*)		srtp_hmac_description,
     (const srtp_auth_test_case_t*)	&srtp_hmac_test_case_0,
-    (srtp_debug_module_t*)	&srtp_mod_hmac,
     (srtp_auth_type_id_t) SRTP_HMAC_SHA1
 };
 

--- a/crypto/hash/hmac_ossl.c
+++ b/crypto/hash/hmac_ossl.c
@@ -123,8 +123,9 @@ static srtp_err_status_t srtp_hmac_dealloc (srtp_auth_t *a)
     return srtp_err_status_ok;
 }
 
-static srtp_err_status_t srtp_hmac_start (srtp_hmac_ctx_t *state)
+static srtp_err_status_t srtp_hmac_start (void *statev)
 {
+    srtp_hmac_ctx_t *state = (srtp_hmac_ctx_t *)statev;
     if (state->ctx_initialized) {
         EVP_MD_CTX_cleanup(&state->ctx);
     }
@@ -136,8 +137,9 @@ static srtp_err_status_t srtp_hmac_start (srtp_hmac_ctx_t *state)
     }
 }
 
-static srtp_err_status_t srtp_hmac_init (srtp_hmac_ctx_t *state, const uint8_t *key, int key_len)
+static srtp_err_status_t srtp_hmac_init (void *statev, const uint8_t *key, int key_len)
 {
+    srtp_hmac_ctx_t *state = (srtp_hmac_ctx_t *)statev;
     int i;
     uint8_t ipad[64];
 
@@ -174,8 +176,9 @@ static srtp_err_status_t srtp_hmac_init (srtp_hmac_ctx_t *state, const uint8_t *
     return (srtp_hmac_start(state));
 }
 
-static srtp_err_status_t srtp_hmac_update (srtp_hmac_ctx_t *state, const uint8_t *message, int msg_octets)
+static srtp_err_status_t srtp_hmac_update (void *statev, const uint8_t *message, int msg_octets)
 {
+    srtp_hmac_ctx_t *state = (srtp_hmac_ctx_t *)statev;
     debug_print(srtp_mod_hmac, "input: %s",
                 srtp_octet_string_hex_string(message, msg_octets));
 
@@ -185,9 +188,10 @@ static srtp_err_status_t srtp_hmac_update (srtp_hmac_ctx_t *state, const uint8_t
     return srtp_err_status_ok;
 }
 
-static srtp_err_status_t srtp_hmac_compute (srtp_hmac_ctx_t *state, const void *message,
+static srtp_err_status_t srtp_hmac_compute (void *statev, const uint8_t *message,
               int msg_octets, int tag_len, uint8_t *result)
 {
+    srtp_hmac_ctx_t *state = (srtp_hmac_ctx_t *)statev;
     uint32_t hash_value[5];
     uint32_t H[5];
     int i;
@@ -269,14 +273,14 @@ static const char srtp_hmac_description[] = "hmac sha-1 authentication function"
  */
 
 const srtp_auth_type_t srtp_hmac  = {
-    (auth_alloc_func)	srtp_hmac_alloc,
-    (auth_dealloc_func)	srtp_hmac_dealloc,
-    (auth_init_func)	srtp_hmac_init,
-    (auth_compute_func)	srtp_hmac_compute,
-    (auth_update_func)	srtp_hmac_update,
-    (auth_start_func)	srtp_hmac_start,
-    (const char*)		srtp_hmac_description,
-    (const srtp_auth_test_case_t*)	&srtp_hmac_test_case_0,
-    (srtp_auth_type_id_t) SRTP_HMAC_SHA1
+    srtp_hmac_alloc,
+    srtp_hmac_dealloc,
+    srtp_hmac_init,
+    srtp_hmac_compute,
+    srtp_hmac_update,
+    srtp_hmac_start,
+    srtp_hmac_description,
+    &srtp_hmac_test_case_0,
+    SRTP_HMAC_SHA1
 };
 

--- a/crypto/hash/null_auth.c
+++ b/crypto/hash/null_auth.c
@@ -151,7 +151,6 @@ const srtp_auth_type_t srtp_null_auth  = {
     (auth_start_func)srtp_null_auth_start,
     (const char*)srtp_null_auth_description,
     (const srtp_auth_test_case_t*)&srtp_null_auth_test_case_0,
-    (srtp_debug_module_t*)NULL,
     (srtp_auth_type_id_t)SRTP_NULL_AUTH
 };
 

--- a/crypto/hash/null_auth.c
+++ b/crypto/hash/null_auth.c
@@ -49,6 +49,7 @@
 #endif
 
 #include "null_auth.h"
+#include "err.h"                /* for srtp_debug */
 #include "alloc.h"
 
 /* null_auth uses the auth debug module */

--- a/crypto/hash/null_auth.c
+++ b/crypto/hash/null_auth.c
@@ -95,30 +95,34 @@ static srtp_err_status_t srtp_null_auth_dealloc (srtp_auth_t *a)
     return srtp_err_status_ok;
 }
 
-static srtp_err_status_t srtp_null_auth_init (srtp_null_auth_ctx_t *state, const uint8_t *key, int key_len)
+static srtp_err_status_t srtp_null_auth_init (void *statev, const uint8_t *key, int key_len)
 {
-
+    /* srtp_null_auth_ctx_t *state = (srtp_null_auth_ctx_t *)statev; */
     /* accept any length of key, and do nothing */
 
     return srtp_err_status_ok;
 }
 
-static srtp_err_status_t srtp_null_auth_compute (srtp_null_auth_ctx_t *state, const uint8_t *message,
+static srtp_err_status_t srtp_null_auth_compute (void *statev, const uint8_t *message,
                                           int msg_octets, int tag_len, uint8_t *result)
 {
+    /* srtp_null_auth_ctx_t *state = (srtp_null_auth_ctx_t *)statev; */
 
     return srtp_err_status_ok;
 }
 
-static srtp_err_status_t srtp_null_auth_update (srtp_null_auth_ctx_t *state, const uint8_t *message,
+static srtp_err_status_t srtp_null_auth_update (void *statev, const uint8_t *message,
                                          int msg_octets)
 {
+    /* srtp_null_auth_ctx_t *state = (srtp_null_auth_ctx_t *)statev; */
 
     return srtp_err_status_ok;
 }
 
-static srtp_err_status_t srtp_null_auth_start (srtp_null_auth_ctx_t *state)
+static srtp_err_status_t srtp_null_auth_start (void *statev)
 {
+    /* srtp_null_auth_ctx_t *state = (srtp_null_auth_ctx_t *)statev; */
+
     return srtp_err_status_ok;
 }
 
@@ -144,14 +148,14 @@ static const srtp_auth_test_case_t srtp_null_auth_test_case_0 = {
 static const char srtp_null_auth_description[] = "null authentication function";
 
 const srtp_auth_type_t srtp_null_auth  = {
-    (auth_alloc_func)srtp_null_auth_alloc,
-    (auth_dealloc_func)srtp_null_auth_dealloc,
-    (auth_init_func)srtp_null_auth_init,
-    (auth_compute_func)srtp_null_auth_compute,
-    (auth_update_func)srtp_null_auth_update,
-    (auth_start_func)srtp_null_auth_start,
-    (const char*)srtp_null_auth_description,
-    (const srtp_auth_test_case_t*)&srtp_null_auth_test_case_0,
-    (srtp_auth_type_id_t)SRTP_NULL_AUTH
+    srtp_null_auth_alloc,
+    srtp_null_auth_dealloc,
+    srtp_null_auth_init,
+    srtp_null_auth_compute,
+    srtp_null_auth_update,
+    srtp_null_auth_start,
+    srtp_null_auth_description,
+    &srtp_null_auth_test_case_0,
+    SRTP_NULL_AUTH
 };
 

--- a/crypto/include/aes_gcm_ossl.h
+++ b/crypto/include/aes_gcm_ossl.h
@@ -48,6 +48,7 @@
 
 #include "cipher.h"
 #include "srtp.h"
+#include "datatypes.h"
 #include <openssl/evp.h>
 #include <openssl/aes.h>
 

--- a/crypto/include/aes_icm_ossl.h
+++ b/crypto/include/aes_icm_ossl.h
@@ -47,6 +47,7 @@
 #define AES_ICM_H
 
 #include "cipher.h"
+#include "datatypes.h"
 #include <openssl/evp.h>
 #include <openssl/aes.h>
 

--- a/crypto/include/auth.h
+++ b/crypto/include/auth.h
@@ -151,13 +151,13 @@ srtp_err_status_t srtp_auth_type_test(const srtp_auth_type_t *at,
 	const srtp_auth_test_case_t *test_data);
 
 /*
- * srtp_crypto_kernel_replace_auth_type(ct, id)
+ * srtp_replace_auth_type(ct, id)
  *
- * replaces the crypto kernel's existing cipher for the auth_type id
+ * replaces srtp's kernel's auth type implementation for the auth_type id
  * with a new one passed in externally.  The new auth type must pass all the
  * existing auth_type's self tests as well as its own.
  */
-srtp_err_status_t srtp_crypto_kernel_replace_auth_type(const srtp_auth_type_t *ct, srtp_auth_type_id_t id);
+srtp_err_status_t srtp_replace_auth_type(const srtp_auth_type_t *ct, srtp_auth_type_id_t id);
 
 #ifdef __cplusplus
 }

--- a/crypto/include/auth.h
+++ b/crypto/include/auth.h
@@ -150,6 +150,15 @@ srtp_err_status_t srtp_auth_type_self_test(const srtp_auth_type_t *at);
 srtp_err_status_t srtp_auth_type_test(const srtp_auth_type_t *at, 
 	const srtp_auth_test_case_t *test_data);
 
+/*
+ * srtp_crypto_kernel_replace_auth_type(ct, id)
+ *
+ * replaces the crypto kernel's existing cipher for the auth_type id
+ * with a new one passed in externally.  The new auth type must pass all the
+ * existing auth_type's self tests as well as its own.
+ */
+srtp_err_status_t srtp_crypto_kernel_replace_auth_type(const srtp_auth_type_t *ct, srtp_auth_type_id_t id);
+
 #ifdef __cplusplus
 }
 #endif

--- a/crypto/include/auth.h
+++ b/crypto/include/auth.h
@@ -53,42 +53,42 @@
 extern "C" {
 #endif
 
-typedef const struct srtp_auth_type_t *auth_type_pointer;
-typedef struct srtp_auth_t      *auth_pointer_t;
+typedef const struct srtp_auth_type_t *srtp_auth_type_pointer;
+typedef struct srtp_auth_t      *srtp_auth_pointer_t;
 
-typedef srtp_err_status_t (*auth_alloc_func)
-    (auth_pointer_t *ap, int key_len, int out_len);
+typedef srtp_err_status_t (*srtp_auth_alloc_func)
+    (srtp_auth_pointer_t *ap, int key_len, int out_len);
 
-typedef srtp_err_status_t (*auth_init_func)
+typedef srtp_err_status_t (*srtp_auth_init_func)
     (void *state, const uint8_t *key, int key_len);
 
-typedef srtp_err_status_t (*auth_dealloc_func)(auth_pointer_t ap);
+typedef srtp_err_status_t (*srtp_auth_dealloc_func)(srtp_auth_pointer_t ap);
 
-typedef srtp_err_status_t (*auth_compute_func)
+typedef srtp_err_status_t (*srtp_auth_compute_func)
     (void *state, const uint8_t *buffer, int octets_to_auth,
     int tag_len, uint8_t *tag);
 
-typedef srtp_err_status_t (*auth_update_func)
+typedef srtp_err_status_t (*srtp_auth_update_func)
     (void *state, const uint8_t *buffer, int octets_to_auth);
 
-typedef srtp_err_status_t (*auth_start_func)(void *state);
+typedef srtp_err_status_t (*srtp_auth_start_func)(void *state);
 
 /* some syntactic sugar on these function types */
-#define auth_type_alloc(at, a, klen, outlen)                        \
+#define srtp_auth_type_alloc(at, a, klen, outlen)                        \
     ((at)->alloc((a), (klen), (outlen)))
 
-#define auth_init(a, key)                                           \
+#define srtp_auth_init(a, key)                                           \
     (((a)->type)->init((a)->state, (key), ((a)->key_len)))
 
-#define auth_compute(a, buf, len, res)                              \
+#define srtp_auth_compute(a, buf, len, res)                              \
     (((a)->type)->compute((a)->state, (buf), (len), (a)->out_len, (res)))
 
-#define auth_update(a, buf, len)                                    \
+#define srtp_auth_update(a, buf, len)                                    \
     (((a)->type)->update((a)->state, (buf), (len)))
 
-#define auth_start(a)(((a)->type)->start((a)->state))
+#define srtp_auth_start(a)(((a)->type)->start((a)->state))
 
-#define auth_dealloc(c) (((c)->type)->dealloc(c))
+#define srtp_auth_dealloc(c) (((c)->type)->dealloc(c))
 
 /* functions to get information about a particular auth_t */
 int srtp_auth_get_key_length(const struct srtp_auth_t *a);
@@ -116,12 +116,12 @@ typedef struct srtp_auth_test_case_t {
 
 /* srtp_auth_type_t */
 typedef struct srtp_auth_type_t {
-    auth_alloc_func alloc;
-    auth_dealloc_func dealloc;
-    auth_init_func init;
-    auth_compute_func compute;
-    auth_update_func update;
-    auth_start_func start;
+    srtp_auth_alloc_func alloc;
+    srtp_auth_dealloc_func dealloc;
+    srtp_auth_init_func init;
+    srtp_auth_compute_func compute;
+    srtp_auth_update_func update;
+    srtp_auth_start_func start;
     const char                *description;
     const srtp_auth_test_case_t    *test_data;
     srtp_auth_type_id_t id;

--- a/crypto/include/auth.h
+++ b/crypto/include/auth.h
@@ -98,10 +98,10 @@ int srtp_auth_get_tag_length(const struct srtp_auth_t *a);
 int srtp_auth_get_prefix_length(const struct srtp_auth_t *a);
 
 /*
- * auth_test_case_t is a (list of) key/message/tag values that are
+ * srtp_auth_test_case_t is a (list of) key/message/tag values that are
  * known to be correct for a particular cipher.  this data can be used
  * to test an implementation in an on-the-fly self test of the
- * correcness of the implementation.  (see the auth_type_self_test()
+ * correcness of the implementation.  (see the srtp_auth_type_self_test()
  * function below)
  */
 typedef struct srtp_auth_test_case_t {
@@ -136,14 +136,14 @@ typedef struct srtp_auth_t {
 } srtp_auth_t;
 
 /*
- * auth_type_self_test() tests an auth_type against test cases
+ * srtp_auth_type_self_test() tests an auth_type against test cases
  * provided in an array of values of key/message/tag that is known to
  * be good
  */
 srtp_err_status_t srtp_auth_type_self_test(const srtp_auth_type_t *at);
 
 /*
- * auth_type_test() tests an auth_type against external test cases
+ * srtp_auth_type_test() tests an auth_type against external test cases
  * provided in an array of values of key/message/tag that is known to
  * be good
  */

--- a/crypto/include/auth.h
+++ b/crypto/include/auth.h
@@ -126,7 +126,6 @@ typedef struct srtp_auth_type_t {
     auth_start_func start;
     const char                *description;
     const srtp_auth_test_case_t    *test_data;
-    srtp_debug_module_t      *debug;
     srtp_auth_type_id_t id;
 } srtp_auth_type_t;
 

--- a/crypto/include/auth.h
+++ b/crypto/include/auth.h
@@ -47,8 +47,6 @@
 #define AUTH_H
 
 #include "srtp.h"
-#include "datatypes.h"
-#include "err.h"                /* error codes    */
 #include "crypto_types.h"       /* for values of auth_type_id_t */
 
 #ifdef __cplusplus

--- a/crypto/include/auth.h
+++ b/crypto/include/auth.h
@@ -101,7 +101,7 @@ int srtp_auth_get_prefix_length(const struct srtp_auth_t *a);
  * srtp_auth_test_case_t is a (list of) key/message/tag values that are
  * known to be correct for a particular cipher.  this data can be used
  * to test an implementation in an on-the-fly self test of the
- * correcness of the implementation.  (see the srtp_auth_type_self_test()
+ * correctness of the implementation.  (see the srtp_auth_type_self_test()
  * function below)
  */
 typedef struct srtp_auth_test_case_t {

--- a/crypto/include/cipher.h
+++ b/crypto/include/cipher.h
@@ -55,9 +55,9 @@ extern "C" {
 #endif
 
 /*
- * cipher_direction_t defines a particular cipher operation.
+ * srtp_cipher_direction_t defines a particular cipher operation.
  *
- * A cipher_direction_t is an enum that describes a particular cipher
+ * A srtp_cipher_direction_t is an enum that describes a particular cipher
  * operation, i.e. encryption or decryption.  For some ciphers, this
  * distinction does not matter, but for others, it is essential.
  */
@@ -68,8 +68,8 @@ typedef enum {
 } srtp_cipher_direction_t;
 
 /*
- * the cipher_pointer and cipher_type_pointer definitions are needed
- * as cipher_t and cipher_type_t are not yet defined
+ * the srtp_cipher_pointer_t definition is needed
+ * as srtp_cipher_t is not yet defined
  */
 typedef struct srtp_cipher_t      *srtp_cipher_pointer_t;
 
@@ -118,11 +118,11 @@ typedef srtp_err_status_t (*cipher_get_tag_func_t)
 
 
 /*
- * cipher_test_case_t is a (list of) key, salt, srtp_xtd_seq_num_t,
+ * srtp_cipher_test_case_t is a (list of) key, salt, srtp_xtd_seq_num_t,
  * plaintext, and ciphertext values that are known to be correct for a
  * particular cipher.  this data can be used to test an implementation
  * in an on-the-fly self test of the correcness of the implementation.
- * (see the cipher_type_self_test() function below)
+ * (see the srtp_cipher_type_self_test() function below)
  */
 typedef struct srtp_cipher_test_case_t {
     int key_length_octets;                          /* octets in key            */
@@ -138,7 +138,7 @@ typedef struct srtp_cipher_test_case_t {
     const struct srtp_cipher_test_case_t *next_test_case; /* pointer to next testcase */
 } srtp_cipher_test_case_t;
 
-/* cipher_type_t defines the 'metadata' for a particular cipher type */
+/* srtp_cipher_type_t defines the 'metadata' for a particular cipher type */
 typedef struct srtp_cipher_type_t {
     cipher_alloc_func_t alloc;
     cipher_dealloc_func_t dealloc;
@@ -154,7 +154,7 @@ typedef struct srtp_cipher_type_t {
 } srtp_cipher_type_t;
 
 /*
- * cipher_t defines an instantiation of a particular cipher, with fixed
+ * srtp_cipher_t defines an instantiation of a particular cipher, with fixed
  * key length, key and salt values
  */
 typedef struct srtp_cipher_t {
@@ -169,7 +169,7 @@ int srtp_cipher_get_key_length(const srtp_cipher_t *c);
 
 
 /*
- * cipher_type_self_test() tests a cipher against test cases provided in
+ * srtp_cipher_type_self_test() tests a cipher against test cases provided in
  * an array of values of key/srtp_xtd_seq_num_t/plaintext/ciphertext
  * that is known to be good
  */
@@ -177,7 +177,7 @@ srtp_err_status_t srtp_cipher_type_self_test(const srtp_cipher_type_t *ct);
 
 
 /*
- * cipher_type_test() tests a cipher against external test cases provided in
+ * srtp_cipher_type_test() tests a cipher against external test cases provided in
  * an array of values of key/srtp_xtd_seq_num_t/plaintext/ciphertext
  * that is known to be good
  */
@@ -185,7 +185,7 @@ srtp_err_status_t srtp_cipher_type_test(const srtp_cipher_type_t *ct, const srtp
 
 
 /*
- * cipher_bits_per_second(c, l, t) computes (and estimate of) the
+ * srtp_cipher_bits_per_second(c, l, t) computes (and estimate of) the
  * number of bits that a cipher implementation can encrypt in a second
  *
  * c is a cipher (which MUST be allocated and initialized already), l

--- a/crypto/include/cipher.h
+++ b/crypto/include/cipher.h
@@ -110,7 +110,7 @@ typedef srtp_err_status_t (*srtp_cipher_set_iv_func_t)
     (void *state, uint8_t *iv, srtp_cipher_direction_t direction);
 
 /*
- * a cipher_get_tag_funct_t function is used to get the authentication
+ * a cipher_get_tag_func_t function is used to get the authentication
  * tag that was calculated by an AEAD cipher.
  */
 typedef srtp_err_status_t (*srtp_cipher_get_tag_func_t)
@@ -118,10 +118,10 @@ typedef srtp_err_status_t (*srtp_cipher_get_tag_func_t)
 
 
 /*
- * srtp_cipher_test_case_t is a (list of) key, salt, srtp_xtd_seq_num_t,
- * plaintext, and ciphertext values that are known to be correct for a
+ * srtp_cipher_test_case_t is a (list of) key, salt, plaintext, ciphertext,
+ * and aad values that are known to be correct for a
  * particular cipher.  this data can be used to test an implementation
- * in an on-the-fly self test of the correcness of the implementation.
+ * in an on-the-fly self test of the correctness of the implementation.
  * (see the srtp_cipher_type_self_test() function below)
  */
 typedef struct srtp_cipher_test_case_t {
@@ -185,7 +185,7 @@ srtp_err_status_t srtp_cipher_type_test(const srtp_cipher_type_t *ct, const srtp
 
 
 /*
- * srtp_cipher_bits_per_second(c, l, t) computes (and estimate of) the
+ * srtp_cipher_bits_per_second(c, l, t) computes (an estimate of) the
  * number of bits that a cipher implementation can encrypt in a second
  *
  * c is a cipher (which MUST be allocated and initialized already), l

--- a/crypto/include/cipher.h
+++ b/crypto/include/cipher.h
@@ -47,9 +47,6 @@
 #define CIPHER_H
 
 #include "srtp.h"
-#include "datatypes.h"
-#include "rdbx.h"               /* for srtp_xtd_seq_num_t */
-#include "err.h"                /* for error codes  */
 #include "crypto_types.h"       /* for values of cipher_type_id_t */
 
 

--- a/crypto/include/cipher.h
+++ b/crypto/include/cipher.h
@@ -91,10 +91,6 @@ typedef srtp_err_status_t (*cipher_init_func_t)
 /* a cipher_dealloc_func_t de-allocates a cipher_t */
 typedef srtp_err_status_t (*cipher_dealloc_func_t)(srtp_cipher_pointer_t cp);
 
-/* a cipher_set_segment_func_t sets the segment index of a cipher_t */
-typedef srtp_err_status_t (*cipher_set_segment_func_t)
-    (void *state, srtp_xtd_seq_num_t idx);
-
 /*
  * a cipher_set_aad_func_t processes the AAD data for AEAD ciphers
  */

--- a/crypto/include/cipher.h
+++ b/crypto/include/cipher.h
@@ -206,6 +206,15 @@ srtp_err_status_t srtp_cipher_decrypt(srtp_cipher_t *c, uint8_t *buffer, uint32_
 srtp_err_status_t srtp_cipher_get_tag(srtp_cipher_t *c, uint8_t *buffer, uint32_t *tag_len);
 srtp_err_status_t srtp_cipher_set_aad(srtp_cipher_t *c, const uint8_t *aad, uint32_t aad_len);
 
+/*
+ * srtp_crypto_kernel_replace_cipher_type(ct, id)
+ *
+ * replaces the crypto kernel's existing cipher for the cipher_type id
+ * with a new one passed in externally.  The new cipher must pass all the
+ * existing cipher_type's self tests as well as its own.
+ */
+srtp_err_status_t srtp_crypto_kernel_replace_cipher_type(const srtp_cipher_type_t *ct, srtp_cipher_type_id_t id);
+
 #ifdef __cplusplus
 }
 #endif

--- a/crypto/include/cipher.h
+++ b/crypto/include/cipher.h
@@ -207,13 +207,13 @@ srtp_err_status_t srtp_cipher_get_tag(srtp_cipher_t *c, uint8_t *buffer, uint32_
 srtp_err_status_t srtp_cipher_set_aad(srtp_cipher_t *c, const uint8_t *aad, uint32_t aad_len);
 
 /*
- * srtp_crypto_kernel_replace_cipher_type(ct, id)
+ * srtp_replace_cipher_type(ct, id)
  *
- * replaces the crypto kernel's existing cipher for the cipher_type id
+ * replaces srtp's existing cipher implementation for the cipher_type id
  * with a new one passed in externally.  The new cipher must pass all the
  * existing cipher_type's self tests as well as its own.
  */
-srtp_err_status_t srtp_crypto_kernel_replace_cipher_type(const srtp_cipher_type_t *ct, srtp_cipher_type_id_t id);
+srtp_err_status_t srtp_replace_cipher_type(const srtp_cipher_type_t *ct, srtp_cipher_type_id_t id);
 
 #ifdef __cplusplus
 }

--- a/crypto/include/cipher.h
+++ b/crypto/include/cipher.h
@@ -107,7 +107,7 @@ typedef srtp_err_status_t (*cipher_decrypt_func_t)
  * a cipher_set_iv_func_t function sets the current initialization vector
  */
 typedef srtp_err_status_t (*cipher_set_iv_func_t)
-    (srtp_cipher_pointer_t cp, uint8_t *iv, srtp_cipher_direction_t direction);
+    (void *state, uint8_t *iv, srtp_cipher_direction_t direction);
 
 /*
  * a cipher_get_tag_funct_t function is used to get the authentication

--- a/crypto/include/cipher.h
+++ b/crypto/include/cipher.h
@@ -62,9 +62,9 @@ extern "C" {
  * distinction does not matter, but for others, it is essential.
  */
 typedef enum {
-    direction_encrypt, /**< encryption (convert plaintext to ciphertext) */
-    direction_decrypt, /**< decryption (convert ciphertext to plaintext) */
-    direction_any      /**< encryption or decryption                     */
+    srtp_direction_encrypt, /**< encryption (convert plaintext to ciphertext) */
+    srtp_direction_decrypt, /**< decryption (convert ciphertext to plaintext) */
+    srtp_direction_any      /**< encryption or decryption                     */
 } srtp_cipher_direction_t;
 
 /*
@@ -74,46 +74,46 @@ typedef enum {
 typedef struct srtp_cipher_t      *srtp_cipher_pointer_t;
 
 /*
- *  a cipher_alloc_func_t allocates (but does not initialize) a cipher_t
+ *  a srtp_cipher_alloc_func_t allocates (but does not initialize) a srtp_cipher_t
  */
-typedef srtp_err_status_t (*cipher_alloc_func_t)
+typedef srtp_err_status_t (*srtp_cipher_alloc_func_t)
     (srtp_cipher_pointer_t *cp, int key_len, int tag_len);
 
 /*
- * a cipher_init_func_t [re-]initializes a cipher_t with a given key
+ * a srtp_cipher_init_func_t [re-]initializes a cipher_t with a given key
  */
-typedef srtp_err_status_t (*cipher_init_func_t)
+typedef srtp_err_status_t (*srtp_cipher_init_func_t)
     (void *state, const uint8_t *key);
 
-/* a cipher_dealloc_func_t de-allocates a cipher_t */
-typedef srtp_err_status_t (*cipher_dealloc_func_t)(srtp_cipher_pointer_t cp);
+/* a srtp_cipher_dealloc_func_t de-allocates a cipher_t */
+typedef srtp_err_status_t (*srtp_cipher_dealloc_func_t)(srtp_cipher_pointer_t cp);
 
 /*
- * a cipher_set_aad_func_t processes the AAD data for AEAD ciphers
+ * a srtp_cipher_set_aad_func_t processes the AAD data for AEAD ciphers
  */
-typedef srtp_err_status_t (*cipher_set_aad_func_t)
+typedef srtp_err_status_t (*srtp_cipher_set_aad_func_t)
     (void *state, const uint8_t *aad, uint32_t aad_len);
 
 
-/* a cipher_encrypt_func_t encrypts data in-place */
-typedef srtp_err_status_t (*cipher_encrypt_func_t)
+/* a srtp_cipher_encrypt_func_t encrypts data in-place */
+typedef srtp_err_status_t (*srtp_cipher_encrypt_func_t)
     (void *state, uint8_t *buffer, unsigned int *octets_to_encrypt);
 
-/* a cipher_decrypt_func_t decrypts data in-place */
-typedef srtp_err_status_t (*cipher_decrypt_func_t)
+/* a srtp_cipher_decrypt_func_t decrypts data in-place */
+typedef srtp_err_status_t (*srtp_cipher_decrypt_func_t)
     (void *state, uint8_t *buffer, unsigned int *octets_to_decrypt);
 
 /*
- * a cipher_set_iv_func_t function sets the current initialization vector
+ * a srtp_cipher_set_iv_func_t function sets the current initialization vector
  */
-typedef srtp_err_status_t (*cipher_set_iv_func_t)
+typedef srtp_err_status_t (*srtp_cipher_set_iv_func_t)
     (void *state, uint8_t *iv, srtp_cipher_direction_t direction);
 
 /*
  * a cipher_get_tag_funct_t function is used to get the authentication
  * tag that was calculated by an AEAD cipher.
  */
-typedef srtp_err_status_t (*cipher_get_tag_func_t)
+typedef srtp_err_status_t (*srtp_cipher_get_tag_func_t)
     (void *state, uint8_t *tag, uint32_t *len);
 
 
@@ -140,14 +140,14 @@ typedef struct srtp_cipher_test_case_t {
 
 /* srtp_cipher_type_t defines the 'metadata' for a particular cipher type */
 typedef struct srtp_cipher_type_t {
-    cipher_alloc_func_t alloc;
-    cipher_dealloc_func_t dealloc;
-    cipher_init_func_t init;
-    cipher_set_aad_func_t set_aad;
-    cipher_encrypt_func_t encrypt;
-    cipher_encrypt_func_t decrypt;
-    cipher_set_iv_func_t set_iv;
-    cipher_get_tag_func_t get_tag;
+    srtp_cipher_alloc_func_t alloc;
+    srtp_cipher_dealloc_func_t dealloc;
+    srtp_cipher_init_func_t init;
+    srtp_cipher_set_aad_func_t set_aad;
+    srtp_cipher_encrypt_func_t encrypt;
+    srtp_cipher_encrypt_func_t decrypt;
+    srtp_cipher_set_iv_func_t set_iv;
+    srtp_cipher_get_tag_func_t get_tag;
     const char                       *description;
     const srtp_cipher_test_case_t         *test_data;
     srtp_cipher_type_id_t id;

--- a/crypto/include/cipher.h
+++ b/crypto/include/cipher.h
@@ -157,7 +157,6 @@ typedef struct srtp_cipher_type_t {
     cipher_get_tag_func_t get_tag;
     const char                       *description;
     const srtp_cipher_test_case_t         *test_data;
-    srtp_debug_module_t             *debug;
     srtp_cipher_type_id_t id;
 } srtp_cipher_type_t;
 

--- a/crypto/include/crypto_kernel.h
+++ b/crypto/include/crypto_kernel.h
@@ -165,26 +165,6 @@ srtp_err_status_t srtp_crypto_kernel_load_cipher_type(const srtp_cipher_type_t *
 
 srtp_err_status_t srtp_crypto_kernel_load_auth_type(const srtp_auth_type_t *ct, srtp_auth_type_id_t id);
 
-/*
- * srtp_crypto_kernel_replace_cipher_type(ct, id)
- *
- * replaces the crypto kernel's existing cipher for the cipher_type id
- * with a new one passed in externally.  The new cipher must pass all the
- * existing cipher_type's self tests as well as its own.
- */
-srtp_err_status_t srtp_crypto_kernel_replace_cipher_type(const srtp_cipher_type_t *ct, srtp_cipher_type_id_t id);
-
-
-/*
- * srtp_crypto_kernel_replace_auth_type(ct, id)
- *
- * replaces the crypto kernel's existing cipher for the auth_type id
- * with a new one passed in externally.  The new auth type must pass all the
- * existing auth_type's self tests as well as its own.
- */
-srtp_err_status_t srtp_crypto_kernel_replace_auth_type(const srtp_auth_type_t *ct, srtp_auth_type_id_t id);
-
-
 srtp_err_status_t srtp_crypto_kernel_load_debug_module(srtp_debug_module_t *new_dm);
 
 /*

--- a/crypto/include/crypto_kernel.h
+++ b/crypto/include/crypto_kernel.h
@@ -190,7 +190,7 @@ srtp_err_status_t srtp_crypto_kernel_alloc_cipher(srtp_cipher_type_id_t id, srtp
  *    srtp_err_status_alloc_fail   an allocation failure occured
  *    srtp_err_status_fail         couldn't find auth with identifier 'id'
  */
-srtp_err_status_t srtp_crypto_kernel_alloc_auth(srtp_auth_type_id_t id, auth_pointer_t *ap, int key_len, int tag_len);
+srtp_err_status_t srtp_crypto_kernel_alloc_auth(srtp_auth_type_id_t id, srtp_auth_pointer_t *ap, int key_len, int tag_len);
 
 
 /*

--- a/crypto/kernel/crypto_kernel.c
+++ b/crypto/kernel/crypto_kernel.c
@@ -515,7 +515,7 @@ const srtp_auth_type_t * srtp_crypto_kernel_get_auth_type (srtp_auth_type_id_t i
     return NULL;
 }
 
-srtp_err_status_t srtp_crypto_kernel_alloc_auth (srtp_auth_type_id_t id, auth_pointer_t *ap, int key_len, int tag_len)
+srtp_err_status_t srtp_crypto_kernel_alloc_auth (srtp_auth_type_id_t id, srtp_auth_pointer_t *ap, int key_len, int tag_len)
 {
     const srtp_auth_type_t *at;
 

--- a/crypto/kernel/crypto_kernel.c
+++ b/crypto/kernel/crypto_kernel.c
@@ -382,7 +382,7 @@ srtp_err_status_t srtp_crypto_kernel_load_cipher_type (const srtp_cipher_type_t 
     return srtp_crypto_kernel_do_load_cipher_type(new_ct, id, 0);
 }
 
-srtp_err_status_t srtp_crypto_kernel_replace_cipher_type (const srtp_cipher_type_t *new_ct, srtp_cipher_type_id_t id)
+srtp_err_status_t srtp_replace_cipher_type (const srtp_cipher_type_t *new_ct, srtp_cipher_type_id_t id)
 {
     return srtp_crypto_kernel_do_load_cipher_type(new_ct, id, 1);
 }
@@ -452,7 +452,7 @@ srtp_err_status_t srtp_crypto_kernel_load_auth_type (const srtp_auth_type_t *new
     return srtp_crypto_kernel_do_load_auth_type(new_at, id, 0);
 }
 
-srtp_err_status_t srtp_crypto_kernel_replace_auth_type (const srtp_auth_type_t *new_at, srtp_auth_type_id_t id)
+srtp_err_status_t srtp_replace_auth_type (const srtp_auth_type_t *new_at, srtp_auth_type_id_t id)
 {
     return srtp_crypto_kernel_do_load_auth_type(new_at, id, 1);
 }

--- a/crypto/kernel/crypto_kernel.c
+++ b/crypto/kernel/crypto_kernel.c
@@ -59,7 +59,7 @@ srtp_debug_module_t srtp_mod_crypto_kernel = {
 };
 
 /*
- * other debug modules that can be included in the kernel
+ * other generic debug modules that can be included in the kernel
  */
 
 extern srtp_debug_module_t srtp_mod_auth;
@@ -82,6 +82,11 @@ extern srtp_cipher_type_t srtp_aes_gcm_128_openssl;
 extern srtp_cipher_type_t srtp_aes_gcm_256_openssl;
 #endif
 
+/* debug modules for cipher types */
+extern srtp_debug_module_t srtp_mod_aes_icm;
+#ifdef OPENSSL
+extern srtp_debug_module_t srtp_mod_aes_gcm;
+#endif
 
 /*
  * auth func types that can be included in the kernel
@@ -89,6 +94,9 @@ extern srtp_cipher_type_t srtp_aes_gcm_256_openssl;
 
 extern srtp_auth_type_t srtp_null_auth;
 extern srtp_auth_type_t srtp_hmac;
+
+/* debug modules for auth types */
+extern srtp_debug_module_t srtp_mod_hmac;
 
 /* crypto_kernel is a global variable, the only one of its datatype */
 
@@ -152,6 +160,10 @@ srtp_err_status_t srtp_crypto_kernel_init ()
     if (status) {
         return status;
     }
+    status = srtp_crypto_kernel_load_debug_module(&srtp_mod_aes_icm);
+    if (status) {
+        return status;
+    }
 #ifdef OPENSSL
 #ifndef SRTP_NO_AES192
     status = srtp_crypto_kernel_load_cipher_type(&srtp_aes_icm_192, SRTP_AES_192_ICM);
@@ -171,6 +183,10 @@ srtp_err_status_t srtp_crypto_kernel_init ()
     if (status) {
         return status;
     }
+    status = srtp_crypto_kernel_load_debug_module(&srtp_mod_aes_gcm);
+    if (status) {
+        return status;
+    }
 #endif
 
     /* load auth func types */
@@ -179,6 +195,10 @@ srtp_err_status_t srtp_crypto_kernel_init ()
         return status;
     }
     status = srtp_crypto_kernel_load_auth_type(&srtp_hmac, SRTP_HMAC_SHA1);
+    if (status) {
+        return status;
+    }
+    status = srtp_crypto_kernel_load_debug_module(&srtp_mod_hmac);
     if (status) {
         return status;
     }
@@ -354,12 +374,6 @@ static inline srtp_err_status_t srtp_crypto_kernel_do_load_cipher_type (const sr
     new_ctype->cipher_type = new_ct;
     new_ctype->id = id;
 
-    /* load debug module, if there is one present */
-    if (new_ct->debug != NULL) {
-        srtp_crypto_kernel_load_debug_module(new_ct->debug);
-    }
-    /* we could check for errors here */
-
     return srtp_err_status_ok;
 }
 
@@ -428,12 +442,6 @@ srtp_err_status_t srtp_crypto_kernel_do_load_auth_type (const srtp_auth_type_t *
     /* set fields */
     new_atype->auth_type = new_at;
     new_atype->id = id;
-
-    /* load debug module, if there is one present */
-    if (new_at->debug != NULL) {
-        srtp_crypto_kernel_load_debug_module(new_at->debug);
-    }
-    /* we could check for errors here */
 
     return srtp_err_status_ok;
 

--- a/crypto/test/cipher_driver.c
+++ b/crypto/test/cipher_driver.c
@@ -386,7 +386,7 @@ cipher_driver_test_buffering(srtp_cipher_t *c) {
     }
     
     /* initialize cipher  */
-    status = srtp_cipher_set_iv(c, (uint8_t*)idx, direction_encrypt);
+    status = srtp_cipher_set_iv(c, (uint8_t*)idx, srtp_direction_encrypt);
     if (status)
       return status;
 
@@ -396,7 +396,7 @@ cipher_driver_test_buffering(srtp_cipher_t *c) {
       return status;
 
     /* re-initialize cipher */
-    status = srtp_cipher_set_iv(c, (uint8_t*)idx, direction_encrypt);
+    status = srtp_cipher_set_iv(c, (uint8_t*)idx, srtp_direction_encrypt);
     if (status)
       return status;
     
@@ -557,7 +557,7 @@ cipher_array_bits_per_second(srtp_cipher_t *cipher_array[], int num_cipher,
     unsigned octets_to_encrypt = octets_in_buffer;
 
     /* encrypt buffer with cipher */
-    srtp_cipher_set_iv(cipher_array[cipher_index], (uint8_t*)&nonce, direction_encrypt);
+    srtp_cipher_set_iv(cipher_array[cipher_index], (uint8_t*)&nonce, srtp_direction_encrypt);
     srtp_cipher_encrypt(cipher_array[cipher_index], enc_buf, &octets_to_encrypt);
 
     /* choose a cipher at random from the array*/

--- a/crypto/test/stat_driver.c
+++ b/crypto/test/stat_driver.c
@@ -118,7 +118,7 @@ main (int argc, char *argv[]) {
     buffer[i] = 0;
   err_check(srtp_cipher_type_alloc(&srtp_aes_icm, &c, 30, 0));
   err_check(srtp_cipher_init(c, key));
-  err_check(srtp_cipher_set_iv(c, (uint8_t*)&nonce, direction_encrypt));
+  err_check(srtp_cipher_set_iv(c, (uint8_t*)&nonce, srtp_direction_encrypt));
   err_check(srtp_cipher_encrypt(c, buffer, &buf_len));
   /* run tests on cipher outout */
   printf("monobit %d\n", stat_test_monobit(buffer));
@@ -133,7 +133,7 @@ main (int argc, char *argv[]) {
     for (i=0; i < 2500; i++)
       buffer[i] = 0;
     nonce.v32[3] = i;
-    err_check(srtp_cipher_set_iv(c, (uint8_t*)&nonce, direction_encrypt));
+    err_check(srtp_cipher_set_iv(c, (uint8_t*)&nonce, srtp_direction_encrypt));
     err_check(srtp_cipher_encrypt(c, buffer, &buf_len));
     if (stat_test_runs(buffer)) {
       num_fail++;
@@ -152,7 +152,7 @@ main (int argc, char *argv[]) {
     buffer[i] = 0;
   err_check(srtp_cipher_type_alloc(&srtp_aes_icm, &c, 46, 0));
   err_check(srtp_cipher_init(c, key));
-  err_check(srtp_cipher_set_iv(c, (uint8_t*)&nonce, direction_encrypt));
+  err_check(srtp_cipher_set_iv(c, (uint8_t*)&nonce, srtp_direction_encrypt));
   err_check(srtp_cipher_encrypt(c, buffer, &buf_len));
   /* run tests on cipher outout */
   printf("monobit %d\n", stat_test_monobit(buffer));
@@ -167,7 +167,7 @@ main (int argc, char *argv[]) {
     for (i=0; i < 2500; i++)
       buffer[i] = 0;
     nonce.v32[3] = i;
-    err_check(srtp_cipher_set_iv(c, (uint8_t*)&nonce, direction_encrypt));
+    err_check(srtp_cipher_set_iv(c, (uint8_t*)&nonce, srtp_direction_encrypt));
     err_check(srtp_cipher_encrypt(c, buffer, &buf_len));
     if (stat_test_runs(buffer)) {
       num_fail++;
@@ -183,7 +183,7 @@ main (int argc, char *argv[]) {
     }
     err_check(srtp_cipher_type_alloc(&srtp_aes_gcm_128_openssl, &c, SRTP_AES_128_GCM_KEYSIZE_WSALT, 8));
     err_check(srtp_cipher_init(c, key));
-    err_check(srtp_cipher_set_iv(c, (uint8_t*)&nonce, direction_encrypt));
+    err_check(srtp_cipher_set_iv(c, (uint8_t*)&nonce, srtp_direction_encrypt));
     err_check(srtp_cipher_encrypt(c, buffer, &buf_len));
     /* run tests on cipher outout */
     printf("monobit %d\n", stat_test_monobit(buffer));
@@ -197,7 +197,7 @@ main (int argc, char *argv[]) {
 	    buffer[i] = 0;
 	}
 	nonce.v32[3] = i;
-	err_check(srtp_cipher_set_iv(c, (uint8_t*)&nonce, direction_encrypt));
+	err_check(srtp_cipher_set_iv(c, (uint8_t*)&nonce, srtp_direction_encrypt));
 	err_check(srtp_cipher_encrypt(c, buffer, &buf_len));
 	buf_len = 2500;
 	if (stat_test_runs(buffer)) {
@@ -212,7 +212,7 @@ main (int argc, char *argv[]) {
     }
     err_check(srtp_cipher_type_alloc(&srtp_aes_gcm_256_openssl, &c, SRTP_AES_256_GCM_KEYSIZE_WSALT, 16));
     err_check(srtp_cipher_init(c, key));
-    err_check(srtp_cipher_set_iv(c, (uint8_t*)&nonce, direction_encrypt));
+    err_check(srtp_cipher_set_iv(c, (uint8_t*)&nonce, srtp_direction_encrypt));
     err_check(srtp_cipher_encrypt(c, buffer, &buf_len));
     /* run tests on cipher outout */
     printf("monobit %d\n", stat_test_monobit(buffer));
@@ -226,7 +226,7 @@ main (int argc, char *argv[]) {
 	    buffer[i] = 0;
 	}
 	nonce.v32[3] = i;
-	err_check(srtp_cipher_set_iv(c, (uint8_t*)&nonce, direction_encrypt));
+	err_check(srtp_cipher_set_iv(c, (uint8_t*)&nonce, srtp_direction_encrypt));
 	err_check(srtp_cipher_encrypt(c, buffer, &buf_len));
 	buf_len = 2500;
 	if (stat_test_runs(buffer)) {

--- a/srtp/srtp.c
+++ b/srtp/srtp.c
@@ -154,7 +154,7 @@ srtp_stream_free(srtp_stream_ctx_t *str) {
     srtp_crypto_free(str->enc_xtn_hdr);
   }
   if (str->rtcp_auth) {
-    auth_dealloc(str->rtcp_auth);
+    srtp_auth_dealloc(str->rtcp_auth);
   }
   if (str->rtcp_cipher) {
     srtp_cipher_dealloc(str->rtcp_cipher);
@@ -163,7 +163,7 @@ srtp_stream_free(srtp_stream_ctx_t *str) {
     srtp_crypto_free(str->limit);
   }
   if (str->rtp_auth) {
-    auth_dealloc(str->rtp_auth);
+    srtp_auth_dealloc(str->rtp_auth);
   }
   if (str->rtp_cipher) {
     srtp_cipher_dealloc(str->rtp_cipher);
@@ -321,7 +321,7 @@ srtp_stream_dealloc(srtp_stream_ctx_t *stream, srtp_stream_ctx_t *stream_templat
       && stream->rtp_auth == stream_template->rtp_auth) {
     /* do nothing */
   } else {
-    status = auth_dealloc(stream->rtp_auth);
+    status = srtp_auth_dealloc(stream->rtp_auth);
     if (status)
       return status;
   }
@@ -364,7 +364,7 @@ srtp_stream_dealloc(srtp_stream_ctx_t *stream, srtp_stream_ctx_t *stream_templat
       && stream->rtcp_auth == stream_template->rtcp_auth) {
     /* do nothing */
   } else {
-    status = auth_dealloc(stream->rtcp_auth);
+    status = srtp_auth_dealloc(stream->rtcp_auth);
     if (status)
       return status;
   }
@@ -607,7 +607,7 @@ static srtp_err_status_t srtp_kdf_generate(srtp_kdf_t *kdf, srtp_prf_label label
     v128_set_to_zero(&nonce);
     nonce.v8[7] = label;
  
-    status = srtp_cipher_set_iv(kdf->cipher, (uint8_t*)&nonce, direction_encrypt);
+    status = srtp_cipher_set_iv(kdf->cipher, (uint8_t*)&nonce, srtp_direction_encrypt);
     if (status) return status;
   
     /* generate keystream output */
@@ -849,7 +849,7 @@ srtp_stream_init_keys(srtp_stream_ctx_t *srtp, const void *key) {
 				      srtp_auth_get_key_length(srtp->rtp_auth))); 
 
   /* initialize auth function */
-  stat = auth_init(srtp->rtp_auth, tmp_key);
+  stat = srtp_auth_init(srtp->rtp_auth, tmp_key);
   if (stat) {
     /* zeroize temp buffer */
     octet_string_set_to_zero(tmp_key, MAX_SRTP_KEY_LEN);
@@ -920,7 +920,7 @@ srtp_stream_init_keys(srtp_stream_ctx_t *srtp, const void *key) {
 		     srtp_auth_get_key_length(srtp->rtcp_auth))); 
 
   /* initialize auth function */
-  stat = auth_init(srtp->rtcp_auth, tmp_key);
+  stat = srtp_auth_init(srtp->rtcp_auth, tmp_key);
   if (stat) {
     /* zeroize temp buffer */
     octet_string_set_to_zero(tmp_key, MAX_SRTP_KEY_LEN);
@@ -1348,12 +1348,12 @@ srtp_protect_aead (srtp_ctx_t *ctx, srtp_stream_ctx_t *stream,
     est = be64_to_cpu(est << 16);
 #endif
 
-    status = srtp_cipher_set_iv(stream->rtp_cipher, (uint8_t*)&iv, direction_encrypt);
+    status = srtp_cipher_set_iv(stream->rtp_cipher, (uint8_t*)&iv, srtp_direction_encrypt);
     if (!status && stream->rtp_xtn_hdr_cipher) {
       iv.v32[0] = 0;
       iv.v32[1] = hdr->ssrc;
       iv.v64[1] = est;
-      status = srtp_cipher_set_iv(stream->rtp_xtn_hdr_cipher, (uint8_t*)&iv, direction_encrypt);
+      status = srtp_cipher_set_iv(stream->rtp_xtn_hdr_cipher, (uint8_t*)&iv, srtp_direction_encrypt);
     }
     if (status) {
         return srtp_err_status_cipher_fail;
@@ -1436,7 +1436,7 @@ srtp_unprotect_aead (srtp_ctx_t *ctx, srtp_stream_ctx_t *stream, int delta,
      * AEAD uses a new IV formation method 
      */
     srtp_calc_aead_iv(stream, &iv, &est, hdr);
-    status = srtp_cipher_set_iv(stream->rtp_cipher, (uint8_t*)&iv, direction_decrypt);
+    status = srtp_cipher_set_iv(stream->rtp_cipher, (uint8_t*)&iv, srtp_direction_decrypt);
     if (!status && stream->rtp_xtn_hdr_cipher) {
       iv.v32[0] = 0;
       iv.v32[1] = hdr->ssrc;
@@ -1446,7 +1446,7 @@ srtp_unprotect_aead (srtp_ctx_t *ctx, srtp_stream_ctx_t *stream, int delta,
 #else
       iv.v64[1] = be64_to_cpu(est << 16);
 #endif
-      status = srtp_cipher_set_iv(stream->rtp_xtn_hdr_cipher, (uint8_t*)&iv, direction_encrypt);
+      status = srtp_cipher_set_iv(stream->rtp_xtn_hdr_cipher, (uint8_t*)&iv, srtp_direction_encrypt);
     }
     if (status) {
         return srtp_err_status_cipher_fail;
@@ -1760,9 +1760,9 @@ srtp_unprotect_aead (srtp_ctx_t *ctx, srtp_stream_ctx_t *stream, int delta,
 #else
      iv.v64[1] = be64_to_cpu(est << 16);
 #endif
-     status = srtp_cipher_set_iv(stream->rtp_cipher, (uint8_t*)&iv, direction_encrypt);
+     status = srtp_cipher_set_iv(stream->rtp_cipher, (uint8_t*)&iv, srtp_direction_encrypt);
      if (!status && stream->rtp_xtn_hdr_cipher) {
-       status = srtp_cipher_set_iv(stream->rtp_xtn_hdr_cipher, (uint8_t*)&iv, direction_encrypt);
+       status = srtp_cipher_set_iv(stream->rtp_xtn_hdr_cipher, (uint8_t*)&iv, srtp_direction_encrypt);
      }
    } else {  
      v128_t iv;
@@ -1775,9 +1775,9 @@ srtp_unprotect_aead (srtp_ctx_t *ctx, srtp_stream_ctx_t *stream, int delta,
      iv.v64[0] = 0;
 #endif
      iv.v64[1] = be64_to_cpu(est);
-     status = srtp_cipher_set_iv(stream->rtp_cipher, (uint8_t*)&iv, direction_encrypt);
+     status = srtp_cipher_set_iv(stream->rtp_cipher, (uint8_t*)&iv, srtp_direction_encrypt);
      if (!status && stream->rtp_xtn_hdr_cipher) {
-       status = srtp_cipher_set_iv(stream->rtp_xtn_hdr_cipher, (uint8_t*)&iv, direction_encrypt);
+       status = srtp_cipher_set_iv(stream->rtp_xtn_hdr_cipher, (uint8_t*)&iv, srtp_direction_encrypt);
      }
    }
    if (status)
@@ -1833,17 +1833,17 @@ srtp_unprotect_aead (srtp_ctx_t *ctx, srtp_stream_ctx_t *stream, int delta,
   if (auth_start) {        
 
     /* initialize auth func context */
-    status = auth_start(stream->rtp_auth);
+    status = srtp_auth_start(stream->rtp_auth);
     if (status) return status;
 
     /* run auth func over packet */
-    status = auth_update(stream->rtp_auth, 
+    status = srtp_auth_update(stream->rtp_auth,
 			 (uint8_t *)auth_start, *pkt_octet_len);
     if (status) return status;
     
     /* run auth func over ROC, put result into auth_tag */
     debug_print(mod_srtp, "estimated packet index: %016llx", est);
-    status = auth_compute(stream->rtp_auth, (uint8_t *)&est, 4, auth_tag); 
+    status = srtp_auth_compute(stream->rtp_auth, (uint8_t *)&est, 4, auth_tag);
     debug_print(mod_srtp, "srtp auth tag:    %s", 
 		srtp_octet_string_hex_string(auth_tag, tag_len));
     if (status)
@@ -1968,9 +1968,9 @@ srtp_unprotect(srtp_ctx_t *ctx, void *srtp_hdr, int *pkt_octet_len) {
 #else
     iv.v64[1] = be64_to_cpu(est << 16);
 #endif
-    status = srtp_cipher_set_iv(stream->rtp_cipher, (uint8_t*)&iv, direction_decrypt);
+    status = srtp_cipher_set_iv(stream->rtp_cipher, (uint8_t*)&iv, srtp_direction_decrypt);
     if (!status && stream->rtp_xtn_hdr_cipher) {
-      status = srtp_cipher_set_iv(stream->rtp_xtn_hdr_cipher, (uint8_t*)&iv, direction_decrypt);
+      status = srtp_cipher_set_iv(stream->rtp_xtn_hdr_cipher, (uint8_t*)&iv, srtp_direction_decrypt);
     }
   } else {  
     
@@ -1982,9 +1982,9 @@ srtp_unprotect(srtp_ctx_t *ctx, void *srtp_hdr, int *pkt_octet_len) {
     iv.v64[0] = 0;
 #endif
     iv.v64[1] = be64_to_cpu(est);
-    status = srtp_cipher_set_iv(stream->rtp_cipher, (uint8_t*)&iv, direction_decrypt);
+    status = srtp_cipher_set_iv(stream->rtp_cipher, (uint8_t*)&iv, srtp_direction_decrypt);
     if (!status && stream->rtp_xtn_hdr_cipher) {
-      status = srtp_cipher_set_iv(stream->rtp_xtn_hdr_cipher, (uint8_t*)&iv, direction_decrypt);
+      status = srtp_cipher_set_iv(stream->rtp_xtn_hdr_cipher, (uint8_t*)&iv, srtp_direction_decrypt);
     }
   }
   if (status)
@@ -2058,15 +2058,15 @@ srtp_unprotect(srtp_ctx_t *ctx, void *srtp_hdr, int *pkt_octet_len) {
     } 
 
     /* initialize auth func context */
-    status = auth_start(stream->rtp_auth);
+    status = srtp_auth_start(stream->rtp_auth);
     if (status) return status;
  
     /* now compute auth function over packet */
-    status = auth_update(stream->rtp_auth, (uint8_t *)auth_start,  
+    status = srtp_auth_update(stream->rtp_auth, (uint8_t *)auth_start,
 			 *pkt_octet_len - tag_len);
 
     /* run auth func over ROC, then write tmp tag */
-    status = auth_compute(stream->rtp_auth, (uint8_t *)&est, 4, tmp_tag);  
+    status = srtp_auth_compute(stream->rtp_auth, (uint8_t *)&est, 4, tmp_tag);
 
     debug_print(mod_srtp, "computed auth tag:    %s", 
 		srtp_octet_string_hex_string(tmp_tag, tag_len));
@@ -2958,7 +2958,7 @@ srtp_protect_rtcp_aead (srtp_t ctx, srtp_stream_ctx_t *stream,
      * Calculating the IV and pass it down to the cipher 
      */
     srtp_calc_aead_iv_srtcp(stream, &iv, seq_num, hdr);
-    status = srtp_cipher_set_iv(stream->rtcp_cipher, (uint8_t*)&iv, direction_encrypt);
+    status = srtp_cipher_set_iv(stream->rtcp_cipher, (uint8_t*)&iv, srtp_direction_encrypt);
     if (status) {
         return srtp_err_status_cipher_fail;
     }
@@ -3103,7 +3103,7 @@ srtp_unprotect_rtcp_aead (srtp_t ctx, srtp_stream_ctx_t *stream,
      * Calculate and set the IV
      */
     srtp_calc_aead_iv_srtcp(stream, &iv, seq_num, hdr);
-    status = srtp_cipher_set_iv(stream->rtcp_cipher, (uint8_t*)&iv, direction_decrypt);
+    status = srtp_cipher_set_iv(stream->rtcp_cipher, (uint8_t*)&iv, srtp_direction_decrypt);
     if (status) {
         return srtp_err_status_cipher_fail;
     }
@@ -3346,7 +3346,7 @@ srtp_protect_rtcp(srtp_t ctx, void *rtcp_hdr, int *pkt_octet_len) {
     iv.v32[1] = hdr->ssrc;  /* still in network order! */
     iv.v32[2] = htonl(seq_num >> 16);
     iv.v32[3] = htonl(seq_num << 16);
-    status = srtp_cipher_set_iv(stream->rtcp_cipher, (uint8_t*)&iv, direction_encrypt);
+    status = srtp_cipher_set_iv(stream->rtcp_cipher, (uint8_t*)&iv, srtp_direction_encrypt);
 
   } else {  
     v128_t iv;
@@ -3356,7 +3356,7 @@ srtp_protect_rtcp(srtp_t ctx, void *rtcp_hdr, int *pkt_octet_len) {
     iv.v32[1] = 0;
     iv.v32[2] = 0;
     iv.v32[3] = htonl(seq_num);
-    status = srtp_cipher_set_iv(stream->rtcp_cipher, (uint8_t*)&iv, direction_encrypt);
+    status = srtp_cipher_set_iv(stream->rtcp_cipher, (uint8_t*)&iv, srtp_direction_encrypt);
   }
   if (status)
     return srtp_err_status_cipher_fail;
@@ -3389,13 +3389,13 @@ srtp_protect_rtcp(srtp_t ctx, void *rtcp_hdr, int *pkt_octet_len) {
   }
 
   /* initialize auth func context */
-  auth_start(stream->rtcp_auth);
+  srtp_auth_start(stream->rtcp_auth);
 
   /* 
    * run auth func over packet (including trailer), and write the
    * result at auth_tag 
    */
-  status = auth_compute(stream->rtcp_auth, 
+  status = srtp_auth_compute(stream->rtcp_auth,
 			(uint8_t *)auth_start, 
 			(*pkt_octet_len) + sizeof(srtcp_trailer_t), 
 			auth_tag);
@@ -3567,7 +3567,7 @@ srtp_unprotect_rtcp(srtp_t ctx, void *srtcp_hdr, int *pkt_octet_len) {
     iv.v32[1] = hdr->ssrc; /* still in network order! */
     iv.v32[2] = htonl(seq_num >> 16);
     iv.v32[3] = htonl(seq_num << 16);
-    status = srtp_cipher_set_iv(stream->rtcp_cipher, (uint8_t*)&iv, direction_decrypt);
+    status = srtp_cipher_set_iv(stream->rtcp_cipher, (uint8_t*)&iv, srtp_direction_decrypt);
 
   } else {  
     v128_t iv;
@@ -3577,17 +3577,17 @@ srtp_unprotect_rtcp(srtp_t ctx, void *srtcp_hdr, int *pkt_octet_len) {
     iv.v32[1] = 0;
     iv.v32[2] = 0;
     iv.v32[3] = htonl(seq_num);
-    status = srtp_cipher_set_iv(stream->rtcp_cipher, (uint8_t*)&iv, direction_decrypt);
+    status = srtp_cipher_set_iv(stream->rtcp_cipher, (uint8_t*)&iv, srtp_direction_decrypt);
 
   }
   if (status)
     return srtp_err_status_cipher_fail;
 
   /* initialize auth func context */
-  auth_start(stream->rtcp_auth);
+  srtp_auth_start(stream->rtcp_auth);
 
   /* run auth func over packet, put result into tmp_tag */
-  status = auth_compute(stream->rtcp_auth, (uint8_t *)auth_start,  
+  status = srtp_auth_compute(stream->rtcp_auth, (uint8_t *)auth_start,
 			auth_len, tmp_tag);
   debug_print(mod_srtp, "srtcp computed tag:       %s", 
 	      srtp_octet_string_hex_string(tmp_tag, tag_len));


### PR DESCRIPTION
This set of patches resolves Issue #200 -- it makes the replace_cipher and replace_auth functions public again, while excluding srtp crypto functions which should be internal from the published headers, and making sure all the symbols which are now made public are properly prefixed with "srtp_" prefixes.

There are some other cleanups along the way as well, hopefully explained in each patch. The patches should all be self-contained and self-explanatory.