### PR TITLE
ekt is not really supported yet, remove from install

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -241,9 +241,8 @@ libsrtp2doc:
 install:
 	$(INSTALL) -d $(DESTDIR)$(includedir)/srtp2
 	$(INSTALL) -d $(DESTDIR)$(libdir)
-	cp $(srcdir)/include/srtp.h $(DESTDIR)$(includedir)/srtp2  
-	cp $(srcdir)/include/ekt.h $(DESTDIR)$(includedir)/srtp2  
-	cp $(srcdir)/include/rtp.h $(DESTDIR)$(includedir)/srtp2  
+	cp $(srcdir)/include/srtp.h $(DESTDIR)$(includedir)/srtp2
+	cp $(srcdir)/include/rtp.h $(DESTDIR)$(includedir)/srtp2
 	cp $(srcdir)/crypto/include/cipher.h $(DESTDIR)$(includedir)/srtp2
 	cp $(srcdir)/crypto/include/auth.h $(DESTDIR)$(includedir)/srtp2
 	cp $(srcdir)/crypto/include/crypto_types.h $(DESTDIR)$(includedir)/srtp2

--- a/include/ekt.h
+++ b/include/ekt.h
@@ -62,7 +62,8 @@
 #ifndef EKT_H
 #define EKT_H
 
-#include "srtp_priv.h"
+// left in commented out as reminder to not include private headers
+//#include "srtp_priv.h"
 
 #ifdef __cplusplus
 extern "C" {


### PR DESCRIPTION
The ekt support in master is not currently usable so remove it from the install. there is a ekt dev branch that will eventually be merged back to master, at which point the ekt header can be installed again.

This indirectly address #219 by not installing ekt.h .