### PR TITLE
avoid empty initializer braces, closes #206

### DIFF
--- a/configure.in
+++ b/configure.in
@@ -4,7 +4,7 @@ AC_INIT([libsrtp2], [2.0.0-pre], [https://github.com/cisco/libsrtp/issues])
 dnl Must come before AC_PROG_CC
 if test -z "$CFLAGS"; then
    dnl Default value for CFLAGS if not specified.
-   CFLAGS="-Wall -O4 -fexpensive-optimizations -funroll-loops"
+   CFLAGS="-Wall -pedantic -O4 -fexpensive-optimizations -funroll-loops"
 fi
 
 dnl Checks for programs.

--- a/test/util.c
+++ b/test/util.c
@@ -143,7 +143,7 @@ static const char b64chars[] = "ABCDEFGHIJKLMNOPQRSTUVWXYZ"
 
 static int base64_block_to_octet_triple (char *out, char *in)
 {
-    unsigned char sextets[4] = {};
+    unsigned char sextets[4] = {0};
     int j = 0;
     int i;
 


### PR DESCRIPTION
Furthermore, I added the GCC flag `-pedantic` to detect such coding issues in future. There are some reports on the Internet, `-pedantic` would set `-std=c90` [aka](https://gcc.gnu.org/onlinedocs/gcc/C-Dialect-Options.html) `-ansi`. In my tests and according the [GCC documentation](https://gcc.gnu.org/onlinedocs/gcc/Warning-Options.html), `-pedantic` even works with the current default of GCC `-std=gnu11`. Consequently, these flags are orthogonal concepts.

By the way as of today, libSRTP requires `-std=gnu99` and does not compile with `-std=c99`, because of some issues in `test/rtpw.c`. I am not sure, if that is intended. Perhaps one day, the expected C standard should be added to the CFLAGS of libSRTP as well.

Finally, I did not run `autoreconf` to generate the latest `./configure` because that was not updated for a while. Should I commit an updated `./configure` script in future as well?
