### PR TITLE
crypto/replay/rdbx.c: Return type of srtp_index_guess from int to int32_t

### DIFF
--- a/crypto/include/integers.h
+++ b/crypto/include/integers.h
@@ -94,6 +94,9 @@ typedef unsigned short int	uint16_t;
 #ifndef HAVE_UINT32_T
 typedef unsigned int		uint32_t;
 #endif
+#ifndef HAVE_INT32_T
+typedef int int32_t;
+#endif
 
 
 #if defined(NO_64BIT_MATH) && defined(HAVE_CONFIG_H)

--- a/crypto/include/rdbx.h
+++ b/crypto/include/rdbx.h
@@ -113,7 +113,7 @@ srtp_err_status_t srtp_rdbx_dealloc(srtp_rdbx_t *rdbx);
  * index to which s corresponds, and returns the difference between
  * *guess and the locally stored synch info
  */
-int srtp_rdbx_estimate_index(const srtp_rdbx_t *rdbx, srtp_xtd_seq_num_t *guess, srtp_sequence_number_t s);
+int32_t srtp_rdbx_estimate_index(const srtp_rdbx_t *rdbx, srtp_xtd_seq_num_t *guess, srtp_sequence_number_t s);
 
 /*
  * srtp_rdbx_check(rdbx, delta);
@@ -183,7 +183,7 @@ void srtp_index_advance(srtp_xtd_seq_num_t *pi, srtp_sequence_number_t s);
  * guess of the packet index to which s corresponds, and returns the
  * difference between *guess and *local
  */
-int srtp_index_guess(const srtp_xtd_seq_num_t *local, srtp_xtd_seq_num_t *guess, srtp_sequence_number_t s);
+int32_t srtp_index_guess(const srtp_xtd_seq_num_t *local, srtp_xtd_seq_num_t *guess, srtp_sequence_number_t s);
 
 
 #ifdef __cplusplus

--- a/crypto/replay/rdbx.c
+++ b/crypto/replay/rdbx.c
@@ -124,7 +124,7 @@ void srtp_index_advance (srtp_xtd_seq_num_t *pi, srtp_sequence_number_t s)
  * unsigned integer!
  */
 
-int srtp_index_guess (const srtp_xtd_seq_num_t *local, srtp_xtd_seq_num_t *guess, srtp_sequence_number_t s)
+int32_t srtp_index_guess (const srtp_xtd_seq_num_t *local, srtp_xtd_seq_num_t *guess, srtp_sequence_number_t s)
 {
 #ifdef NO_64BIT_MATH
     uint32_t local_roc = ((high32(*local) << 16) |
@@ -142,7 +142,7 @@ int srtp_index_guess (const srtp_xtd_seq_num_t *local, srtp_xtd_seq_num_t *guess
     uint32_t guess_roc = (uint32_t)(*guess >> 16);
     uint16_t guess_seq = (uint16_t)*guess;
 #endif
-    int difference;
+    int32_t difference;
 
     if (local_seq < seq_num_median) {
         if (s - local_seq > seq_num_median) {
@@ -313,7 +313,7 @@ srtp_err_status_t srtp_rdbx_add_index (srtp_rdbx_t *rdbx, int delta)
  * index to which s corresponds, and returns the difference between
  * *guess and the locally stored synch info
  */
-int srtp_rdbx_estimate_index (const srtp_rdbx_t *rdbx, srtp_xtd_seq_num_t *guess, srtp_sequence_number_t s)
+int32_t srtp_rdbx_estimate_index (const srtp_rdbx_t *rdbx, srtp_xtd_seq_num_t *guess, srtp_sequence_number_t s)
 {
 
     /*


### PR DESCRIPTION
On platforms where int is 16 bits this has the potential to overflow.
This is also for consistency since other parts of the code seems to have moved to the C99(ish) types.

Mentioned in issue #216