### PR TITLE
Changes for OpenSSL 1.1.0 compatibility.

### DIFF
--- a/crypto/include/aes_gcm_ossl.h
+++ b/crypto/include/aes_gcm_ossl.h
@@ -55,7 +55,7 @@
 typedef struct {
     int key_size;
     int tag_len;
-    EVP_CIPHER_CTX ctx;
+    EVP_CIPHER_CTX* ctx;
     srtp_cipher_direction_t dir;
 } srtp_aes_gcm_ctx_t;
 

--- a/crypto/include/aes_icm_ossl.h
+++ b/crypto/include/aes_icm_ossl.h
@@ -70,7 +70,7 @@ typedef struct {
     v128_t counter;                /* holds the counter value          */
     v128_t offset;                 /* initial offset value             */
     int key_size;
-    EVP_CIPHER_CTX ctx;
+    EVP_CIPHER_CTX* ctx;
 } srtp_aes_icm_ctx_t;
 
 #endif /* AES_ICM_H */


### PR DESCRIPTION
Resolve issue #210:

In OpenSSL 1.1.0, EVP_CIPHER_CTX, HMAC_CTX, and EVP_MD_CTX are opaque types, and have
to be allocated with *_new methods and deallocated with *_free.

EVP_CIPHER_CTX_new/free is present in OpenSSL 1.0.1 and later, but HMAC_CTX_new and
EVP_MD_CTX_new are new in OpenSSL 1.1.0.

Use the _new unconditionally for ciphers, and conditionally use the old or new APIs
for HMAC and MD.

No noticible performance change for older OpenSSL.