### PR TITLE
Fix to install-win.bat syntax, and add installation of x64 libraries.

### DIFF
--- a/install-win.bat
+++ b/install-win.bat
@@ -14,7 +14,7 @@
    exit /b 1
 )
 
-@for %%d in (include\srtp.h Debug\srtp.lib Release\srtp.lib) do (
+@for %%d in (include\srtp.h Debug\srtp2.lib Release\srtp2.lib x64\Debug\srtp2.lib x64\Release\srtp2.lib) do (
 	if not exist "%%d" (
 	   echo "%%d not found: are you in the right directory?"
 	   exit /b 1
@@ -24,7 +24,11 @@
 mkdir %destdir%\include
 mkdir %destdir%\include\srtp2
 mkdir %destdir%\lib
+mkdir %destdir%\lib\x64
 
-copy include\srtp.h include\ekt.h %destdir%\include\srtp2
+copy include\srtp.h %destdir%\include\srtp2
+copy include\ekt.h %destdir%\include\srtp2
 copy Release\srtp2.lib %destdir%\lib\srtp2.lib
 copy Debug\srtp2.lib %destdir%\lib\srtp2d.lib
+copy x64\Release\srtp2.lib %destdir%\lib\x64\srtp2.lib
+copy x64\Debug\srtp2.lib %destdir%\lib\x64\srtp2d.lib


### PR DESCRIPTION
Sorry, had a syntax error in .bat syntax (bat file syntax is awful); also, we should install x64 libs now that we're building them.