### PR TITLE
octet_string_set_to_zero() now delegates to OPENSSL_cleanse() if available, if not it will use srtp_cleanse() to zero memory.

### DIFF
--- a/crypto/cipher/aes_gcm_ossl.c
+++ b/crypto/cipher/aes_gcm_ossl.c
@@ -163,7 +163,7 @@ static srtp_err_status_t srtp_aes_gcm_openssl_dealloc (srtp_cipher_t *c)
     if (ctx) {
         EVP_CIPHER_CTX_free(ctx->ctx);
 	/* zeroize the key material */
-	octet_string_set_to_zero((uint8_t*)ctx, sizeof(srtp_aes_gcm_ctx_t));
+    octet_string_set_to_zero(ctx, sizeof(srtp_aes_gcm_ctx_t));
 	srtp_crypto_free(ctx);
     }
 

--- a/crypto/cipher/aes_gcm_ossl.c
+++ b/crypto/cipher/aes_gcm_ossl.c
@@ -162,9 +162,9 @@ static srtp_err_status_t srtp_aes_gcm_openssl_dealloc (srtp_cipher_t *c)
     ctx = (srtp_aes_gcm_ctx_t*)c->state;
     if (ctx) {
         EVP_CIPHER_CTX_free(ctx->ctx);
-	/* zeroize the key material */
-    octet_string_set_to_zero(ctx, sizeof(srtp_aes_gcm_ctx_t));
-	srtp_crypto_free(ctx);
+        /* zeroize the key material */
+        octet_string_set_to_zero(ctx, sizeof(srtp_aes_gcm_ctx_t));
+        srtp_crypto_free(ctx);
     }
 
     /* free memory */

--- a/crypto/cipher/aes_icm.c
+++ b/crypto/cipher/aes_icm.c
@@ -165,9 +165,9 @@ static srtp_err_status_t srtp_aes_icm_dealloc (srtp_cipher_t *c)
 
     ctx = (srtp_aes_icm_ctx_t *)c->state;
     if (ctx) {
-	/* zeroize the key material */
-    octet_string_set_to_zero(ctx, sizeof(srtp_aes_icm_ctx_t));
-	srtp_crypto_free(ctx);
+        /* zeroize the key material */
+        octet_string_set_to_zero(ctx, sizeof(srtp_aes_icm_ctx_t));
+        srtp_crypto_free(ctx);
     }
 
     /* free the cipher context */

--- a/crypto/cipher/aes_icm.c
+++ b/crypto/cipher/aes_icm.c
@@ -166,7 +166,7 @@ static srtp_err_status_t srtp_aes_icm_dealloc (srtp_cipher_t *c)
     ctx = (srtp_aes_icm_ctx_t *)c->state;
     if (ctx) {
 	/* zeroize the key material */
-	octet_string_set_to_zero((uint8_t*)ctx, sizeof(srtp_aes_icm_ctx_t));
+    octet_string_set_to_zero(ctx, sizeof(srtp_aes_icm_ctx_t));
 	srtp_crypto_free(ctx);
     }
 

--- a/crypto/cipher/aes_icm_ossl.c
+++ b/crypto/cipher/aes_icm_ossl.c
@@ -193,7 +193,7 @@ static srtp_err_status_t srtp_aes_icm_openssl_dealloc (srtp_cipher_t *c)
     if (ctx != NULL) {
         EVP_CIPHER_CTX_free(ctx->ctx);
 	/* zeroize the key material */
-	octet_string_set_to_zero((uint8_t*)ctx, sizeof(srtp_aes_icm_ctx_t));
+    octet_string_set_to_zero(ctx, sizeof(srtp_aes_icm_ctx_t));
 	srtp_crypto_free(ctx);
     }
 

--- a/crypto/cipher/aes_icm_ossl.c
+++ b/crypto/cipher/aes_icm_ossl.c
@@ -192,9 +192,9 @@ static srtp_err_status_t srtp_aes_icm_openssl_dealloc (srtp_cipher_t *c)
     ctx = (srtp_aes_icm_ctx_t*)c->state;
     if (ctx != NULL) {
         EVP_CIPHER_CTX_free(ctx->ctx);
-	/* zeroize the key material */
-    octet_string_set_to_zero(ctx, sizeof(srtp_aes_icm_ctx_t));
-	srtp_crypto_free(ctx);
+        /* zeroize the key material */
+        octet_string_set_to_zero(ctx, sizeof(srtp_aes_icm_ctx_t));
+        srtp_crypto_free(ctx);
     }
 
     /* free memory */

--- a/crypto/cipher/null_cipher.c
+++ b/crypto/cipher/null_cipher.c
@@ -88,7 +88,7 @@ static srtp_err_status_t srtp_null_cipher_dealloc (srtp_cipher_t *c)
     extern const srtp_cipher_type_t srtp_null_cipher;
 
     /* zeroize entire state*/
-    octet_string_set_to_zero((uint8_t*)c, sizeof(srtp_cipher_t));
+    octet_string_set_to_zero(c, sizeof(srtp_cipher_t));
 
     /* free memory of type null_cipher */
     srtp_crypto_free(c);

--- a/crypto/hash/hmac.c
+++ b/crypto/hash/hmac.c
@@ -98,8 +98,7 @@ static srtp_err_status_t srtp_hmac_alloc (srtp_auth_t **a, int key_len, int out_
 static srtp_err_status_t srtp_hmac_dealloc (srtp_auth_t *a)
 {
     /* zeroize entire state*/
-    octet_string_set_to_zero((uint8_t*)a,
-                             sizeof(srtp_hmac_ctx_t) + sizeof(srtp_auth_t));
+    octet_string_set_to_zero(a, sizeof(srtp_hmac_ctx_t) + sizeof(srtp_auth_t));
 
     /* free memory */
     srtp_crypto_free(a);

--- a/crypto/hash/hmac_ossl.c
+++ b/crypto/hash/hmac_ossl.c
@@ -125,14 +125,13 @@ static srtp_err_status_t srtp_hmac_dealloc (srtp_auth_t *a)
     HMAC_CTX_cleanup(hmac_ctx);
 
     /* zeroize entire state*/
-    octet_string_set_to_zero((uint8_t*)a,
-                             sizeof(HMAC_CTX) + sizeof(srtp_auth_t));
+    octet_string_set_to_zero(a, sizeof(HMAC_CTX) + sizeof(srtp_auth_t));
 
 #else
     HMAC_CTX_free(hmac_ctx);
 
     /* zeroize entire state*/
-    octet_string_set_to_zero((uint8_t*)a, sizeof(srtp_auth_t));
+    octet_string_set_to_zero(a, sizeof(srtp_auth_t));
 #endif
 
     /* free memory */

--- a/crypto/hash/null_auth.c
+++ b/crypto/hash/null_auth.c
@@ -86,8 +86,7 @@ static srtp_err_status_t srtp_null_auth_dealloc (srtp_auth_t *a)
     extern const srtp_auth_type_t srtp_null_auth;
 
     /* zeroize entire state*/
-    octet_string_set_to_zero((uint8_t*)a,
-                             sizeof(srtp_null_auth_ctx_t) + sizeof(srtp_auth_t));
+    octet_string_set_to_zero(a, sizeof(srtp_null_auth_ctx_t) + sizeof(srtp_auth_t));
 
     /* free memory */
     srtp_crypto_free(a);

--- a/crypto/include/crypto_math.h
+++ b/crypto/include/crypto_math.h
@@ -117,11 +117,6 @@ v128_add(v128_t *z, v128_t *x, v128_t *y);
 int
 octet_string_is_eq(uint8_t *a, uint8_t *b, int len);
 
-void
-octet_string_set_to_zero(uint8_t *s, int len);
-
-
-
 /* 
  * the matrix A[] is stored in column format, i.e., A[i] is the ith
  * column of the matrix
@@ -232,10 +227,6 @@ v128_set_bit_to(v128_t *x, int i, int y);
 
 int
 octet_string_is_eq(uint8_t *a, uint8_t *b, int len);
-
-void
-octet_string_set_to_zero(uint8_t *s, int len);
-
 
 #ifdef __cplusplus
 }

--- a/crypto/include/datatypes.h
+++ b/crypto/include/datatypes.h
@@ -352,9 +352,20 @@ v128_set_bit_to(v128_t *x, int i, int y);
 int
 octet_string_is_eq(uint8_t *a, uint8_t *b, int len);
 
+/*
+ * A portable way to zero out memory as recommended by
+ * https://cryptocoding.net/index.php/Coding_rules#Clean_memory_of_secret_data
+ * This is used to zero memory when OPENSSL_cleanse() is not available.
+ */
 void
-octet_string_set_to_zero(uint8_t *s, int len);
+srtp_cleanse(void *s, size_t len);
 
+/*
+ * Functions as a wrapper that delegates to either srtp_cleanse() or
+ * OPENSSL_cleanse() if available to zero memory.
+ */
+void
+octet_string_set_to_zero(void *s, size_t len);
 
 #if defined(HAVE_CONFIG_H) 
 

--- a/crypto/math/datatypes.c
+++ b/crypto/math/datatypes.c
@@ -47,6 +47,10 @@
     #include <config.h>
 #endif
 
+#ifdef OPENSSL
+#include <openssl/crypto.h>
+#endif
+
 #include "datatypes.h"
 
 int 
@@ -458,13 +462,20 @@ octet_string_is_eq(uint8_t *a, uint8_t *b, int len) {
 }
 
 void
-octet_string_set_to_zero(uint8_t *s, int len) {
-  uint8_t *end = s + len;
+srtp_cleanse(void *s, size_t len)
+{
+  volatile unsigned char *p = (volatile unsigned char *)s;
+  while(len--) *p++ = 0;
+}
 
-  do {
-    *s = 0;
-  } while (++s < end);
-  
+void
+octet_string_set_to_zero(void *s, size_t len)
+{
+#ifdef OPENSSL
+  OPENSSL_cleanse(s, len);
+#else
+  srtp_cleanse(s, len);
+#endif
 }
 
 #ifdef TESTAPP_SOURCE

--- a/srtp/srtp.c
+++ b/srtp/srtp.c
@@ -550,7 +550,6 @@ static srtp_err_status_t srtp_kdf_generate(srtp_kdf_t *kdf, srtp_prf_label label
 
     /* The NULL cipher will not have an EVP */
     if (!kdf->evp) return srtp_err_status_ok;
-
     octet_string_set_to_zero(key, length);
 
     /*
@@ -929,7 +928,7 @@ srtp_stream_init_keys(srtp_stream_ctx_t *srtp, const void *key) {
 
   /* clear memory then return */
   stat = srtp_kdf_clear(&kdf);
-  octet_string_set_to_zero(tmp_key, MAX_SRTP_KEY_LEN);  
+  octet_string_set_to_zero(tmp_key, MAX_SRTP_KEY_LEN);
   if (stat)
     return srtp_err_status_init_fail;
 


### PR DESCRIPTION
Please see the first commit for a more in depth explanation.

Posting this since I would like to get some input on how to proceed before a merge happens.

The problem is that there is some code smell:
/crypto/hash/hmac.c:
`srtp_burn(a, sizeof(srtp_hmac_ctx_t) + sizeof(srtp_auth_t));`
/crypto/hash/hmac_ossl.c:
`srtp_burn(a, sizeof(HMAC_CTX) + sizeof(srtp_auth_t));`
/crypto/hash/null_auth.c:
`srtp_burn(a, sizeof(srtp_null_auth_ctx_t) + sizeof(srtp_auth_t));`

I'd like some input on if this is safe or not considering that we theoretically can exceed the limits of `size_t` by adding the result of two `sizeof()`s together, however this is not likely (?) since we are in control of the structures in question, as well as performing the memory allocation in one go in `srtp_crypto_alloc()` which would not succeed in allocating if we exceed the maximum value for 'size_t'.

Other than that please review with some scrutiny. :)