### PR TITLE
Don't use underscore as leading character in header guards.

### DIFF
--- a/crypto/include/aes.h
+++ b/crypto/include/aes.h
@@ -78,4 +78,4 @@ void srtp_aes_decrypt(v128_t *plaintext, const srtp_aes_expanded_key_t *exp_key)
 }
 #endif
 
-#endif /* _AES_H */
+#endif /* AES_H */

--- a/crypto/include/aes.h
+++ b/crypto/include/aes.h
@@ -43,8 +43,8 @@
  *
  */
 
-#ifndef _AES_H
-#define _AES_H
+#ifndef AES_H
+#define AES_H
 
 #include "datatypes.h"
 #include "err.h"

--- a/crypto/include/auth.h
+++ b/crypto/include/auth.h
@@ -43,8 +43,8 @@
  *
  */
 
-#ifndef AUTH_H
-#define AUTH_H
+#ifndef SRTP_AUTH_H
+#define SRTP_AUTH_H
 
 #include "srtp.h"
 #include "crypto_types.h"       /* for values of auth_type_id_t */
@@ -163,4 +163,4 @@ srtp_err_status_t srtp_replace_auth_type(const srtp_auth_type_t *ct, srtp_auth_t
 }
 #endif
 
-#endif /* AUTH_H */
+#endif /* SRTP_AUTH_H */

--- a/crypto/include/cipher.h
+++ b/crypto/include/cipher.h
@@ -43,8 +43,8 @@
  */
 
 
-#ifndef CIPHER_H
-#define CIPHER_H
+#ifndef SRTP_CIPHER_H
+#define SRTP_CIPHER_H
 
 #include "srtp.h"
 #include "crypto_types.h"       /* for values of cipher_type_id_t */
@@ -219,4 +219,4 @@ srtp_err_status_t srtp_replace_cipher_type(const srtp_cipher_type_t *ct, srtp_ci
 }
 #endif
 
-#endif /* CIPHER_H */
+#endif /* SRTP_CIPHER_H */

--- a/crypto/include/crypto_types.h
+++ b/crypto/include/crypto_types.h
@@ -42,8 +42,8 @@
  *
  */
 
-#ifndef CRYPTO_TYPES_H
-#define CRYPTO_TYPES_H
+#ifndef SRTP_CRYPTO_TYPES_H
+#define SRTP_CRYPTO_TYPES_H
 
 /*
  * The null cipher performs no encryption.
@@ -113,4 +113,4 @@
  */
 #define SRTP_HMAC_SHA1          3          
 
-#endif  /* CRYPTO_TYPES_H */
+#endif  /* SRTP_CRYPTO_TYPES_H */

--- a/crypto/include/datatypes.h
+++ b/crypto/include/datatypes.h
@@ -486,4 +486,4 @@ bitvector_bit_string(bitvector_t *x, char* buf, int len);
 }
 #endif
 
-#endif /* _DATATYPES_H */
+#endif /* DATATYPES_H */

--- a/crypto/include/datatypes.h
+++ b/crypto/include/datatypes.h
@@ -44,8 +44,8 @@
  */
 
 
-#ifndef _DATATYPES_H
-#define _DATATYPES_H
+#ifndef DATATYPES_H
+#define DATATYPES_H
 
 #include "integers.h"           /* definitions of uint32_t, et cetera   */
 #include "alloc.h"

--- a/include/ekt.h
+++ b/include/ekt.h
@@ -59,8 +59,8 @@
  *
  */
 
-#ifndef EKT_H
-#define EKT_H
+#ifndef SRTP_EKT_H
+#define SRTP_EKT_H
 
 #include "srtp_priv.h"
 
@@ -170,4 +170,4 @@ srtp_err_status_t srtcp_auth_tag_generation_postprocess(void);
 }
 #endif
 
-#endif /* EKT_H */
+#endif /* SRTP_EKT_H */

--- a/include/rtp.h
+++ b/include/rtp.h
@@ -51,8 +51,8 @@
  */
 
 
-#ifndef RTP_H
-#define RTP_H
+#ifndef SRTP_RTP_H
+#define SRTP_RTP_H
 
 #ifdef HAVE_NETINET_IN_H
 # include <netinet/in.h>
@@ -167,4 +167,4 @@ rtp_receiver_dealloc(rtp_receiver_t rtp_ctx);
 }
 #endif
 
-#endif /* RTP_H */
+#endif /* SRTP_RTP_H */

--- a/include/srtp.h
+++ b/include/srtp.h
@@ -43,8 +43,8 @@
  */
 
 
-#ifndef SRTP_H
-#define SRTP_H
+#ifndef SRTP_SRTP_H
+#define SRTP_SRTP_H
 
 #include <stdint.h>
 
@@ -1498,4 +1498,4 @@ srtp_err_status_t srtp_list_debug_modules(void);
 }
 #endif
 
-#endif /* SRTP_H */
+#endif /* SRTP_SRTP_H */

--- a/test/util.h
+++ b/test/util.h
@@ -41,8 +41,8 @@
  * OF THE POSSIBILITY OF SUCH DAMAGE.
  *
  */
-#ifndef _UTIL_H
-#define _UTIL_H
+#ifndef UTIL_H
+#define UTIL_H
 
 #define MAX_PRINT_STRING_LEN 1024
 


### PR DESCRIPTION
This address the concern in #114 , It still compiles both with and without opeenssl for me. Not sure if there is a platform where this will be a problem.