### PR TITLE
Limited MKI support

### DIFF
--- a/README
+++ b/README
@@ -151,9 +151,9 @@ set master key/salt to C1EEC3717DA76195BB878578790AF71C/4EE9F859E197A414A78D5ABC
 Implementation Notes
 
   * The srtp_protect() function assumes that the buffer holding the
-    rtp packet has enough storage allocated that the authentication 
-    tag can be written to the end of that packet.  If this assumption
-    is not valid, memory corruption will ensue.  
+    rtp packet has enough storage allocated that the authentication
+    tag and optional MKI can be written to the end of that packet.  If
+    this assumption is not valid, memory corruption will ensue.
 
   * Automated tests for the crypto functions are provided through
     the cipher_type_self_test() and auth_type_self_test() functions.
@@ -181,4 +181,10 @@ Implementation Notes
   * The replay window is 128 bits in length, and is hard-coded to this
     value for now.  
 
+  * Although the library has limited support for MKI, and the API appears
+    to support setting up a stream with multiple keys, only a single key
+    can be set.  Any attempt to use more than one key will cause the
+    setup function to return an error code.  (The API needed to change
+    when basic MKI support was added.  It is expected that the API
+    will not have to change again to support multiple keys.)
 

--- a/include/srtp_priv.h
+++ b/include/srtp_priv.h
@@ -75,10 +75,10 @@ srtp_stream_t srtp_get_stream(srtp_t srtp, uint32_t ssrc);
 
 
 /*
- * srtp_stream_init_keys(s, k) (re)initializes the srtp_stream_t s by
- * deriving all of the needed keys using the KDF and the key k.
+ * srtp_stream_init_keys(s, n, k) (re)initializes the srtp_stream_t s by
+ * deriving all of the needed keys using the KDF and the specified keys.
  */
-srtp_err_status_t srtp_stream_init_keys(srtp_stream_t srtp, const void *key);
+srtp_err_status_t srtp_stream_init_keys(srtp_stream_t srtp, int n_keys, unsigned char* const* keys);
 
 /*
  * srtp_stream_init(s, p) initializes the srtp_stream_t s to 
@@ -98,7 +98,7 @@ typedef enum direction_t {
 } direction_t;
 
 /* 
- * an srtp_stream_t has its own SSRC, encryption key, authentication
+ * an srtp_stream_t has its own SSRC, MKI, encryption key, authentication
  * key, sequence number, and replay database
  * 
  * note that the keys might not actually be unique, in which case the
@@ -107,6 +107,8 @@ typedef enum direction_t {
 
 typedef struct srtp_stream_ctx_t_ {
   uint32_t   ssrc;
+  int        mki_len;
+  unsigned char *mki;
   srtp_cipher_t  *rtp_cipher;
   srtp_cipher_t  *rtp_xtn_hdr_cipher;
   srtp_auth_t    *rtp_auth;

--- a/srtp/srtp.c
+++ b/srtp/srtp.c
@@ -220,6 +220,20 @@ srtp_stream_alloc(srtp_stream_ctx_t **str_ptr,
     return srtp_err_status_alloc_fail;
   }
 
+  /* allocate mki */
+  if (p->mki_len) {
+    str->mki = srtp_crypto_alloc(p->mki_len);
+    if (str->mki == NULL) {
+      srtp_auth_dealloc(str->rtp_auth);
+      srtp_cipher_dealloc(str->rtp_cipher);
+      srtp_crypto_free(str->limit);
+      srtp_crypto_free(str);
+      return srtp_err_status_alloc_fail;
+    }
+  } else {
+    str->mki = NULL;
+  }
+
   /*
    * ...and now the RTCP-specific initialization - first, allocate
    * the cipher 
@@ -388,7 +402,17 @@ srtp_stream_dealloc(srtp_stream_ctx_t *stream, srtp_stream_ctx_t *stream_templat
   memset(stream->salt, 0, SRTP_AEAD_SALT_LEN);
   memset(stream->c_salt, 0, SRTP_AEAD_SALT_LEN);
 
-  
+  /*
+   * deallocate the MKI, if it is not the same as that in template
+   */
+  if (stream->mki != NULL) {
+    if (stream_template && stream->mki == stream_template->mki) {
+      /* do nothing */
+    } else {
+      srtp_crypto_free(stream->mki);
+    }
+  }
+
   /* deallocate srtp stream context */
   srtp_crypto_free(stream);
 
@@ -452,6 +476,10 @@ srtp_stream_clone(const srtp_stream_ctx_t *stream_template,
   str->direction     = stream_template->direction;
   str->rtp_services  = stream_template->rtp_services;
   str->rtcp_services = stream_template->rtcp_services;
+
+  /* set MKI */
+  str->mki_len = stream_template->mki_len;
+  str->mki     = stream_template->mki;
 
   /* set pointer to EKT data associated with stream */
   str->ekt = stream_template->ekt;
@@ -661,10 +689,18 @@ static inline int base_key_length(const srtp_cipher_type_t *cipher, int key_leng
 }
 
 srtp_err_status_t
-srtp_stream_init_keys(srtp_stream_ctx_t *srtp, const void *key) {
+srtp_stream_init_keys(srtp_stream_ctx_t *srtp, int n_keys, unsigned char* const* keys) {
   srtp_err_status_t stat;
   srtp_kdf_t kdf;
   uint8_t tmp_key[MAX_SRTP_KEY_LEN];
+  const unsigned char *key;
+
+  if (n_keys == 0)
+    return srtp_err_status_bad_param;
+  if (n_keys > 1)
+    return srtp_err_status_many_keys;
+
+  key = keys[0];
   int kdf_keylen = 30, rtp_keylen, rtcp_keylen;
   int rtp_base_key_len, rtp_salt_len;
   int rtcp_base_key_len, rtcp_salt_len;
@@ -976,6 +1012,13 @@ srtp_stream_init(srtp_stream_ctx_t *srtp,
    srtp->rtp_services  = p->rtp.sec_serv;
    srtp->rtcp_services = p->rtcp.sec_serv;
 
+   /* initialize the MKI */
+   srtp->mki_len = p->mki_len;
+   if (p->mki_len) {
+     memcpy(srtp->mki, p->mkis[0], p->mki_len);
+     debug_print(mod_srtp, "Setting up stream MKI of len %d", p->mki_len);
+   }
+
    /*
     * set direction to unknown - this flag gets checked in srtp_protect(),
     * srtp_unprotect(), srtp_protect_rtcp(), and srtp_unprotect_rtcp(), and 
@@ -997,7 +1040,7 @@ srtp_stream_init(srtp_stream_ctx_t *srtp,
    /* DAM - no RTCP key limit at present */
 
    /* initialize keys */
-   err = srtp_stream_init_keys(srtp, p->key);
+   err = srtp_stream_init_keys(srtp, 1, &p->key);
    if (err) {
      srtp_rdbx_dealloc(&srtp->rtp_rdbx);
      return err;
@@ -1719,7 +1762,7 @@ srtp_unprotect_aead (srtp_ctx_t *ctx, srtp_stream_ctx_t *stream, int delta,
     */
    if (stream->rtp_services & sec_serv_auth) {
      auth_start = (uint32_t *)hdr;
-     auth_tag = (uint8_t *)hdr + *pkt_octet_len;
+     auth_tag = (uint8_t *)hdr + *pkt_octet_len + stream->mki_len;
    } else {
      auth_start = NULL;
      auth_tag = NULL;
@@ -1851,6 +1894,13 @@ srtp_unprotect_aead (srtp_ctx_t *ctx, srtp_stream_ctx_t *stream, int delta,
 
   }
 
+  if (stream->mki_len) {
+
+    /* insert the MKI and increase the packet length */
+    memcpy((uint8_t *)hdr + *pkt_octet_len, stream->mki, stream->mki_len);
+    *pkt_octet_len += stream->mki_len;
+  }
+
   if (auth_tag) {
 
     /* increase the packet length by the length of the auth tag */
@@ -1868,6 +1918,7 @@ srtp_unprotect(srtp_ctx_t *ctx, void *srtp_hdr, int *pkt_octet_len) {
   uint32_t *auth_start;     /* pointer to start of auth. portion      */
   unsigned int enc_octet_len = 0;/* number of octets in encrypted portion */
   uint8_t *auth_tag = NULL; /* location of auth_tag within packet     */
+  uint8_t *mki = NULL;      /* location of MKI within packet     */
   srtp_xtd_seq_num_t est;        /* estimated xtd_seq_num_t of *hdr        */
   int delta;                /* delta of local pkt idx and that in hdr */
   v128_t iv;
@@ -2011,12 +2062,16 @@ srtp_unprotect(srtp_ctx_t *ctx, void *srtp_hdr, int *pkt_octet_len) {
     enc_start = (uint32_t *)hdr + uint32s_in_rtp_header + hdr->cc;  
     if (hdr->x == 1) {
       xtn_hdr = (srtp_hdr_xtnd_t *)enc_start;
+
+      if ((uint8_t*)(xtn_hdr + 1) > (uint8_t*)hdr + *pkt_octet_len)
+        return srtp_err_status_parse_err;
+
       enc_start += (ntohs(xtn_hdr->length) + 1);
     }  
-    if (!((uint8_t*)enc_start <= (uint8_t*)hdr + (*pkt_octet_len - tag_len)))
+    if (!((uint8_t*)enc_start + stream->mki_len <= (uint8_t*)hdr + (*pkt_octet_len - tag_len)))
       return srtp_err_status_parse_err;
-    enc_octet_len = (uint32_t)(*pkt_octet_len - tag_len -
-                               ((uint8_t*)enc_start - (uint8_t*)hdr));
+    enc_octet_len = (uint32_t)(*pkt_octet_len - tag_len - stream->mki_len
+                    - ((uint8_t*)enc_start - (uint8_t*)hdr));
   } else {
     enc_start = NULL;
   }
@@ -2033,6 +2088,30 @@ srtp_unprotect(srtp_ctx_t *ctx, void *srtp_hdr, int *pkt_octet_len) {
     auth_start = NULL;
     auth_tag = NULL;
   } 
+
+
+  /*
+   * Check the Master Key Index (MKI) if present.
+   */
+
+  if (stream->mki_len > 0) {
+
+    debug_print(mod_srtp, "Checking MKI of len %d", stream->mki_len);
+
+    if (auth_tag)
+      mki = auth_tag - stream->mki_len;
+    else
+      mki = (uint8_t*)hdr + *pkt_octet_len - stream->mki_len;
+
+    if (mki + stream->mki_len > (uint8_t*)hdr + *pkt_octet_len)
+      return srtp_err_status_parse_err;
+
+    /* FIXME: Here, we should look up the key to use based on the MKI.
+       Since we currently support only a single key, we just check
+       that the MKI is what we expect.  */
+    if (octet_string_is_eq(stream->mki, mki, stream->mki_len))
+      return srtp_err_status_undef_mki;
+  }
 
   /*
    * if we expect message authentication, run the authentication
@@ -2062,8 +2141,8 @@ srtp_unprotect(srtp_ctx_t *ctx, void *srtp_hdr, int *pkt_octet_len) {
     if (status) return status;
  
     /* now compute auth function over packet */
-    status = srtp_auth_update(stream->rtp_auth, (uint8_t *)auth_start,
-			 *pkt_octet_len - tag_len);
+    status = srtp_auth_update(stream->rtp_auth, (uint8_t *)auth_start,  
+			 *pkt_octet_len - tag_len - stream->mki_len);
 
     /* run auth func over ROC, then write tmp tag */
     status = srtp_auth_compute(stream->rtp_auth, (uint8_t *)&est, 4, tmp_tag);
@@ -2165,8 +2244,8 @@ srtp_unprotect(srtp_ctx_t *ctx, void *srtp_hdr, int *pkt_octet_len) {
    */
   srtp_rdbx_add_index(&stream->rtp_rdbx, delta);
 
-  /* decrease the packet length by the length of the auth tag */
-  *pkt_octet_len -= tag_len;
+  /* decrease the packet length by the length of the auth tag and MKI */
+  *pkt_octet_len -= (tag_len + stream->mki_len);
 
   return srtp_err_status_ok;  
 }
@@ -2217,7 +2296,7 @@ srtp_shutdown() {
 
 int
 srtp_get_trailer_length(const srtp_stream_t s) {
-  return srtp_auth_get_tag_length(s->rtp_auth);
+  return srtp_auth_get_tag_length(s->rtp_auth) + MKI;
 }
 
 #endif
@@ -3315,11 +3394,12 @@ srtp_protect_rtcp(srtp_t ctx, void *rtcp_hdr, int *pkt_octet_len) {
 
   /* 
    * set the auth_start and auth_tag pointers to the proper locations
-   * (note that srtpc *always* provides authentication, unlike srtp)
+   * (note that srtcp *always* provides authentication, unlike srtp)
    */
   /* Note: This would need to change for optional mikey data */
   auth_start = (uint32_t *)hdr;
-  auth_tag = (uint8_t *)hdr + *pkt_octet_len + sizeof(srtcp_trailer_t); 
+  auth_tag = (uint8_t *)hdr + *pkt_octet_len + sizeof(srtcp_trailer_t)
+    + stream->mki_len; 
 
   /* perform EKT processing if needed */
   srtp_ekt_write_data(stream->ekt, auth_tag, tag_len, pkt_octet_len, 
@@ -3403,7 +3483,13 @@ srtp_protect_rtcp(srtp_t ctx, void *rtcp_hdr, int *pkt_octet_len) {
 	      srtp_octet_string_hex_string(auth_tag, tag_len));
   if (status)
     return srtp_err_status_auth_fail;   
-    
+
+  /* insert the MKI */
+  if (stream->mki_len > 0) {
+    memcpy((char*)(trailer + 1), stream->mki, stream->mki_len);
+    *pkt_octet_len += stream->mki_len;
+  }
+
   /* increase the packet length by the length of the auth tag and seq_num*/
   *pkt_octet_len += (tag_len + sizeof(srtcp_trailer_t));
     
@@ -3424,6 +3510,7 @@ srtp_unprotect_rtcp(srtp_t ctx, void *srtcp_hdr, int *pkt_octet_len) {
   srtp_err_status_t status;   
   unsigned int auth_len;
   int tag_len;
+  int trailer_len;	    /* length of E, SRTCP index, MKI and auth tag */
   srtp_stream_ctx_t *stream;
   uint32_t prefix_len;
   uint32_t seq_num;
@@ -3477,10 +3564,12 @@ srtp_unprotect_rtcp(srtp_t ctx, void *srtcp_hdr, int *pkt_octet_len) {
   /* get tag length from stream context */
   tag_len = srtp_auth_get_tag_length(stream->rtcp_auth);
 
+  trailer_len = tag_len + stream->mki_len + sizeof(srtcp_trailer_t);
+
   /* check the packet length - it must contain at least a full RTCP
      header, an auth tag (if applicable), and the SRTCP encrypted flag
      and 31-bit index value */
-  if (*pkt_octet_len < (int) (octets_in_rtcp_header + tag_len + sizeof(srtcp_trailer_t))) {
+  if (*pkt_octet_len < (int) (octets_in_rtcp_header + trailer_len)) {
     return srtp_err_status_bad_param;
   }
 
@@ -3496,11 +3585,14 @@ srtp_unprotect_rtcp(srtp_t ctx, void *srtcp_hdr, int *pkt_octet_len) {
   sec_serv_confidentiality = stream->rtcp_services == sec_serv_conf ||
       stream->rtcp_services == sec_serv_conf_and_auth;
 
+  trailer_len = tag_len + stream->mki_len + sizeof(srtcp_trailer_t);
+  /* check that the packet is large enough */
+  if (*pkt_octet_len < octets_in_rtcp_header + trailer_len)
+    return srtp_err_status_parse_err;
   /*
    * set encryption start, encryption length, and trailer
    */
-  enc_octet_len = *pkt_octet_len - 
-                  (octets_in_rtcp_header + tag_len + sizeof(srtcp_trailer_t));
+  enc_octet_len = *pkt_octet_len - (octets_in_rtcp_header + trailer_len);
   /* index & E (encryption) bit follow normal data.  hdr->len
 	 is the number of words (32-bit) in the normal packet minus 1 */
   /* This should point trailer to the word past the end of the
@@ -3510,8 +3602,7 @@ srtp_unprotect_rtcp(srtp_t ctx, void *srtcp_hdr, int *pkt_octet_len) {
    * NOTE: trailer is 32-bit aligned because RTCP 'packets' are always
    *	 multiples of 32-bits (RFC 3550 6.1)
    */
-  trailer = (uint32_t *) ((char *) hdr +
-      *pkt_octet_len -(tag_len + sizeof(srtcp_trailer_t)));
+  trailer = (uint32_t *) ((char *) hdr + *pkt_octet_len - trailer_len);
   e_bit_in_packet =
       (*((unsigned char *) trailer) & SRTCP_E_BYTE_BIT) == SRTCP_E_BYTE_BIT;
   if (e_bit_in_packet != sec_serv_confidentiality) {
@@ -3531,6 +3622,20 @@ srtp_unprotect_rtcp(srtp_t ctx, void *srtcp_hdr, int *pkt_octet_len) {
   auth_start = (uint32_t *)hdr;
   auth_len = *pkt_octet_len - tag_len;
   auth_tag = (uint8_t *)hdr + auth_len;
+
+  /*
+   * check the MKI, if present
+   */
+
+  if (stream->mki_len > 0) {
+
+    /* FIXME: Here, we should look up the key to use based on the MKI.
+       Since we currently support only a single key, we just check
+       that the MKI is what we expect.  */
+    if (octet_string_is_eq(stream->mki, auth_tag - stream->mki_len,
+            stream->mki_len))
+      return srtp_err_status_undef_mki;
+  }
 
   /* 
    * if EKT is in use, then we make a copy of the tag from the packet,
@@ -3587,8 +3692,8 @@ srtp_unprotect_rtcp(srtp_t ctx, void *srtcp_hdr, int *pkt_octet_len) {
   srtp_auth_start(stream->rtcp_auth);
 
   /* run auth func over packet, put result into tmp_tag */
-  status = srtp_auth_compute(stream->rtcp_auth, (uint8_t *)auth_start,
-			auth_len, tmp_tag);
+  status = srtp_auth_compute(stream->rtcp_auth, (uint8_t *)auth_start,  
+         auth_len - stream->mki_len, tmp_tag);
   debug_print(mod_srtp, "srtcp computed tag:       %s", 
 	      srtp_octet_string_hex_string(tmp_tag, tag_len));
   if (status)
@@ -3620,8 +3725,8 @@ srtp_unprotect_rtcp(srtp_t ctx, void *srtcp_hdr, int *pkt_octet_len) {
       return srtp_err_status_cipher_fail;
   }
 
-  /* decrease the packet length by the length of the auth tag and seq_num */
-  *pkt_octet_len -= (tag_len + sizeof(srtcp_trailer_t));
+  /* decrease the packet length by the length of the trailer */
+  *pkt_octet_len -= trailer_len;
 
   /*
    * if EKT is in effect, subtract the EKT data out of the packet

--- a/test/srtp_driver.c
+++ b/test/srtp_driver.c
@@ -1285,7 +1285,8 @@ srtp_session_print_policy (srtp_t srtp)
                "# rtcp auth:     %s\r\n"
                "# rtcp services: %s\r\n"
                "# window size:   %lu\r\n"
-               "# tx rtx allowed:%s\r\n",
+               "# tx rtx allowed:%s\r\n"
+               "# mki in use:    %s\r\n",
                direction[stream->direction],
                stream->rtp_cipher->type->description,
                stream->rtp_auth->type->description,
@@ -1294,7 +1295,8 @@ srtp_session_print_policy (srtp_t srtp)
                stream->rtcp_auth->type->description,
                serv_descr[stream->rtcp_services],
                srtp_rdbx_get_window_size(&stream->rtp_rdbx),
-               stream->allow_repeat_tx ? "true" : "false");
+               stream->allow_repeat_tx ? "true" : "false",
+               stream->mki_len ? "true" : "false");
 
         printf("# Encrypted extension headers: ");
         if (stream->enc_xtn_hdr && stream->enc_xtn_hdr_count > 0) {
@@ -1326,7 +1328,8 @@ srtp_session_print_policy (srtp_t srtp)
                "# rtcp auth:     %s\r\n"
                "# rtcp services: %s\r\n"
                "# window size:   %lu\r\n"
-               "# tx rtx allowed:%s\r\n",
+               "# tx rtx allowed:%s\r\n"
+               "# mki in use:    %s\r\n",
                stream->ssrc,
                stream->rtp_cipher->type->description,
                stream->rtp_auth->type->description,
@@ -1335,7 +1338,8 @@ srtp_session_print_policy (srtp_t srtp)
                stream->rtcp_auth->type->description,
                serv_descr[stream->rtcp_services],
                srtp_rdbx_get_window_size(&stream->rtp_rdbx),
-               stream->allow_repeat_tx ? "true" : "false");
+               stream->allow_repeat_tx ? "true" : "false",
+               stream->mki_len ? "true" : "false");
 
         printf("# Encrypted extension headers: ");
         if (stream->enc_xtn_hdr && stream->enc_xtn_hdr_count > 0) {
@@ -2632,6 +2636,13 @@ unsigned char test_key[46] = {
     0xb6, 0x96, 0x0b, 0x3a, 0xab, 0xe6
 };
 
+unsigned char test_mki_key[1] = {
+    0xe1
+};
+
+unsigned char *test_mki_ptr[1] = {
+  test_mki_key
+};
 
 const srtp_policy_t default_policy = {
     { ssrc_any_outbound, 0 },  /* SSRC                           */
@@ -2652,6 +2663,37 @@ const srtp_policy_t default_policy = {
         sec_serv_conf_and_auth /* security services flag      */
     },
     test_key,
+    0,         /* MKI length */
+    NULL,      /* vector of MKI values */
+    NULL,      /* indicates that EKT is not in use */
+    128,       /* replay window size */
+    0,         /* retransmission not allowed */
+    NULL,      /* no encrypted extension headers */
+    0,         /* list of encrypted extension headers is empty */
+    NULL
+};
+
+const srtp_policy_t default_mki_policy = {
+    { ssrc_any_outbound, 0 },  /* SSRC                           */
+    {                          /* SRTP policy                    */
+        SRTP_AES_128_ICM,      /* cipher type                 */
+        30,                    /* cipher key length in octets */
+        SRTP_HMAC_SHA1,        /* authentication func type    */
+        16,                    /* auth key length in octets   */
+        10,                    /* auth tag length in octets   */
+        sec_serv_conf_and_auth /* security services flag      */
+    },
+    {                          /* SRTCP policy                   */
+        SRTP_AES_128_ICM,      /* cipher type                 */
+        30,                    /* cipher key length in octets */
+        SRTP_HMAC_SHA1,        /* authentication func type    */
+        16,                    /* auth key length in octets   */
+        10,                    /* auth tag length in octets   */
+        sec_serv_conf_and_auth /* security services flag      */
+    },
+    test_key,
+    1,                         /* MKI length */
+    test_mki_ptr,              /* vector of MKI values */
     NULL,      /* indicates that EKT is not in use */
     128,       /* replay window size */
     0,         /* retransmission not allowed */
@@ -2679,6 +2721,37 @@ const srtp_policy_t aes_only_policy = {
         sec_serv_conf       /* security services flag      */
     },
     test_key,
+    0,			/* MKI length */
+    NULL,      /* vector of MKI values */
+    NULL,      /* indicates that EKT is not in use */
+    128,       /* replay window size */
+    0,         /* retransmission not allowed */
+    NULL,      /* no encrypted extension headers */
+    0,         /* list of encrypted extension headers is empty */
+    NULL
+};
+
+const srtp_policy_t aes_only_mki_policy = {
+    { ssrc_any_outbound, 0 }, /* SSRC                        */
+    {
+        SRTP_AES_128_ICM,          /* cipher type                 */
+        30,                   /* cipher key length in octets */
+        SRTP_NULL_AUTH,            /* authentication func type    */
+        0,                    /* auth key length in octets   */
+        0,                    /* auth tag length in octets   */
+        sec_serv_conf         /* security services flag      */
+    },
+    {
+        SRTP_AES_128_ICM,        /* cipher type                 */
+        30,                 /* cipher key length in octets */
+        SRTP_NULL_AUTH,          /* authentication func type    */
+        0,                  /* auth key length in octets   */
+        0,                  /* auth tag length in octets   */
+        sec_serv_conf       /* security services flag      */
+    },
+    test_key,
+    1,                      /* MKI length */
+    test_mki_ptr,	      	 /* vector of MKI values */
     NULL,      /* indicates that EKT is not in use */
     128,       /* replay window size */
     0,         /* retransmission not allowed */
@@ -2706,6 +2779,37 @@ const srtp_policy_t hmac_only_policy = {
         sec_serv_auth       /* security services flag      */
     },
     test_key,
+    0,			/* MKI length */
+    NULL,		/* vector of MKI values */
+    NULL,      /* indicates that EKT is not in use */
+    128,       /* replay window size */
+    0,         /* retransmission not allowed */
+    NULL,      /* no encrypted extension headers */
+    0,         /* list of encrypted extension headers is empty */
+    NULL
+};
+
+const srtp_policy_t hmac_only_mki_policy = {
+    { ssrc_any_outbound, 0 }, /* SSRC                        */
+    {
+        SRTP_NULL_CIPHER,          /* cipher type                 */
+        0,                    /* cipher key length in octets */
+        SRTP_HMAC_SHA1,            /* authentication func type    */
+        20,                   /* auth key length in octets   */
+        4,                    /* auth tag length in octets   */
+        sec_serv_auth         /* security services flag      */
+    },
+    {
+        SRTP_NULL_CIPHER,        /* cipher type                 */
+        0,                  /* cipher key length in octets */
+        SRTP_HMAC_SHA1,          /* authentication func type    */
+        20,                 /* auth key length in octets   */
+        4,                  /* auth tag length in octets   */
+        sec_serv_auth       /* security services flag      */
+    },
+    test_key,
+    1,                      /* MKI length */
+    test_mki_ptr,           /* vector of MKI values */
     NULL,      /* indicates that EKT is not in use */
     128,       /* replay window size */
     0,         /* retransmission not allowed */
@@ -2734,6 +2838,37 @@ const srtp_policy_t aes128_gcm_8_policy = {
         sec_serv_conf_and_auth          /* security services flag      */
     },
     test_key,
+    0,			  /* MKI length */
+    NULL,        /* vector of MKI values */
+    NULL,        /* indicates that EKT is not in use */
+    128,         /* replay window size */
+    0,           /* retransmission not allowed */
+    NULL,        /* no encrypted extension headers */
+    0,           /* list of encrypted extension headers is empty */
+    NULL
+};
+
+const srtp_policy_t aes128_gcm_8_mki_policy = {
+    { ssrc_any_outbound, 0 },           /* SSRC                           */
+    {                                   /* SRTP policy                    */
+        SRTP_AES_128_GCM,                    /* cipher type                 */
+        SRTP_AES_128_GCM_KEYSIZE_WSALT, /* cipher key length in octets */
+        SRTP_NULL_AUTH,                      /* authentication func type    */
+        0,                              /* auth key length in octets   */
+        8,                              /* auth tag length in octets   */
+        sec_serv_conf_and_auth          /* security services flag      */
+    },
+    {                                   /* SRTCP policy                   */
+        SRTP_AES_128_GCM,                    /* cipher type                 */
+        SRTP_AES_128_GCM_KEYSIZE_WSALT, /* cipher key length in octets */
+        SRTP_NULL_AUTH,                      /* authentication func type    */
+        0,                              /* auth key length in octets   */
+        8,                              /* auth tag length in octets   */
+        sec_serv_conf_and_auth          /* security services flag      */
+    },
+    test_key,
+    1,                /* MKI length */
+    test_mki_ptr,		 /* vector of MKI values */
     NULL,        /* indicates that EKT is not in use */
     128,         /* replay window size */
     0,           /* retransmission not allowed */
@@ -2761,6 +2896,37 @@ const srtp_policy_t aes128_gcm_8_cauth_policy = {
         sec_serv_auth                   /* security services flag      */
     },
     test_key,
+    0,			  /* MKI length */
+    NULL,		  /* vector of MKI values */
+    NULL,        /* indicates that EKT is not in use */
+    128,         /* replay window size */
+    0,           /* retransmission not allowed */
+    NULL,        /* no encrypted extension headers */
+    0,           /* list of encrypted extension headers is empty */
+    NULL
+};
+
+const srtp_policy_t aes128_gcm_8_cauth_mki_policy = {
+    { ssrc_any_outbound, 0 },           /* SSRC                           */
+    {                                   /* SRTP policy                    */
+        SRTP_AES_128_GCM,                    /* cipher type                 */
+        SRTP_AES_128_GCM_KEYSIZE_WSALT, /* cipher key length in octets */
+        SRTP_NULL_AUTH,                      /* authentication func type    */
+        0,                              /* auth key length in octets   */
+        8,                              /* auth tag length in octets   */
+        sec_serv_conf_and_auth          /* security services flag      */
+    },
+    {                                   /* SRTCP policy                   */
+        SRTP_AES_128_GCM,                    /* cipher type                 */
+        SRTP_AES_128_GCM_KEYSIZE_WSALT, /* cipher key length in octets */
+        SRTP_NULL_AUTH,                      /* authentication func type    */
+        0,                              /* auth key length in octets   */
+        8,                              /* auth tag length in octets   */
+        sec_serv_auth                   /* security services flag      */
+    },
+    test_key,
+    1,			  /* MKI length */
+    test_mki_ptr,/* vector of MKI values */
     NULL,        /* indicates that EKT is not in use */
     128,         /* replay window size */
     0,           /* retransmission not allowed */
@@ -2788,6 +2954,37 @@ const srtp_policy_t aes256_gcm_8_policy = {
         sec_serv_conf_and_auth          /* security services flag      */
     },
     test_key,
+    0,			  /* MKI length */
+    NULL,		  /* vector of MKI values */
+    NULL,        /* indicates that EKT is not in use */
+    128,         /* replay window size */
+    0,           /* retransmission not allowed */
+    NULL,        /* no encrypted extension headers */
+    0,           /* list of encrypted extension headers is empty */
+    NULL
+};
+
+const srtp_policy_t aes256_gcm_8_mki_policy = {
+    { ssrc_any_outbound, 0 },           /* SSRC                           */
+    {                                   /* SRTP policy                    */
+        SRTP_AES_256_GCM,                    /* cipher type                 */
+        SRTP_AES_256_GCM_KEYSIZE_WSALT, /* cipher key length in octets */
+        SRTP_NULL_AUTH,                      /* authentication func type    */
+        0,                              /* auth key length in octets   */
+        8,                              /* auth tag length in octets   */
+        sec_serv_conf_and_auth          /* security services flag      */
+    },
+    {                                   /* SRTCP policy                   */
+        SRTP_AES_256_GCM,                    /* cipher type                 */
+        SRTP_AES_256_GCM_KEYSIZE_WSALT, /* cipher key length in octets */
+        SRTP_NULL_AUTH,                      /* authentication func type    */
+        0,                              /* auth key length in octets   */
+        8,                              /* auth tag length in octets   */
+        sec_serv_conf_and_auth          /* security services flag      */
+    },
+    test_key,
+    1,			  /* MKI length */
+    test_mki_ptr,/* vector of MKI values */
     NULL,        /* indicates that EKT is not in use */
     128,         /* replay window size */
     0,           /* retransmission not allowed */
@@ -2815,6 +3012,37 @@ const srtp_policy_t aes256_gcm_8_cauth_policy = {
         sec_serv_auth                   /* security services flag      */
     },
     test_key,
+    0,			  /* MKI length */
+    NULL,		  /* vector of MKI values */
+    NULL,        /* indicates that EKT is not in use */
+    128,         /* replay window size */
+    0,           /* retransmission not allowed */
+    NULL,        /* no encrypted extension headers */
+    0,           /* list of encrypted extension headers is empty */
+    NULL
+};
+
+const srtp_policy_t aes256_gcm_8_cauth_mki_policy = {
+    { ssrc_any_outbound, 0 },           /* SSRC                           */
+    {                                   /* SRTP policy                    */
+        SRTP_AES_256_GCM,                    /* cipher type                 */
+        SRTP_AES_256_GCM_KEYSIZE_WSALT, /* cipher key length in octets */
+        SRTP_NULL_AUTH,                      /* authentication func type    */
+        0,                              /* auth key length in octets   */
+        8,                              /* auth tag length in octets   */
+        sec_serv_conf_and_auth          /* security services flag      */
+    },
+    {                                   /* SRTCP policy                   */
+        SRTP_AES_256_GCM,                    /* cipher type                 */
+        SRTP_AES_256_GCM_KEYSIZE_WSALT, /* cipher key length in octets */
+        SRTP_NULL_AUTH,                      /* authentication func type    */
+        0,                              /* auth key length in octets   */
+        8,                              /* auth tag length in octets   */
+        sec_serv_auth                   /* security services flag      */
+    },
+    test_key,
+    1,			  /* MKI length */
+    test_mki_ptr,/* vector of MKI values */
     NULL,        /* indicates that EKT is not in use */
     128,         /* replay window size */
     0,           /* retransmission not allowed */
@@ -2843,6 +3071,37 @@ const srtp_policy_t null_policy = {
         sec_serv_none       /* security services flag      */
     },
     test_key,
+    0,			/* MKI length */
+    NULL,		/* vector of MKI values */
+    NULL,      /* indicates that EKT is not in use */
+    128,       /* replay window size */
+    0,         /* retransmission not allowed */
+    NULL,      /* no encrypted extension headers */
+    0,         /* list of encrypted extension headers is empty */
+    NULL
+};
+
+const srtp_policy_t null_mki_policy = {
+    { ssrc_any_outbound, 0 }, /* SSRC                        */
+    {
+        SRTP_NULL_CIPHER,          /* cipher type                 */
+        0,                    /* cipher key length in octets */
+        SRTP_NULL_AUTH,            /* authentication func type    */
+        0,                    /* auth key length in octets   */
+        0,                    /* auth tag length in octets   */
+        sec_serv_none         /* security services flag      */
+    },
+    {
+        SRTP_NULL_CIPHER,        /* cipher type                 */
+        0,                  /* cipher key length in octets */
+        SRTP_NULL_AUTH,          /* authentication func type    */
+        0,                  /* auth key length in octets   */
+        0,                  /* auth tag length in octets   */
+        sec_serv_none       /* security services flag      */
+    },
+    test_key,
+    1,                      /* MKI length */
+    test_mki_ptr,           /* vector of MKI values */
     NULL,      /* indicates that EKT is not in use */
     128,       /* replay window size */
     0,         /* retransmission not allowed */
@@ -2880,6 +3139,37 @@ const srtp_policy_t aes_256_hmac_policy = {
         sec_serv_conf_and_auth /* security services flag      */
     },
     test_256_key,
+    0,			/* MKI length */
+    NULL,		/* vector of MKI values */
+    NULL,      /* indicates that EKT is not in use */
+    128,       /* replay window size */
+    0,         /* retransmission not allowed */
+    NULL,      /* no encrypted extension headers */
+    0,         /* list of encrypted extension headers is empty */
+    NULL
+};
+
+const srtp_policy_t aes_256_hmac_mki_policy = {
+    { ssrc_any_outbound, 0 },  /* SSRC                           */
+    {                          /* SRTP policy                    */
+        SRTP_AES_ICM,               /* cipher type                 */
+        46,                    /* cipher key length in octets */
+        SRTP_HMAC_SHA1,             /* authentication func type    */
+        20,                    /* auth key length in octets   */
+        10,                    /* auth tag length in octets   */
+        sec_serv_conf_and_auth /* security services flag      */
+    },
+    {                          /* SRTCP policy                   */
+        SRTP_AES_ICM,               /* cipher type                 */
+        46,                    /* cipher key length in octets */
+        SRTP_HMAC_SHA1,             /* authentication func type    */
+        20,                    /* auth key length in octets   */
+        10,                    /* auth tag length in octets   */
+        sec_serv_conf_and_auth /* security services flag      */
+    },
+    test_256_key,
+    1,                         /* MKI length */
+    test_mki_ptr,              /* vector of MKI values */
     NULL,      /* indicates that EKT is not in use */
     128,       /* replay window size */
     0,         /* retransmission not allowed */
@@ -2921,6 +3211,8 @@ const srtp_policy_t hmac_only_with_ekt_policy = {
         sec_serv_auth       /* security services flag      */
     },
     test_key,
+    0,                     /* MKI length */
+    NULL,                  /* vector of MKI values */
     &ekt_test_policy,      /* indicates that EKT is not in use */
     128,                   /* replay window size */
     0,                     /* retransmission not allowed */
@@ -2929,6 +3221,34 @@ const srtp_policy_t hmac_only_with_ekt_policy = {
     NULL
 };
 
+const srtp_policy_t hmac_only_with_ekt_mki_policy = {
+    { ssrc_any_outbound, 0 }, /* SSRC                        */
+    {
+        SRTP_NULL_CIPHER,          /* cipher type                 */
+        0,                    /* cipher key length in octets */
+        SRTP_HMAC_SHA1,            /* authentication func type    */
+        20,                   /* auth key length in octets   */
+        4,                    /* auth tag length in octets   */
+        sec_serv_auth         /* security services flag      */
+    },
+    {
+        SRTP_NULL_CIPHER,        /* cipher type                 */
+        0,                  /* cipher key length in octets */
+        SRTP_HMAC_SHA1,          /* authentication func type    */
+        20,                 /* auth key length in octets   */
+        4,                  /* auth tag length in octets   */
+        sec_serv_auth       /* security services flag      */
+    },
+    test_key,
+    1,                     /* MKI length */
+    test_mki_ptr,          /* vector of MKI values */
+    &ekt_test_policy,      /* indicates that EKT is not in use */
+    128,                   /* replay window size */
+    0,                     /* retransmission not allowed */
+    NULL,                  /* no encrypted extension headers */
+    0,                     /* list of encrypted extension headers is empty */
+    NULL
+};
 
 /*
  * an array of pointers to the policies listed above
@@ -2954,6 +3274,20 @@ policy_array[] = {
     &null_policy,
     &aes_256_hmac_policy,
     &hmac_only_with_ekt_policy,
+
+    // MKI variants
+    &hmac_only_mki_policy,
+    &aes_only_mki_policy,
+    &default_mki_policy,
+#ifdef OPENSSL
+    &aes128_gcm_8_mki_policy,
+    &aes128_gcm_8_cauth_mki_policy,
+    &aes256_gcm_8_mki_policy,
+    &aes256_gcm_8_cauth_mki_policy,
+#endif
+    &null_mki_policy,
+    &aes_256_hmac_mki_policy,
+    &hmac_only_with_ekt_mki_policy,
     NULL
 };
 
@@ -2976,6 +3310,8 @@ const srtp_policy_t wildcard_policy = {
         sec_serv_conf_and_auth /* security services flag      */
     },
     test_key,
+    0,                   /* MKI length */
+    NULL,                /* vector of MKI values */
     NULL,
     128,                 /* replay window size */
     0,                   /* retransmission not allowed */


### PR DESCRIPTION
This is basically Per Cederqvist patch that adds MKI support. I just adopted it to current master state and removed user visible changes to policy objects. It adds limited MKI support - only one key used from array. When someone will add fully functional MKI support than API changes will be ok, but right no they are not even required.