### PR TITLE
OpenSSL crypto performance improvements

### DIFF
--- a/crypto/cipher/aes_icm_ossl.c
+++ b/crypto/cipher/aes_icm_ossl.c
@@ -214,6 +214,8 @@ static srtp_err_status_t srtp_aes_icm_openssl_dealloc (srtp_cipher_t *c)
  */
 static srtp_err_status_t srtp_aes_icm_openssl_context_init (srtp_aes_icm_ctx_t *c, const uint8_t *key)
 {
+    const EVP_CIPHER *evp;
+
     /*
      * set counter and initial values to 'offset' value, being careful not to
      * go past the end of the key buffer
@@ -227,51 +229,10 @@ static srtp_err_status_t srtp_aes_icm_openssl_context_init (srtp_aes_icm_ctx_t *
     c->offset.v8[SRTP_SALT_SIZE] = c->offset.v8[SRTP_SALT_SIZE + 1] = 0;
     c->counter.v8[SRTP_SALT_SIZE] = c->counter.v8[SRTP_SALT_SIZE + 1] = 0;
 
-    /* copy key to be used later when CiscoSSL crypto context is created */
-    v128_copy_octet_string((v128_t*)&c->key, key);
-
-    /* if the key is greater than 16 bytes, copy the second
-     * half.  Note, we treat AES-192 and AES-256 the same here
-     * for simplicity.  The storage location receiving the
-     * key is statically allocated to handle a full 32 byte key
-     * regardless of the cipher in use.
-     */
-    if (c->key_size == SRTP_AES_256_KEYSIZE || 
-#ifndef SRTP_NO_AES192
-	    c->key_size == SRTP_AES_192_KEYSIZE
-#endif
-	    ) {
-        debug_print(srtp_mod_aes_icm, "Copying last 16 bytes of key: %s",
-                    v128_hex_string((v128_t*)(key + SRTP_AES_128_KEYSIZE)));
-        v128_copy_octet_string(((v128_t*)(&c->key.v8)) + 1, key + SRTP_AES_128_KEYSIZE);
-    }
-
-    debug_print(srtp_mod_aes_icm, "key:  %s", v128_hex_string((v128_t*)&c->key));
+    debug_print(srtp_mod_aes_icm, "key:  %s", srtp_octet_string_hex_string(key, c->key_size));
     debug_print(srtp_mod_aes_icm, "offset: %s", v128_hex_string(&c->offset));
 
-    EVP_CIPHER_CTX_cleanup(&c->ctx);
-
-    return srtp_err_status_ok;
-}
-
-
-/*
- * aes_icm_set_iv(c, iv) sets the counter value to the exor of iv with
- * the offset
- */
-static srtp_err_status_t srtp_aes_icm_openssl_set_iv (srtp_aes_icm_ctx_t *c, uint8_t *iv, int dir)
-{
-    const EVP_CIPHER *evp;
-    v128_t nonce;
-
-    /* set nonce (for alignment) */
-    v128_copy_octet_string(&nonce, iv);
-
-    debug_print(srtp_mod_aes_icm, "setting iv: %s", v128_hex_string(&nonce));
-
-    v128_xor(&c->counter, &c->offset, &nonce);
-
-    debug_print(srtp_mod_aes_icm, "set_counter: %s", v128_hex_string(&c->counter));
+    EVP_CIPHER_CTX_init(&c->ctx);
 
     switch (c->key_size) {
     case SRTP_AES_256_KEYSIZE:
@@ -291,7 +252,35 @@ static srtp_err_status_t srtp_aes_icm_openssl_set_iv (srtp_aes_icm_ctx_t *c, uin
     }
 
     if (!EVP_EncryptInit_ex(&c->ctx, evp,
-                            NULL, c->key.v8, c->counter.v8)) {
+                            NULL, key, NULL)) {
+        return srtp_err_status_fail;
+    } else {
+        return srtp_err_status_ok;
+    }
+
+    return srtp_err_status_ok;
+}
+
+
+/*
+ * aes_icm_set_iv(c, iv) sets the counter value to the exor of iv with
+ * the offset
+ */
+static srtp_err_status_t srtp_aes_icm_openssl_set_iv (srtp_aes_icm_ctx_t *c, uint8_t *iv, int dir)
+{
+    v128_t nonce;
+
+    /* set nonce (for alignment) */
+    v128_copy_octet_string(&nonce, iv);
+
+    debug_print(srtp_mod_aes_icm, "setting iv: %s", v128_hex_string(&nonce));
+
+    v128_xor(&c->counter, &c->offset, &nonce);
+
+    debug_print(srtp_mod_aes_icm, "set_counter: %s", v128_hex_string(&c->counter));
+
+    if (!EVP_EncryptInit_ex(&c->ctx, NULL,
+                            NULL, NULL, c->counter.v8)) {
         return srtp_err_status_fail;
     } else {
         return srtp_err_status_ok;

--- a/crypto/hash/hmac_ossl.c
+++ b/crypto/hash/hmac_ossl.c
@@ -102,6 +102,10 @@ static srtp_err_status_t srtp_hmac_dealloc (srtp_auth_t *a)
 
     HMAC_CTX_cleanup(hmac_ctx);
 
+    /* zeroize entire state*/
+    octet_string_set_to_zero((uint8_t*)a,
+                             sizeof(HMAC_CTX) + sizeof(srtp_auth_t));
+
     /* free memory */
     srtp_crypto_free(a);
 

--- a/crypto/hash/hmac_ossl.c
+++ b/crypto/hash/hmac_ossl.c
@@ -46,11 +46,12 @@
     #include <config.h>
 #endif
 
-#include "hmac.h"
+#include "auth.h"
 #include "alloc.h"
 #include <openssl/evp.h>
+#include <openssl/hmac.h>
 
-#define HMAC_KEYLEN_MAX		20
+#define SHA1_DIGEST_SIZE		20
 
 /* the debug module for authentiation */
 
@@ -64,26 +65,18 @@ static srtp_err_status_t srtp_hmac_alloc (srtp_auth_t **a, int key_len, int out_
 {
     extern const srtp_auth_type_t srtp_hmac;
     uint8_t *pointer;
-    srtp_hmac_ctx_t *new_hmac_ctx;
+    HMAC_CTX *new_hmac_ctx;
 
     debug_print(srtp_mod_hmac, "allocating auth func with key length %d", key_len);
     debug_print(srtp_mod_hmac, "                          tag length %d", out_len);
 
-    /*
-     * check key length - note that we don't support keys larger
-     * than 20 bytes yet
-     */
-    if (key_len > HMAC_KEYLEN_MAX) {
-        return srtp_err_status_bad_param;
-    }
-
     /* check output length - should be less than 20 bytes */
-    if (out_len > HMAC_KEYLEN_MAX) {
+    if (out_len > SHA1_DIGEST_SIZE) {
         return srtp_err_status_bad_param;
     }
 
-    /* allocate memory for auth and srtp_hmac_ctx_t structures */
-    pointer = (uint8_t*)srtp_crypto_alloc(sizeof(srtp_hmac_ctx_t) + sizeof(srtp_auth_t));
+    /* allocate memory for auth and HMAC_CTX structures */
+    pointer = (uint8_t*)srtp_crypto_alloc(sizeof(HMAC_CTX) + sizeof(srtp_auth_t));
     if (pointer == NULL) {
         return srtp_err_status_alloc_fail;
     }
@@ -95,27 +88,19 @@ static srtp_err_status_t srtp_hmac_alloc (srtp_auth_t **a, int key_len, int out_
     (*a)->out_len = out_len;
     (*a)->key_len = key_len;
     (*a)->prefix_len = 0;
-    new_hmac_ctx = (srtp_hmac_ctx_t*)((*a)->state);
-    memset(new_hmac_ctx, 0, sizeof(srtp_hmac_ctx_t));
+    new_hmac_ctx = (HMAC_CTX*)((*a)->state);
+    HMAC_CTX_init(new_hmac_ctx);
 
     return srtp_err_status_ok;
 }
 
 static srtp_err_status_t srtp_hmac_dealloc (srtp_auth_t *a)
 {
-    srtp_hmac_ctx_t *hmac_ctx;
+    HMAC_CTX *hmac_ctx;
 
-    hmac_ctx = (srtp_hmac_ctx_t*)a->state;
-    if (hmac_ctx->ctx_initialized) {
-        EVP_MD_CTX_cleanup(&hmac_ctx->ctx);
-    }
-    if (hmac_ctx->init_ctx_initialized) {
-        EVP_MD_CTX_cleanup(&hmac_ctx->init_ctx);
-    }
+    hmac_ctx = (HMAC_CTX*)a->state;
 
-    /* zeroize entire state*/
-    octet_string_set_to_zero((uint8_t*)a,
-                             sizeof(srtp_hmac_ctx_t) + sizeof(srtp_auth_t));
+    HMAC_CTX_cleanup(hmac_ctx);
 
     /* free memory */
     srtp_crypto_free(a);
@@ -123,110 +108,62 @@ static srtp_err_status_t srtp_hmac_dealloc (srtp_auth_t *a)
     return srtp_err_status_ok;
 }
 
-static srtp_err_status_t srtp_hmac_start (srtp_hmac_ctx_t *state)
+static srtp_err_status_t srtp_hmac_start (HMAC_CTX *state)
 {
-    if (state->ctx_initialized) {
-        EVP_MD_CTX_cleanup(&state->ctx);
-    }
-    if (!EVP_MD_CTX_copy(&state->ctx, &state->init_ctx)) {
+    if (HMAC_Init_ex(state, NULL, 0, NULL, NULL) == 0)
         return srtp_err_status_auth_fail;
-    } else {
-        state->ctx_initialized = 1;
-        return srtp_err_status_ok;
-    }
-}
-
-static srtp_err_status_t srtp_hmac_init (srtp_hmac_ctx_t *state, const uint8_t *key, int key_len)
-{
-    int i;
-    uint8_t ipad[64];
-
-    /*
-     * check key length - note that we don't support keys larger
-     * than 20 bytes yet
-     */
-    if (key_len > HMAC_KEYLEN_MAX) {
-        return srtp_err_status_bad_param;
-    }
-
-    /*
-     * set values of ipad and opad by exoring the key into the
-     * appropriate constant values
-     */
-    for (i = 0; i < key_len; i++) {
-        ipad[i] = key[i] ^ 0x36;
-        state->opad[i] = key[i] ^ 0x5c;
-    }
-    /* set the rest of ipad, opad to constant values */
-    for (; i < sizeof(ipad); i++) {
-        ipad[i] = 0x36;
-        ((uint8_t*)state->opad)[i] = 0x5c;
-    }
-
-    debug_print(srtp_mod_hmac, "ipad: %s", srtp_octet_string_hex_string(ipad, sizeof(ipad)));
-
-    /* initialize sha1 context */
-    srtp_sha1_init(&state->init_ctx);
-    state->init_ctx_initialized = 1;
-
-    /* hash ipad ^ key */
-    srtp_sha1_update(&state->init_ctx, ipad, sizeof(ipad));
-    return (srtp_hmac_start(state));
-}
-
-static srtp_err_status_t srtp_hmac_update (srtp_hmac_ctx_t *state, const uint8_t *message, int msg_octets)
-{
-    debug_print(srtp_mod_hmac, "input: %s",
-                srtp_octet_string_hex_string(message, msg_octets));
-
-    /* hash message into sha1 context */
-    srtp_sha1_update(&state->ctx, message, msg_octets);
 
     return srtp_err_status_ok;
 }
 
-static srtp_err_status_t srtp_hmac_compute (srtp_hmac_ctx_t *state, const void *message,
+static srtp_err_status_t srtp_hmac_init (HMAC_CTX *state, const uint8_t *key, int key_len)
+{
+    if (HMAC_Init_ex(state, key, key_len, EVP_sha1(), NULL) == 0)
+        return srtp_err_status_auth_fail;
+
+    return srtp_err_status_ok;
+}
+
+static srtp_err_status_t srtp_hmac_update (HMAC_CTX *state, const uint8_t *message, int msg_octets)
+{
+    debug_print(srtp_mod_hmac, "input: %s",
+                srtp_octet_string_hex_string(message, msg_octets));
+
+    if (HMAC_Update(state, message, msg_octets) == 0)
+        return srtp_err_status_auth_fail;
+
+    return srtp_err_status_ok;
+}
+
+static srtp_err_status_t srtp_hmac_compute (HMAC_CTX *state, const void *message,
               int msg_octets, int tag_len, uint8_t *result)
 {
-    uint32_t hash_value[5];
-    uint32_t H[5];
+    uint8_t hash_value[SHA1_DIGEST_SIZE];
     int i;
+    unsigned int len;
 
     /* check tag length, return error if we can't provide the value expected */
-    if (tag_len > HMAC_KEYLEN_MAX) {
+    if (tag_len > SHA1_DIGEST_SIZE) {
         return srtp_err_status_bad_param;
     }
 
     /* hash message, copy output into H */
-    srtp_sha1_update(&state->ctx, message, msg_octets);
-    srtp_sha1_final(&state->ctx, H);
+    if (HMAC_Update(state, message, msg_octets) == 0)
+        return srtp_err_status_auth_fail;
 
-    /*
-     * note that we don't need to debug_print() the input, since the
-     * function hmac_update() already did that for us
-     */
-    debug_print(srtp_mod_hmac, "intermediate state: %s",
-                srtp_octet_string_hex_string((uint8_t*)H, sizeof(H)));
+    if (HMAC_Final(state, hash_value, &len) == 0)
+        return srtp_err_status_auth_fail;
 
-    /* re-initialize hash context */
-    srtp_sha1_init(&state->ctx);
-
-    /* hash opad ^ key  */
-    srtp_sha1_update(&state->ctx, (uint8_t*)state->opad, sizeof(state->opad));
-
-    /* hash the result of the inner hash */
-    srtp_sha1_update(&state->ctx, (uint8_t*)H, sizeof(H));
-
-    /* the result is returned in the array hash_value[] */
-    srtp_sha1_final(&state->ctx, hash_value);
+    if (len < tag_len)
+        return srtp_err_status_auth_fail;
 
     /* copy hash_value to *result */
     for (i = 0; i < tag_len; i++) {
-        result[i] = ((uint8_t*)hash_value)[i];
+        result[i] = hash_value[i];
     }
 
     debug_print(srtp_mod_hmac, "output: %s",
-                srtp_octet_string_hex_string((uint8_t*)hash_value, tag_len));
+                srtp_octet_string_hex_string(hash_value, tag_len));
 
     return srtp_err_status_ok;
 }
@@ -234,7 +171,7 @@ static srtp_err_status_t srtp_hmac_compute (srtp_hmac_ctx_t *state, const void *
 
 /* begin test case 0 */
 
-static const uint8_t srtp_hmac_test_case_0_key[HMAC_KEYLEN_MAX] = {
+static const uint8_t srtp_hmac_test_case_0_key[SHA1_DIGEST_SIZE] = {
     0x0b, 0x0b, 0x0b, 0x0b, 0x0b, 0x0b, 0x0b, 0x0b,
     0x0b, 0x0b, 0x0b, 0x0b, 0x0b, 0x0b, 0x0b, 0x0b,
     0x0b, 0x0b, 0x0b, 0x0b
@@ -244,7 +181,7 @@ static const uint8_t srtp_hmac_test_case_0_data[8] = {
     0x48, 0x69, 0x20, 0x54, 0x68, 0x65, 0x72, 0x65 /* "Hi There" */
 };
 
-static const uint8_t srtp_hmac_test_case_0_tag[HMAC_KEYLEN_MAX] = {
+static const uint8_t srtp_hmac_test_case_0_tag[SHA1_DIGEST_SIZE] = {
     0xb6, 0x17, 0x31, 0x86, 0x55, 0x05, 0x72, 0x64,
     0xe2, 0x8b, 0xc0, 0xb6, 0xfb, 0x37, 0x8c, 0x8e,
     0xf1, 0x46, 0xbe, 0x00

--- a/crypto/include/aes_gcm_ossl.h
+++ b/crypto/include/aes_gcm_ossl.h
@@ -52,7 +52,6 @@
 #include <openssl/aes.h>
 
 typedef struct {
-    v256_t key;
     int key_size;
     int tag_len;
     EVP_CIPHER_CTX ctx;

--- a/crypto/include/aes_icm_ossl.h
+++ b/crypto/include/aes_icm_ossl.h
@@ -68,7 +68,6 @@
 typedef struct {
     v128_t counter;                /* holds the counter value          */
     v128_t offset;                 /* initial offset value             */
-    v256_t key;
     int key_size;
     EVP_CIPHER_CTX ctx;
 } srtp_aes_icm_ctx_t;

--- a/crypto/include/hmac.h
+++ b/crypto/include/hmac.h
@@ -53,10 +53,6 @@ typedef struct {
     uint8_t opad[64];
     srtp_sha1_ctx_t ctx;
     srtp_sha1_ctx_t init_ctx;
-#ifdef OPENSSL
-    int ctx_initialized;
-    int init_ctx_initialized;
-#endif
 } srtp_hmac_ctx_t;
 
 #endif /* HMAC_H */


### PR DESCRIPTION
The way libsrtp is using OpenSSL crypto is inefficient, causing substantial overhead.

1. For both ICM and GCM, OpenSSL key expansion is being done in srtp_crypto_set_iv, which is called once per packet, rather than in srtp_crypto_init, which is called only once. This has substantial overhead.

2. HMAC-SHA1 isn't using EVP to get the SHA-1 implementation, and so it's not using the best platform-optimized SHA1 implementations.  It also rolls its own HMAC implementation rather than using OpenSSL's.

This patch series fixes both of these issues.  It is directly on top of Master.  Note that it conflicts (syntactically) with my pull request #201 -- see my branch JonathanLennox/libsrtp/ossl_perf_improvements_over_public_crypto for these patches rebased on top of that pull request.


On my MacBook Pro (2.3 GHz Haswell Core i7) this improves the performance of OpenSSL (as reported by srtp_driver -t) as follows.

# AES-128/HMAC-SHA-1:
* rtp cipher:    AES-128 counter mode using openssl
* rtp auth:      hmac sha-1 authentication function
* rtp services:  confidentiality and authentication

```
mesg length (octets)    old throughput (mbps)           new throughput
16                      154.287505                      341.843820
32                      300.592967                      640.592548
64                      557.309241                      1090.707682
128                     985.420777                      1891.567378
256                     1735.107978                     2880.976831
512                     2543.499050                     4033.401607
1024                    3794.384385                     4903.040460
2048                    4526.216918                     5648.019194
```

# AES-GCM-128:
* rtp cipher:    AES-128 GCM using openssl
* rtp auth:      null authentication function
* rtp services:  confidentiality and authentication

```
mesg length (octets)    old throughput (mbps)           new throughput
16                      234.320653                      665.626625
32                      444.591098                      1176.903273
64                      888.580354                      2244.137629
128                     1531.260748                     4354.852428
256                     3226.111339                     7588.557878
512                     5245.297033                     9858.714227
1024                    8371.655732                     15520.442575
2048                    12410.146871                    19804.900456
```
