### PR TITLE
Report ssrc instead of srtp_stream_t in srtp_event_data_t

### DIFF
--- a/include/srtp.h
+++ b/include/srtp.h
@@ -1408,7 +1408,7 @@ typedef enum {
 
 typedef struct srtp_event_data_t {
   srtp_t        session;  /**< The session in which the event happend. */
-  uintptr_t     ssrc;     /**< The ssrc in host order of the stream in which the event happend */
+  uint32_t      ssrc;     /**< The ssrc in host order of the stream in which the event happend */
   srtp_event_t  event;    /**< An enum indicating the type of event.   */
 } srtp_event_data_t;
 

--- a/include/srtp.h
+++ b/include/srtp.h
@@ -270,7 +270,7 @@ typedef enum {
   srtp_err_status_pfkey_err    = 24  /**< error while using pfkey                 */
 } srtp_err_status_t;
 
-typedef struct srtp_stream_ctx_t_ srtp_stream_ctx_t;
+
 typedef struct srtp_ctx_t_ srtp_ctx_t;
 
 /* 
@@ -434,22 +434,6 @@ typedef struct srtp_policy_t {
  */
 
 typedef srtp_ctx_t *srtp_t;
-
-
-/**
- * @brief An srtp_stream_t points to an SRTP stream structure.
- *
- * The typedef srtp_stream_t is a pointer to a structure that
- * represents an SRTP stream.  This datatype is intentionally
- * opaque in order to separate the interface from the implementation. 
- * 
- * An SRTP stream consists of all of the traffic sent to an SRTP
- * session by a single participant.  A session can be viewed as
- * a set of streams.  
- *
- */
-typedef srtp_stream_ctx_t *srtp_stream_t;
-
 
 
 /**
@@ -1424,7 +1408,7 @@ typedef enum {
 
 typedef struct srtp_event_data_t {
   srtp_t        session;  /**< The session in which the event happend. */
-  srtp_stream_t stream;   /**< The stream in which the event happend.  */
+  uintptr_t     ssrc;     /**< The ssrc in host order of the stream in which the event happend */
   srtp_event_t  event;    /**< An enum indicating the type of event.   */
 } srtp_event_data_t;
 

--- a/include/srtp_priv.h
+++ b/include/srtp_priv.h
@@ -63,6 +63,9 @@ extern "C" {
 #define SRTP_VER_STRING	    PACKAGE_STRING
 #define SRTP_VERSION        PACKAGE_VERSION
 
+typedef struct srtp_stream_ctx_t_ srtp_stream_ctx_t;
+typedef srtp_stream_ctx_t *srtp_stream_t;
+
 /*
  * the following declarations are libSRTP internal functions 
  */
@@ -152,7 +155,7 @@ typedef struct srtp_ctx_t_ {
    if(srtp_event_handler) {                         \
       srtp_event_data_t data;                       \
       data.session = srtp;                          \
-      data.stream  = strm;                          \
+      data.ssrc    = ntohl(strm->ssrc);             \
       data.event   = evnt;                          \
       srtp_event_handler(&data);                    \
 }   

--- a/srtp/srtp.c
+++ b/srtp/srtp.c
@@ -1026,7 +1026,7 @@ srtp_stream_init(srtp_stream_ctx_t *srtp,
  srtp_event_reporter(srtp_event_data_t *data) {
 
    srtp_err_report(srtp_err_level_warning, "srtp: in stream 0x%x: ", 
-	      data->stream->ssrc);
+                   data->ssrc);
 
    switch(data->event) {
    case event_ssrc_collision:


### PR DESCRIPTION
An intermediate fix for #67.

srtp_stream_t is an opaque type and unusable from the public api,
this made the entire event framework almost useless.
This change swaps the stream point with an ssrc, which is used as a key
in the public api. A uintptr_t is used instead of a uint32_t to ensure
the size of the srtp_event_data_t struct remains unchanged.

This change could potentially break existing code but the assumption
is that the number of uses of this api that are doing anything with this
value after the version 2.0 release approaches zero.