### PR TITLE
Add cast to `unsigned int` in call to printf in test

### DIFF
--- a/crypto/test/datatypes_driver.c
+++ b/crypto/test/datatypes_driver.c
@@ -227,7 +227,7 @@ test_bswap(void) {
   uint32_t x = 0x11223344;
   uint64_t y = 0x1122334455667788LL;
 
-  printf("before: %0x\nafter:  %0x\n", x, be32_to_cpu(x));
+  printf("before: %0x\nafter:  %0x\n", x, (unsigned int)be32_to_cpu(x));
   printf("before: %0llx\nafter:  %0llx\n", (unsigned long long)y,
 	 (unsigned long long)be64_to_cpu(y));
 


### PR DESCRIPTION
The `%x` format specifier requires an argument of type `unsigned int`.
On Windows, `be32_to_cpu` is defined as `htonl`, which returns `u_long`
(aka `unsigned long`). Even though `unsigned int` and `unsigned long`
are the same size on Windows, clang will complain if `-Wformat` is
enabled.
