### PR TITLE
Add an explicit cast to avoid a printf format warning on macOS

### DIFF
--- a/test/rtp_decoder.c
+++ b/test/rtp_decoder.c
@@ -475,7 +475,7 @@ rtp_decoder_handle_pkt(u_char *arg, const struct pcap_pkthdr *hdr,
     return;
   }
   timersub(&hdr->ts, &dcdr->start_tv, &delta);
-  fprintf(stdout, "%02ld:%02ld.%06lu\n", delta.tv_sec/60, delta.tv_sec%60, delta.tv_usec);
+  fprintf(stdout, "%02ld:%02ld.%06ld\n", delta.tv_sec/60, delta.tv_sec%60, (long)delta.tv_usec);
   hexdump(&dcdr->message, pktsize);
 }
 


### PR DESCRIPTION
suseconds_t isn't required to be type long (on macOS it's int), so explicitly cast to long avoid a format specifier warning.