### PR TITLE
Restore AES-192 under BoringSSL

### DIFF
--- a/crypto/cipher/aes_icm_ossl.c
+++ b/crypto/cipher/aes_icm_ossl.c
@@ -64,9 +64,7 @@ srtp_debug_module_t srtp_mod_aes_icm = {
     "aes icm ossl"   /* printable module name       */
 };
 extern const srtp_cipher_type_t srtp_aes_icm;
-#ifndef SRTP_NO_AES192
 extern const srtp_cipher_type_t srtp_aes_icm_192;
-#endif
 extern const srtp_cipher_type_t srtp_aes_icm_256;
 
 /*
@@ -120,10 +118,7 @@ static srtp_err_status_t srtp_aes_icm_openssl_alloc (srtp_cipher_t **c, int key_
     /*
      * Verify the key_len is valid for one of: AES-128/192/256
      */
-    if (key_len != SRTP_AES_128_KEYSIZE_WSALT &&
-#ifndef SRTP_NO_AES192
-        key_len != SRTP_AES_192_KEYSIZE_WSALT &&
-#endif
+    if (key_len != SRTP_AES_128_KEYSIZE_WSALT && key_len != SRTP_AES_192_KEYSIZE_WSALT &&
         key_len != SRTP_AES_256_KEYSIZE_WSALT) {
         return srtp_err_status_bad_param;
     }
@@ -153,13 +148,11 @@ static srtp_err_status_t srtp_aes_icm_openssl_alloc (srtp_cipher_t **c, int key_
         (*c)->type = &srtp_aes_icm;
         icm->key_size = SRTP_AES_128_KEYSIZE;
         break;
-#ifndef SRTP_NO_AES192
     case SRTP_AES_192_KEYSIZE_WSALT:
         (*c)->algorithm = SRTP_AES_192_ICM;
         (*c)->type = &srtp_aes_icm_192;
         icm->key_size = SRTP_AES_192_KEYSIZE;
         break;
-#endif
     case SRTP_AES_256_KEYSIZE_WSALT:
         (*c)->algorithm = SRTP_AES_256_ICM;
         (*c)->type = &srtp_aes_icm_256;
@@ -239,11 +232,9 @@ static srtp_err_status_t srtp_aes_icm_openssl_context_init (void* cv, const uint
     case SRTP_AES_256_KEYSIZE:
         evp = EVP_aes_256_ctr();
         break;
-#ifndef SRTP_NO_AES192
     case SRTP_AES_192_KEYSIZE:
         evp = EVP_aes_192_ctr();
         break;
-#endif
     case SRTP_AES_128_KEYSIZE:
         evp = EVP_aes_128_ctr();
         break;
@@ -321,9 +312,7 @@ static srtp_err_status_t srtp_aes_icm_openssl_encrypt (void *cv, unsigned char *
  * Name of this crypto engine
  */
 static const char srtp_aes_icm_openssl_description[] = "AES-128 counter mode using openssl";
-#ifndef SRTP_NO_AES192
 static const char srtp_aes_icm_192_openssl_description[] = "AES-192 counter mode using openssl";
-#endif
 static const char srtp_aes_icm_256_openssl_description[] = "AES-256 counter mode using openssl";
 
 
@@ -371,7 +360,6 @@ static const srtp_cipher_test_case_t srtp_aes_icm_test_case_0 = {
     NULL                                   /* pointer to next testcase */
 };
 
-#ifndef SRTP_NO_AES192
 /*
  * KAT values for AES-192-CTR self-test.  These
  * values came from section 7 of RFC 6188.
@@ -416,7 +404,6 @@ static const srtp_cipher_test_case_t srtp_aes_icm_192_test_case_1 = {
     0,
     NULL                                   /* pointer to next testcase */
 };
-#endif
 
 /*
  * KAT values for AES-256-CTR self-test.  These
@@ -482,7 +469,6 @@ const srtp_cipher_type_t srtp_aes_icm = {
     SRTP_AES_ICM
 };
 
-#ifndef SRTP_NO_AES192
 /*
  * This is the function table for this crypto engine.
  * note: the encrypt function is identical to the decrypt function
@@ -500,7 +486,6 @@ const srtp_cipher_type_t srtp_aes_icm_192 = {
     &srtp_aes_icm_192_test_case_1,
     SRTP_AES_192_ICM
 };
-#endif
 
 /*
  * This is the function table for this crypto engine.

--- a/crypto/include/aes_icm_ossl.h
+++ b/crypto/include/aes_icm_ossl.h
@@ -51,20 +51,13 @@
 #include <openssl/evp.h>
 #include <openssl/aes.h>
 
-#ifdef OPENSSL_IS_BORINGSSL
-// BoringSSL doesn't support AES-192, cipher will be disabled
-#define SRTP_NO_AES192
-#endif
-
 #define     SRTP_SALT_SIZE               14
 #define     SRTP_AES_128_KEYSIZE         AES_BLOCK_SIZE
 #define     SRTP_AES_256_KEYSIZE         AES_BLOCK_SIZE * 2
 #define     SRTP_AES_128_KEYSIZE_WSALT   SRTP_AES_128_KEYSIZE + SRTP_SALT_SIZE
 #define     SRTP_AES_256_KEYSIZE_WSALT   SRTP_AES_256_KEYSIZE + SRTP_SALT_SIZE
-#ifndef SRTP_NO_AES192
 #define     SRTP_AES_192_KEYSIZE         AES_BLOCK_SIZE + AES_BLOCK_SIZE / 2
 #define     SRTP_AES_192_KEYSIZE_WSALT   SRTP_AES_192_KEYSIZE + SRTP_SALT_SIZE
-#endif
 
 typedef struct {
     v128_t counter;                /* holds the counter value          */

--- a/crypto/kernel/crypto_kernel.c
+++ b/crypto/kernel/crypto_kernel.c
@@ -74,9 +74,7 @@ extern srtp_debug_module_t mod_alloc;
 extern srtp_cipher_type_t srtp_null_cipher;
 extern srtp_cipher_type_t srtp_aes_icm;
 #ifdef OPENSSL
-#ifndef SRTP_NO_AES192
 extern srtp_cipher_type_t srtp_aes_icm_192;
-#endif
 extern srtp_cipher_type_t srtp_aes_icm_256;
 extern srtp_cipher_type_t srtp_aes_gcm_128_openssl;
 extern srtp_cipher_type_t srtp_aes_gcm_256_openssl;
@@ -165,12 +163,10 @@ srtp_err_status_t srtp_crypto_kernel_init ()
         return status;
     }
 #ifdef OPENSSL
-#ifndef SRTP_NO_AES192
     status = srtp_crypto_kernel_load_cipher_type(&srtp_aes_icm_192, SRTP_AES_192_ICM);
     if (status) {
         return status;
     }
-#endif
     status = srtp_crypto_kernel_load_cipher_type(&srtp_aes_icm_256, SRTP_AES_256_ICM);
     if (status) {
         return status;

--- a/crypto/test/cipher_driver.c
+++ b/crypto/test/cipher_driver.c
@@ -123,9 +123,7 @@ check_status(srtp_err_status_t s) {
 extern srtp_cipher_type_t srtp_null_cipher;
 extern srtp_cipher_type_t srtp_aes_icm;
 #ifdef OPENSSL
-#ifndef SRTP_NO_AES192
 extern srtp_cipher_type_t srtp_aes_icm_192;
-#endif
 extern srtp_cipher_type_t srtp_aes_icm_256;
 extern srtp_cipher_type_t srtp_aes_gcm_128_openssl;
 extern srtp_cipher_type_t srtp_aes_gcm_256_openssl;
@@ -190,11 +188,9 @@ main(int argc, char *argv[]) {
     for (num_cipher=1; num_cipher < max_num_cipher; num_cipher *=8)
       cipher_driver_test_array_throughput(&srtp_aes_icm, 46, num_cipher); 
 #else
-#ifndef SRTP_NO_AES192
     for (num_cipher=1; num_cipher < max_num_cipher; num_cipher *=8)
       cipher_driver_test_array_throughput(&srtp_aes_icm_192, 38, num_cipher); 
 
-#endif
     for (num_cipher=1; num_cipher < max_num_cipher; num_cipher *=8)
       cipher_driver_test_array_throughput(&srtp_aes_icm_256, 46, num_cipher); 
 
@@ -212,9 +208,7 @@ main(int argc, char *argv[]) {
     cipher_driver_self_test(&srtp_null_cipher);
     cipher_driver_self_test(&srtp_aes_icm);
 #ifdef OPENSSL
-#ifndef SRTP_NO_AES192
     cipher_driver_self_test(&srtp_aes_icm_192);
-#endif
     cipher_driver_self_test(&srtp_aes_icm_256);
     cipher_driver_self_test(&srtp_aes_gcm_128_openssl);
     cipher_driver_self_test(&srtp_aes_gcm_256_openssl);


### PR DESCRIPTION
PR #93 added the SRTP_NO_AES192 macro and removed all references to AES-192
if it was set. The goal was to get libsrtp to compile with BoringSSL, which
didn't support AES-192 at the time (Feb 2015).

In the time since (Apr 2015), BoringSSL has restored support for AES-192:
https://boringssl.googlesource.com/boringssl/+/1049e26f
https://boringssl.googlesource.com/boringssl/+/5dca031c

Remove the SRTP_NO_AES192 macro, since it's no longer needed.
Effectively reverts #93.
