### PR TITLE
test/rtp_decoder: Add missing conditional

### DIFF
--- a/test/rtp_decoder.c
+++ b/test/rtp_decoder.c
@@ -485,7 +485,7 @@ rtp_decoder_handle_pkt(u_char *arg, const struct pcap_pkthdr *hdr,
   srtp_err_status_t status;
   dcdr->frame_nr++;
 
-  if (dcdr->start_tv.tv_sec == 0) {
+  if ((dcdr->start_tv.tv_sec == 0) && (dcdr->start_tv.tv_usec == 0)) {
     dcdr->start_tv = hdr->ts;
   }
 


### PR DESCRIPTION
This conditional was incorrectly removed in PR #236 where it was just
incorrectly set to be a duplicate of `(dcdr->start_tv.tv_sec == 0)`.

It makes sense to check that the microseconds are 0 as well as these are
used later in the test in `timersub()` in order to calculate and display the 
ΔT for the operations.