### PR TITLE
Cipher type cleanup for aes

### DIFF
--- a/crypto/cipher/aes_gcm_ossl.c
+++ b/crypto/cipher/aes_gcm_ossl.c
@@ -93,8 +93,8 @@ static srtp_err_status_t srtp_aes_gcm_openssl_alloc (srtp_cipher_t **c, int key_
     /*
      * Verify the key_len is valid for one of: AES-128/256
      */
-    if (key_len != SRTP_AES_128_GCM_KEYSIZE_WSALT &&
-        key_len != SRTP_AES_256_GCM_KEYSIZE_WSALT) {
+    if (key_len != SRTP_AES_GCM_128_KEYSIZE_WSALT &&
+        key_len != SRTP_AES_GCM_256_KEYSIZE_WSALT) {
         return (srtp_err_status_bad_param);
     }
 
@@ -131,15 +131,15 @@ static srtp_err_status_t srtp_aes_gcm_openssl_alloc (srtp_cipher_t **c, int key_
 
     /* setup cipher attributes */
     switch (key_len) {
-    case SRTP_AES_128_GCM_KEYSIZE_WSALT:
+    case SRTP_AES_GCM_128_KEYSIZE_WSALT:
         (*c)->type = &srtp_aes_gcm_128_openssl;
-        (*c)->algorithm = SRTP_AES_128_GCM;
+        (*c)->algorithm = SRTP_AES_GCM_128;
         gcm->key_size = SRTP_AES_128_KEYSIZE;
         gcm->tag_len = tlen;
         break;
-    case SRTP_AES_256_GCM_KEYSIZE_WSALT:
+    case SRTP_AES_GCM_256_KEYSIZE_WSALT:
         (*c)->type = &srtp_aes_gcm_256_openssl;
-        (*c)->algorithm = SRTP_AES_256_GCM;
+        (*c)->algorithm = SRTP_AES_GCM_256;
         gcm->key_size = SRTP_AES_256_KEYSIZE;
         gcm->tag_len = tlen;
         break;
@@ -386,7 +386,7 @@ static const char srtp_aes_gcm_256_openssl_description[] = "AES-256 GCM using op
  * values we're derived from independent test code
  * using OpenSSL.
  */
-static const uint8_t srtp_aes_gcm_test_case_0_key[SRTP_AES_128_GCM_KEYSIZE_WSALT] = {
+static const uint8_t srtp_aes_gcm_test_case_0_key[SRTP_AES_GCM_128_KEYSIZE_WSALT] = {
     0xfe, 0xff, 0xe9, 0x92, 0x86, 0x65, 0x73, 0x1c,
     0x6d, 0x6a, 0x8f, 0x94, 0x67, 0x30, 0x83, 0x08,
     0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08,
@@ -430,7 +430,7 @@ static const uint8_t srtp_aes_gcm_test_case_0_ciphertext[76] = {
 };
 
 static const srtp_cipher_test_case_t srtp_aes_gcm_test_case_0a = {
-    SRTP_AES_128_GCM_KEYSIZE_WSALT,      /* octets in key            */
+    SRTP_AES_GCM_128_KEYSIZE_WSALT,      /* octets in key            */
     srtp_aes_gcm_test_case_0_key,        /* key                      */
     srtp_aes_gcm_test_case_0_iv,         /* packet index             */
     60,                                  /* octets in plaintext      */
@@ -444,7 +444,7 @@ static const srtp_cipher_test_case_t srtp_aes_gcm_test_case_0a = {
 };
 
 static const srtp_cipher_test_case_t srtp_aes_gcm_test_case_0 = {
-    SRTP_AES_128_GCM_KEYSIZE_WSALT,      /* octets in key            */
+    SRTP_AES_GCM_128_KEYSIZE_WSALT,      /* octets in key            */
     srtp_aes_gcm_test_case_0_key,        /* key                      */
     srtp_aes_gcm_test_case_0_iv,         /* packet index             */
     60,                                  /* octets in plaintext      */
@@ -457,7 +457,7 @@ static const srtp_cipher_test_case_t srtp_aes_gcm_test_case_0 = {
     &srtp_aes_gcm_test_case_0a           /* pointer to next testcase */
 };
 
-static const uint8_t srtp_aes_gcm_test_case_1_key[SRTP_AES_256_GCM_KEYSIZE_WSALT] = {
+static const uint8_t srtp_aes_gcm_test_case_1_key[SRTP_AES_GCM_256_KEYSIZE_WSALT] = {
     0xfe, 0xff, 0xe9, 0x92, 0x86, 0x65, 0x73, 0x1c,
     0xa5, 0x59, 0x09, 0xc5, 0x54, 0x66, 0x93, 0x1c,
     0xaf, 0xf5, 0x26, 0x9a, 0x21, 0xd5, 0x14, 0xb2,
@@ -504,7 +504,7 @@ static const uint8_t srtp_aes_gcm_test_case_1_ciphertext[76] = {
 };
 
 static const srtp_cipher_test_case_t srtp_aes_gcm_test_case_1a = {
-    SRTP_AES_256_GCM_KEYSIZE_WSALT,      /* octets in key            */
+    SRTP_AES_GCM_256_KEYSIZE_WSALT,      /* octets in key            */
     srtp_aes_gcm_test_case_1_key,        /* key                      */
     srtp_aes_gcm_test_case_1_iv,         /* packet index             */
     60,                                  /* octets in plaintext      */
@@ -518,7 +518,7 @@ static const srtp_cipher_test_case_t srtp_aes_gcm_test_case_1a = {
 };
 
 static const srtp_cipher_test_case_t srtp_aes_gcm_test_case_1 = {
-    SRTP_AES_256_GCM_KEYSIZE_WSALT,      /* octets in key            */
+    SRTP_AES_GCM_256_KEYSIZE_WSALT,      /* octets in key            */
     srtp_aes_gcm_test_case_1_key,        /* key                      */
     srtp_aes_gcm_test_case_1_iv,         /* packet index             */
     60,                                  /* octets in plaintext      */
@@ -545,7 +545,7 @@ const srtp_cipher_type_t srtp_aes_gcm_128_openssl = {
     srtp_aes_gcm_openssl_get_tag,
     srtp_aes_gcm_128_openssl_description,
     &srtp_aes_gcm_test_case_0,
-    SRTP_AES_128_GCM
+    SRTP_AES_GCM_128
 };
 
 /*
@@ -562,6 +562,6 @@ const srtp_cipher_type_t srtp_aes_gcm_256_openssl = {
     srtp_aes_gcm_openssl_get_tag,
     srtp_aes_gcm_256_openssl_description,
     &srtp_aes_gcm_test_case_1,
-    SRTP_AES_256_GCM
+    SRTP_AES_GCM_256
 };
 

--- a/crypto/cipher/aes_icm.c
+++ b/crypto/cipher/aes_icm.c
@@ -130,11 +130,11 @@ static srtp_err_status_t srtp_aes_icm_alloc (srtp_cipher_t **c, int key_len, int
 
     switch (key_len) {
     case 46:
-        (*c)->algorithm = SRTP_AES_256_ICM;
+        (*c)->algorithm = SRTP_AES_ICM_256;
         (*c)->type = &srtp_aes_icm_256;
         break;
     default:
-        (*c)->algorithm = SRTP_AES_128_ICM;
+        (*c)->algorithm = SRTP_AES_ICM_128;
         (*c)->type = &srtp_aes_icm_128;
         break;
     }
@@ -503,7 +503,7 @@ const srtp_cipher_type_t srtp_aes_icm_128 = {
     0,                          /* get_tag */
     srtp_aes_icm_128_description,
     &srtp_aes_icm_128_test_case_0,
-    SRTP_AES_128_ICM
+    SRTP_AES_ICM_128
 };
 
 const srtp_cipher_type_t srtp_aes_icm_256 = {
@@ -517,5 +517,5 @@ const srtp_cipher_type_t srtp_aes_icm_256 = {
     0,                          /* get_tag */
     srtp_aes_icm_256_description,
     &srtp_aes_icm_256_test_case_0,
-    SRTP_AES_256_ICM
+    SRTP_AES_ICM_256
 };

--- a/crypto/cipher/aes_icm.c
+++ b/crypto/cipher/aes_icm.c
@@ -106,7 +106,7 @@ static srtp_err_status_t srtp_aes_icm_alloc (srtp_cipher_t **c, int key_len, int
      * has not broken anything. Don't know what would be the
      * effect of skipping this check for srtp in general.
      */
-    if (key_len != 30 && key_len != 38 && key_len != 46) {
+    if (key_len != 30 && key_len != 46) {
         return srtp_err_status_bad_param;
     }
 
@@ -131,9 +131,6 @@ static srtp_err_status_t srtp_aes_icm_alloc (srtp_cipher_t **c, int key_len, int
     switch (key_len) {
     case 46:
         (*c)->algorithm = SRTP_AES_256_ICM;
-        break;
-    case 38:
-        (*c)->algorithm = SRTP_AES_192_ICM;
         break;
     default:
         (*c)->algorithm = SRTP_AES_128_ICM;

--- a/crypto/cipher/aes_icm.c
+++ b/crypto/cipher/aes_icm.c
@@ -404,47 +404,47 @@ static srtp_err_status_t srtp_aes_icm_encrypt (void *cv,
 static const char srtp_aes_icm_128_description[] = "AES-128 integer counter mode";
 static const char srtp_aes_icm_256_description[] = "AES-256 integer counter mode";
 
-static const uint8_t srtp_aes_icm_test_case_0_key[30] = {
+static const uint8_t srtp_aes_icm_128_test_case_0_key[30] = {
     0x2b, 0x7e, 0x15, 0x16, 0x28, 0xae, 0xd2, 0xa6,
     0xab, 0xf7, 0x15, 0x88, 0x09, 0xcf, 0x4f, 0x3c,
     0xf0, 0xf1, 0xf2, 0xf3, 0xf4, 0xf5, 0xf6, 0xf7,
     0xf8, 0xf9, 0xfa, 0xfb, 0xfc, 0xfd
 };
 
-static uint8_t srtp_aes_icm_test_case_0_nonce[16] = {
+static uint8_t srtp_aes_icm_128_test_case_0_nonce[16] = {
     0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
     0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00
 };
 
-static const uint8_t srtp_aes_icm_test_case_0_plaintext[32] =  {
+static const uint8_t srtp_aes_icm_128_test_case_0_plaintext[32] =  {
     0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
     0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
     0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
     0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
 };
 
-static const uint8_t srtp_aes_icm_test_case_0_ciphertext[32] = {
+static const uint8_t srtp_aes_icm_128_test_case_0_ciphertext[32] = {
     0xe0, 0x3e, 0xad, 0x09, 0x35, 0xc9, 0x5e, 0x80,
     0xe1, 0x66, 0xb1, 0x6d, 0xd9, 0x2b, 0x4e, 0xb4,
     0xd2, 0x35, 0x13, 0x16, 0x2b, 0x02, 0xd0, 0xf7,
     0x2a, 0x43, 0xa2, 0xfe, 0x4a, 0x5f, 0x97, 0xab
 };
 
-static const srtp_cipher_test_case_t srtp_aes_icm_test_case_0 = {
+static const srtp_cipher_test_case_t srtp_aes_icm_128_test_case_0 = {
     30,                                  /* octets in key            */
-    srtp_aes_icm_test_case_0_key,        /* key                      */
-    srtp_aes_icm_test_case_0_nonce,      /* packet index             */
+    srtp_aes_icm_128_test_case_0_key,        /* key                      */
+    srtp_aes_icm_128_test_case_0_nonce,      /* packet index             */
     32,                                  /* octets in plaintext      */
-    srtp_aes_icm_test_case_0_plaintext,  /* plaintext                */
+    srtp_aes_icm_128_test_case_0_plaintext,  /* plaintext                */
     32,                                  /* octets in ciphertext     */
-    srtp_aes_icm_test_case_0_ciphertext, /* ciphertext               */
+    srtp_aes_icm_128_test_case_0_ciphertext, /* ciphertext               */
     0,
     NULL,
     0,
     NULL                                 /* pointer to next testcase */
 };
 
-static const uint8_t srtp_aes_icm_test_case_1_key[46] = {
+static const uint8_t srtp_aes_icm_256_test_case_0_key[46] = {
     0x57, 0xf8, 0x2f, 0xe3, 0x61, 0x3f, 0xd1, 0x70,
     0xa8, 0x5e, 0xc9, 0x3c, 0x40, 0xb1, 0xf0, 0x92,
     0x2e, 0xc4, 0xcb, 0x0d, 0xc0, 0x25, 0xb5, 0x82,
@@ -453,33 +453,33 @@ static const uint8_t srtp_aes_icm_test_case_1_key[46] = {
     0xf8, 0xf9, 0xfa, 0xfb, 0xfc, 0xfd
 };
 
-static uint8_t srtp_aes_icm_test_case_1_nonce[16] = {
+static uint8_t srtp_aes_icm_256_test_case_0_nonce[16] = {
     0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
     0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00
 };
 
-static const uint8_t srtp_aes_icm_test_case_1_plaintext[32] =  {
+static const uint8_t srtp_aes_icm_256_test_case_0_plaintext[32] =  {
     0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
     0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
     0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
     0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
 };
 
-static const uint8_t srtp_aes_icm_test_case_1_ciphertext[32] = {
+static const uint8_t srtp_aes_icm_256_test_case_0_ciphertext[32] = {
     0x92, 0xbd, 0xd2, 0x8a, 0x93, 0xc3, 0xf5, 0x25,
     0x11, 0xc6, 0x77, 0xd0, 0x8b, 0x55, 0x15, 0xa4,
     0x9d, 0xa7, 0x1b, 0x23, 0x78, 0xa8, 0x54, 0xf6,
     0x70, 0x50, 0x75, 0x6d, 0xed, 0x16, 0x5b, 0xac
 };
 
-static const srtp_cipher_test_case_t srtp_aes_icm_test_case_1 = {
+static const srtp_cipher_test_case_t srtp_aes_icm_256_test_case_0 = {
     46,                                  /* octets in key            */
-    srtp_aes_icm_test_case_1_key,        /* key                      */
-    srtp_aes_icm_test_case_1_nonce,      /* packet index             */
+    srtp_aes_icm_256_test_case_0_key,        /* key                      */
+    srtp_aes_icm_256_test_case_0_nonce,      /* packet index             */
     32,                                  /* octets in plaintext      */
-    srtp_aes_icm_test_case_1_plaintext,  /* plaintext                */
+    srtp_aes_icm_256_test_case_0_plaintext,  /* plaintext                */
     32,                                  /* octets in ciphertext     */
-    srtp_aes_icm_test_case_1_ciphertext, /* ciphertext               */
+    srtp_aes_icm_256_test_case_0_ciphertext, /* ciphertext               */
     0,
     NULL,
     0,
@@ -502,7 +502,7 @@ const srtp_cipher_type_t srtp_aes_icm_128 = {
     srtp_aes_icm_set_iv,
     0,                          /* get_tag */
     srtp_aes_icm_128_description,
-    &srtp_aes_icm_test_case_0,
+    &srtp_aes_icm_128_test_case_0,
     SRTP_AES_128_ICM
 };
 
@@ -516,6 +516,6 @@ const srtp_cipher_type_t srtp_aes_icm_256 = {
     srtp_aes_icm_set_iv,
     0,                          /* get_tag */
     srtp_aes_icm_256_description,
-    &srtp_aes_icm_test_case_1,
+    &srtp_aes_icm_256_test_case_0,
     SRTP_AES_256_ICM
 };

--- a/crypto/cipher/aes_icm.c
+++ b/crypto/cipher/aes_icm.c
@@ -57,6 +57,8 @@ srtp_debug_module_t srtp_mod_aes_icm = {
     0,               /* debugging is off by default */
     "aes icm"        /* printable module name       */
 };
+extern const srtp_cipher_type_t srtp_aes_icm_128;
+extern const srtp_cipher_type_t srtp_aes_icm_256;
 
 /*
  * integer counter mode works as follows:
@@ -94,7 +96,6 @@ srtp_debug_module_t srtp_mod_aes_icm = {
 
 static srtp_err_status_t srtp_aes_icm_alloc (srtp_cipher_t **c, int key_len, int tlen)
 {
-    extern const srtp_cipher_type_t srtp_aes_icm;
     srtp_aes_icm_ctx_t *icm;
 
     debug_print(srtp_mod_aes_icm,
@@ -126,14 +127,15 @@ static srtp_err_status_t srtp_aes_icm_alloc (srtp_cipher_t **c, int key_len, int
 
     /* set pointers */
     (*c)->state = icm;
-    (*c)->type = &srtp_aes_icm;
 
     switch (key_len) {
     case 46:
         (*c)->algorithm = SRTP_AES_256_ICM;
+        (*c)->type = &srtp_aes_icm_256;
         break;
     default:
         (*c)->algorithm = SRTP_AES_128_ICM;
+        (*c)->type = &srtp_aes_icm_128;
         break;
     }
 
@@ -399,7 +401,8 @@ static srtp_err_status_t srtp_aes_icm_encrypt (void *cv,
     return srtp_err_status_ok;
 }
 
-static const char srtp_aes_icm_description[] = "aes integer counter mode";
+static const char srtp_aes_icm_128_description[] = "AES-128 integer counter mode";
+static const char srtp_aes_icm_256_description[] = "AES-256 integer counter mode";
 
 static const uint8_t srtp_aes_icm_test_case_0_key[30] = {
     0x2b, 0x7e, 0x15, 0x16, 0x28, 0xae, 0xd2, 0xa6,
@@ -480,7 +483,7 @@ static const srtp_cipher_test_case_t srtp_aes_icm_test_case_1 = {
     0,
     NULL,
     0,
-    &srtp_aes_icm_test_case_0                 /* pointer to next testcase */
+    NULL,                 /* pointer to next testcase */
 };
 
 
@@ -489,7 +492,7 @@ static const srtp_cipher_test_case_t srtp_aes_icm_test_case_1 = {
  * note: the encrypt function is identical to the decrypt function
  */
 
-const srtp_cipher_type_t srtp_aes_icm = {
+const srtp_cipher_type_t srtp_aes_icm_128 = {
     srtp_aes_icm_alloc,
     srtp_aes_icm_dealloc,
     srtp_aes_icm_context_init,
@@ -498,8 +501,21 @@ const srtp_cipher_type_t srtp_aes_icm = {
     srtp_aes_icm_encrypt,
     srtp_aes_icm_set_iv,
     0,                          /* get_tag */
-    srtp_aes_icm_description,
-    &srtp_aes_icm_test_case_1,
-    SRTP_AES_ICM
+    srtp_aes_icm_128_description,
+    &srtp_aes_icm_test_case_0,
+    SRTP_AES_128_ICM
 };
 
+const srtp_cipher_type_t srtp_aes_icm_256 = {
+    srtp_aes_icm_alloc,
+    srtp_aes_icm_dealloc,
+    srtp_aes_icm_context_init,
+    0,                          /* set_aad */
+    srtp_aes_icm_encrypt,
+    srtp_aes_icm_encrypt,
+    srtp_aes_icm_set_iv,
+    0,                          /* get_tag */
+    srtp_aes_icm_256_description,
+    &srtp_aes_icm_test_case_1,
+    SRTP_AES_256_ICM
+};

--- a/crypto/cipher/aes_icm_ossl.c
+++ b/crypto/cipher/aes_icm_ossl.c
@@ -471,7 +471,7 @@ const srtp_cipher_type_t srtp_aes_icm_128 = {
     0,                           /* get_tag */
     srtp_aes_icm_128_openssl_description,
     &srtp_aes_icm_test_case_0,
-    SRTP_AES_ICM
+    SRTP_AES_128_ICM
 };
 
 /*

--- a/crypto/cipher/aes_icm_ossl.c
+++ b/crypto/cipher/aes_icm_ossl.c
@@ -63,7 +63,7 @@ srtp_debug_module_t srtp_mod_aes_icm = {
     0,               /* debugging is off by default */
     "aes icm ossl"   /* printable module name       */
 };
-extern const srtp_cipher_type_t srtp_aes_icm;
+extern const srtp_cipher_type_t srtp_aes_icm_128;
 extern const srtp_cipher_type_t srtp_aes_icm_192;
 extern const srtp_cipher_type_t srtp_aes_icm_256;
 
@@ -153,7 +153,7 @@ static srtp_err_status_t srtp_aes_icm_openssl_alloc (srtp_cipher_t **c, int key_
     switch (key_len) {
     case SRTP_AES_128_KEYSIZE_WSALT:
         (*c)->algorithm = SRTP_AES_128_ICM;
-        (*c)->type = &srtp_aes_icm;
+        (*c)->type = &srtp_aes_icm_128;
         icm->key_size = SRTP_AES_128_KEYSIZE;
         break;
     case SRTP_AES_192_KEYSIZE_WSALT:
@@ -316,7 +316,7 @@ static srtp_err_status_t srtp_aes_icm_openssl_encrypt (void *cv, unsigned char *
 /*
  * Name of this crypto engine
  */
-static const char srtp_aes_icm_openssl_description[] = "AES-128 counter mode using openssl";
+static const char srtp_aes_icm_128_openssl_description[] = "AES-128 counter mode using openssl";
 static const char srtp_aes_icm_192_openssl_description[] = "AES-192 counter mode using openssl";
 static const char srtp_aes_icm_256_openssl_description[] = "AES-256 counter mode using openssl";
 
@@ -460,7 +460,7 @@ static const srtp_cipher_test_case_t srtp_aes_icm_256_test_case_2 = {
  * This is the function table for this crypto engine.
  * note: the encrypt function is identical to the decrypt function
  */
-const srtp_cipher_type_t srtp_aes_icm = {
+const srtp_cipher_type_t srtp_aes_icm_128 = {
     srtp_aes_icm_openssl_alloc,
     srtp_aes_icm_openssl_dealloc,
     srtp_aes_icm_openssl_context_init,
@@ -469,7 +469,7 @@ const srtp_cipher_type_t srtp_aes_icm = {
     srtp_aes_icm_openssl_encrypt,
     srtp_aes_icm_openssl_set_iv,
     0,                           /* get_tag */
-    srtp_aes_icm_openssl_description,
+    srtp_aes_icm_128_openssl_description,
     &srtp_aes_icm_test_case_0,
     SRTP_AES_ICM
 };

--- a/crypto/cipher/aes_icm_ossl.c
+++ b/crypto/cipher/aes_icm_ossl.c
@@ -152,17 +152,17 @@ static srtp_err_status_t srtp_aes_icm_openssl_alloc (srtp_cipher_t **c, int key_
     /* setup cipher parameters */
     switch (key_len) {
     case SRTP_AES_128_KEYSIZE_WSALT:
-        (*c)->algorithm = SRTP_AES_128_ICM;
+        (*c)->algorithm = SRTP_AES_ICM_128;
         (*c)->type = &srtp_aes_icm_128;
         icm->key_size = SRTP_AES_128_KEYSIZE;
         break;
     case SRTP_AES_192_KEYSIZE_WSALT:
-        (*c)->algorithm = SRTP_AES_192_ICM;
+        (*c)->algorithm = SRTP_AES_ICM_192;
         (*c)->type = &srtp_aes_icm_192;
         icm->key_size = SRTP_AES_192_KEYSIZE;
         break;
     case SRTP_AES_256_KEYSIZE_WSALT:
-        (*c)->algorithm = SRTP_AES_256_ICM;
+        (*c)->algorithm = SRTP_AES_ICM_256;
         (*c)->type = &srtp_aes_icm_256;
         icm->key_size = SRTP_AES_256_KEYSIZE;
         break;
@@ -471,7 +471,7 @@ const srtp_cipher_type_t srtp_aes_icm_128 = {
     0,                           /* get_tag */
     srtp_aes_icm_128_openssl_description,
     &srtp_aes_icm_128_test_case_0,
-    SRTP_AES_128_ICM
+    SRTP_AES_ICM_128
 };
 
 /*
@@ -489,7 +489,7 @@ const srtp_cipher_type_t srtp_aes_icm_192 = {
     0,                           /* get_tag */
     srtp_aes_icm_192_openssl_description,
     &srtp_aes_icm_192_test_case_0,
-    SRTP_AES_192_ICM
+    SRTP_AES_ICM_192
 };
 
 /*
@@ -507,6 +507,6 @@ const srtp_cipher_type_t srtp_aes_icm_256 = {
     0,                           /* get_tag */
     srtp_aes_icm_256_openssl_description,
     &srtp_aes_icm_256_test_case_0,
-    SRTP_AES_256_ICM
+    SRTP_AES_ICM_256
 };
 

--- a/crypto/cipher/aes_icm_ossl.c
+++ b/crypto/cipher/aes_icm_ossl.c
@@ -325,40 +325,40 @@ static const char srtp_aes_icm_256_openssl_description[] = "AES-256 counter mode
  * KAT values for AES self-test.  These
  * values came from the legacy libsrtp code.
  */
-static const uint8_t srtp_aes_icm_test_case_0_key[SRTP_AES_128_KEYSIZE_WSALT] = {
+static const uint8_t srtp_aes_icm_128_test_case_0_key[SRTP_AES_128_KEYSIZE_WSALT] = {
     0x2b, 0x7e, 0x15, 0x16, 0x28, 0xae, 0xd2, 0xa6,
     0xab, 0xf7, 0x15, 0x88, 0x09, 0xcf, 0x4f, 0x3c,
     0xf0, 0xf1, 0xf2, 0xf3, 0xf4, 0xf5, 0xf6, 0xf7,
     0xf8, 0xf9, 0xfa, 0xfb, 0xfc, 0xfd
 };
 
-static uint8_t srtp_aes_icm_test_case_0_nonce[16] = {
+static uint8_t srtp_aes_icm_128_test_case_0_nonce[16] = {
     0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
     0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00
 };
 
-static const uint8_t srtp_aes_icm_test_case_0_plaintext[32] =  {
+static const uint8_t srtp_aes_icm_128_test_case_0_plaintext[32] =  {
     0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
     0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
     0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
     0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
 };
 
-static const uint8_t srtp_aes_icm_test_case_0_ciphertext[32] = {
+static const uint8_t srtp_aes_icm_128_test_case_0_ciphertext[32] = {
     0xe0, 0x3e, 0xad, 0x09, 0x35, 0xc9, 0x5e, 0x80,
     0xe1, 0x66, 0xb1, 0x6d, 0xd9, 0x2b, 0x4e, 0xb4,
     0xd2, 0x35, 0x13, 0x16, 0x2b, 0x02, 0xd0, 0xf7,
     0x2a, 0x43, 0xa2, 0xfe, 0x4a, 0x5f, 0x97, 0xab
 };
 
-static const srtp_cipher_test_case_t srtp_aes_icm_test_case_0 = {
+static const srtp_cipher_test_case_t srtp_aes_icm_128_test_case_0 = {
     SRTP_AES_128_KEYSIZE_WSALT,                 /* octets in key            */
-    srtp_aes_icm_test_case_0_key,               /* key                      */
-    srtp_aes_icm_test_case_0_nonce,             /* packet index             */
+    srtp_aes_icm_128_test_case_0_key,               /* key                      */
+    srtp_aes_icm_128_test_case_0_nonce,             /* packet index             */
     32,                                    /* octets in plaintext      */
-    srtp_aes_icm_test_case_0_plaintext,         /* plaintext                */
+    srtp_aes_icm_128_test_case_0_plaintext,         /* plaintext                */
     32,                                    /* octets in ciphertext     */
-    srtp_aes_icm_test_case_0_ciphertext,        /* ciphertext               */
+    srtp_aes_icm_128_test_case_0_ciphertext,        /* ciphertext               */
     0,
     NULL,
     0,
@@ -369,7 +369,7 @@ static const srtp_cipher_test_case_t srtp_aes_icm_test_case_0 = {
  * KAT values for AES-192-CTR self-test.  These
  * values came from section 7 of RFC 6188.
  */
-static const uint8_t srtp_aes_icm_192_test_case_1_key[SRTP_AES_192_KEYSIZE_WSALT] = {
+static const uint8_t srtp_aes_icm_192_test_case_0_key[SRTP_AES_192_KEYSIZE_WSALT] = {
     0xea, 0xb2, 0x34, 0x76, 0x4e, 0x51, 0x7b, 0x2d,
     0x3d, 0x16, 0x0d, 0x58, 0x7d, 0x8c, 0x86, 0x21,
     0x97, 0x40, 0xf6, 0x5f, 0x99, 0xb6, 0xbc, 0xf7,
@@ -377,33 +377,33 @@ static const uint8_t srtp_aes_icm_192_test_case_1_key[SRTP_AES_192_KEYSIZE_WSALT
     0xf8, 0xf9, 0xfa, 0xfb, 0xfc, 0xfd
 };
 
-static uint8_t srtp_aes_icm_192_test_case_1_nonce[16] = {
+static uint8_t srtp_aes_icm_192_test_case_0_nonce[16] = {
     0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
     0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00
 };
 
-static const uint8_t srtp_aes_icm_192_test_case_1_plaintext[32] =  {
+static const uint8_t srtp_aes_icm_192_test_case_0_plaintext[32] =  {
     0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
     0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
     0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
     0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
 };
 
-static const uint8_t srtp_aes_icm_192_test_case_1_ciphertext[32] = {
+static const uint8_t srtp_aes_icm_192_test_case_0_ciphertext[32] = {
     0x35, 0x09, 0x6c, 0xba, 0x46, 0x10, 0x02, 0x8d,
     0xc1, 0xb5, 0x75, 0x03, 0x80, 0x4c, 0xe3, 0x7c,
     0x5d, 0xe9, 0x86, 0x29, 0x1d, 0xcc, 0xe1, 0x61,
     0xd5, 0x16, 0x5e, 0xc4, 0x56, 0x8f, 0x5c, 0x9a
 };
 
-static const srtp_cipher_test_case_t srtp_aes_icm_192_test_case_1 = {
+static const srtp_cipher_test_case_t srtp_aes_icm_192_test_case_0 = {
     SRTP_AES_192_KEYSIZE_WSALT,                 /* octets in key            */
-    srtp_aes_icm_192_test_case_1_key,           /* key                      */
-    srtp_aes_icm_192_test_case_1_nonce,         /* packet index             */
+    srtp_aes_icm_192_test_case_0_key,           /* key                      */
+    srtp_aes_icm_192_test_case_0_nonce,         /* packet index             */
     32,                                    /* octets in plaintext      */
-    srtp_aes_icm_192_test_case_1_plaintext,     /* plaintext                */
+    srtp_aes_icm_192_test_case_0_plaintext,     /* plaintext                */
     32,                                    /* octets in ciphertext     */
-    srtp_aes_icm_192_test_case_1_ciphertext,    /* ciphertext               */
+    srtp_aes_icm_192_test_case_0_ciphertext,    /* ciphertext               */
     0,
     NULL,
     0,
@@ -414,7 +414,7 @@ static const srtp_cipher_test_case_t srtp_aes_icm_192_test_case_1 = {
  * KAT values for AES-256-CTR self-test.  These
  * values came from section 7 of RFC 6188.
  */
-static const uint8_t srtp_aes_icm_256_test_case_2_key[SRTP_AES_256_KEYSIZE_WSALT] = {
+static const uint8_t srtp_aes_icm_256_test_case_0_key[SRTP_AES_256_KEYSIZE_WSALT] = {
     0x57, 0xf8, 0x2f, 0xe3, 0x61, 0x3f, 0xd1, 0x70,
     0xa8, 0x5e, 0xc9, 0x3c, 0x40, 0xb1, 0xf0, 0x92,
     0x2e, 0xc4, 0xcb, 0x0d, 0xc0, 0x25, 0xb5, 0x82,
@@ -423,33 +423,33 @@ static const uint8_t srtp_aes_icm_256_test_case_2_key[SRTP_AES_256_KEYSIZE_WSALT
     0xf8, 0xf9, 0xfa, 0xfb, 0xfc, 0xfd
 };
 
-static uint8_t srtp_aes_icm_256_test_case_2_nonce[16] = {
+static uint8_t srtp_aes_icm_256_test_case_0_nonce[16] = {
     0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
     0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00
 };
 
-static const uint8_t srtp_aes_icm_256_test_case_2_plaintext[32] =  {
+static const uint8_t srtp_aes_icm_256_test_case_0_plaintext[32] =  {
     0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
     0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
     0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
     0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
 };
 
-static const uint8_t srtp_aes_icm_256_test_case_2_ciphertext[32] = {
+static const uint8_t srtp_aes_icm_256_test_case_0_ciphertext[32] = {
     0x92, 0xbd, 0xd2, 0x8a, 0x93, 0xc3, 0xf5, 0x25,
     0x11, 0xc6, 0x77, 0xd0, 0x8b, 0x55, 0x15, 0xa4,
     0x9d, 0xa7, 0x1b, 0x23, 0x78, 0xa8, 0x54, 0xf6,
     0x70, 0x50, 0x75, 0x6d, 0xed, 0x16, 0x5b, 0xac
 };
 
-static const srtp_cipher_test_case_t srtp_aes_icm_256_test_case_2 = {
+static const srtp_cipher_test_case_t srtp_aes_icm_256_test_case_0 = {
     SRTP_AES_256_KEYSIZE_WSALT,                 /* octets in key            */
-    srtp_aes_icm_256_test_case_2_key,           /* key                      */
-    srtp_aes_icm_256_test_case_2_nonce,         /* packet index             */
+    srtp_aes_icm_256_test_case_0_key,           /* key                      */
+    srtp_aes_icm_256_test_case_0_nonce,         /* packet index             */
     32,                                    /* octets in plaintext      */
-    srtp_aes_icm_256_test_case_2_plaintext,     /* plaintext                */
+    srtp_aes_icm_256_test_case_0_plaintext,     /* plaintext                */
     32,                                    /* octets in ciphertext     */
-    srtp_aes_icm_256_test_case_2_ciphertext,    /* ciphertext               */
+    srtp_aes_icm_256_test_case_0_ciphertext,    /* ciphertext               */
     0,
     NULL,
     0,
@@ -470,7 +470,7 @@ const srtp_cipher_type_t srtp_aes_icm_128 = {
     srtp_aes_icm_openssl_set_iv,
     0,                           /* get_tag */
     srtp_aes_icm_128_openssl_description,
-    &srtp_aes_icm_test_case_0,
+    &srtp_aes_icm_128_test_case_0,
     SRTP_AES_128_ICM
 };
 
@@ -488,7 +488,7 @@ const srtp_cipher_type_t srtp_aes_icm_192 = {
     srtp_aes_icm_openssl_set_iv,
     0,                           /* get_tag */
     srtp_aes_icm_192_openssl_description,
-    &srtp_aes_icm_192_test_case_1,
+    &srtp_aes_icm_192_test_case_0,
     SRTP_AES_192_ICM
 };
 
@@ -506,7 +506,7 @@ const srtp_cipher_type_t srtp_aes_icm_256 = {
     srtp_aes_icm_openssl_set_iv,
     0,                           /* get_tag */
     srtp_aes_icm_256_openssl_description,
-    &srtp_aes_icm_256_test_case_2,
+    &srtp_aes_icm_256_test_case_0,
     SRTP_AES_256_ICM
 };
 

--- a/crypto/cipher/cipher.c
+++ b/crypto/cipher/cipher.c
@@ -261,7 +261,7 @@ srtp_err_status_t srtp_cipher_type_test (const srtp_cipher_type_t *ct, const srt
             return status;
         }
 
-        if (c->algorithm == SRTP_AES_128_GCM || c->algorithm == SRTP_AES_256_GCM) {
+        if (c->algorithm == SRTP_AES_GCM_128 || c->algorithm == SRTP_AES_GCM_256) {
             debug_print(srtp_mod_cipher, "IV:    %s",
                         srtp_octet_string_hex_string(test_case->idx, 12));
 
@@ -286,7 +286,7 @@ srtp_err_status_t srtp_cipher_type_test (const srtp_cipher_type_t *ct, const srt
             return status;
         }
 
-        if (c->algorithm == SRTP_AES_128_GCM || c->algorithm == SRTP_AES_256_GCM) {
+        if (c->algorithm == SRTP_AES_GCM_128 || c->algorithm == SRTP_AES_GCM_256) {
             /*
              * Get the GCM tag
              */
@@ -361,7 +361,7 @@ srtp_err_status_t srtp_cipher_type_test (const srtp_cipher_type_t *ct, const srt
             return status;
         }
 
-        if (c->algorithm == SRTP_AES_128_GCM || c->algorithm == SRTP_AES_256_GCM) {
+        if (c->algorithm == SRTP_AES_GCM_128 || c->algorithm == SRTP_AES_GCM_256) {
             /*
              * Set the AAD
              */
@@ -491,7 +491,7 @@ srtp_err_status_t srtp_cipher_type_test (const srtp_cipher_type_t *ct, const srt
             return status;
         }
 
-        if (c->algorithm == SRTP_AES_128_GCM || c->algorithm == SRTP_AES_256_GCM) {
+        if (c->algorithm == SRTP_AES_GCM_128 || c->algorithm == SRTP_AES_GCM_256) {
             /*
              * Set the AAD
              */
@@ -512,7 +512,7 @@ srtp_err_status_t srtp_cipher_type_test (const srtp_cipher_type_t *ct, const srt
             srtp_cipher_dealloc(c);
             return status;
         }
-        if (c->algorithm == SRTP_AES_128_GCM || c->algorithm == SRTP_AES_256_GCM) {
+        if (c->algorithm == SRTP_AES_GCM_128 || c->algorithm == SRTP_AES_GCM_256) {
             /*
              * Get the GCM tag
              */
@@ -540,7 +540,7 @@ srtp_err_status_t srtp_cipher_type_test (const srtp_cipher_type_t *ct, const srt
             srtp_cipher_dealloc(c);
             return status;
         }
-        if (c->algorithm == SRTP_AES_128_GCM || c->algorithm == SRTP_AES_256_GCM) {
+        if (c->algorithm == SRTP_AES_GCM_128 || c->algorithm == SRTP_AES_GCM_256) {
             /*
              * Set the AAD
              */

--- a/crypto/include/crypto_types.h
+++ b/crypto/include/crypto_types.h
@@ -61,7 +61,7 @@
  * Secure RTP.  This cipher uses a 16-octet key concatenated with a
  * 14-octet offset (or salt) value.
  */
-#define SRTP_AES_128_ICM        1
+#define SRTP_AES_ICM_128        1
 
 /* 
  * AES-192 Integer Counter Mode (AES ICM)
@@ -70,7 +70,7 @@
  * Secure RTP.  This cipher uses a 24-octet key concatenated with a
  * 14-octet offset (or salt) value.
  */
-#define SRTP_AES_192_ICM        4 
+#define SRTP_AES_ICM_192        4
 
 /* 
  * AES-256 Integer Counter Mode (AES ICM)
@@ -79,7 +79,7 @@
  * Secure RTP.  This cipher uses a 32-octet key concatenated with a
  * 14-octet offset (or salt) value.
  */
-#define SRTP_AES_256_ICM        5 
+#define SRTP_AES_ICM_256        5
 
 /* 
  * AES-128_GCM Galois Counter Mode (AES GCM)             
@@ -87,7 +87,7 @@
  * AES-128 GCM is the variant of galois counter mode that is used by 
  * Secure RTP.  This cipher uses a 16-octet key.
  */
-#define SRTP_AES_128_GCM        6            
+#define SRTP_AES_GCM_128        6
 
 /* 
  * AES-256_GCM Galois Counter Mode (AES GCM)             
@@ -95,7 +95,7 @@
  * AES-256 GCM is the variant of galois counter mode that is used by 
  * Secure RTP.  This cipher uses a 32-octet key.
  */
-#define SRTP_AES_256_GCM        7            
+#define SRTP_AES_GCM_256        7
 
 /*
  * The null authentication function performs no authentication.

--- a/crypto/include/crypto_types.h
+++ b/crypto/include/crypto_types.h
@@ -55,29 +55,29 @@
 #define SRTP_NULL_CIPHER        0            
 
 /* 
- * AES Integer Counter Mode (AES ICM)             
+ * AES-128 Integer Counter Mode (AES ICM)
  *
- * AES ICM is the variant of counter mode that is used by Secure RTP.  
- * This cipher uses a 16-, 24-, or 32-octet key concatenated with a
+ * AES-128 ICM is the variant of counter mode that is used by
+ * Secure RTP.  This cipher uses a 16-octet key concatenated with a
  * 14-octet offset (or salt) value.
  */
-#define SRTP_AES_ICM            1            
+#define SRTP_AES_128_ICM        1
 
 /* 
- * AES-128 Integer Counter Mode (AES ICM)             
- * AES-128 ICM is a deprecated alternate name for AES ICM.
- */
-#define SRTP_AES_128_ICM        SRTP_AES_ICM
-
-/* 
- * AES-192 Integer Counter Mode (AES ICM)             
- * AES-192 ICM is a deprecated alternate name for AES ICM.
+ * AES-192 Integer Counter Mode (AES ICM)
+ *
+ * AES-128 ICM is the variant of counter mode that is used by
+ * Secure RTP.  This cipher uses a 24-octet key concatenated with a
+ * 14-octet offset (or salt) value.
  */
 #define SRTP_AES_192_ICM        4 
 
 /* 
- * AES-256 Integer Counter Mode (AES ICM)             
- * AES-256 ICM is a deprecated alternate name for AES ICM.
+ * AES-256 Integer Counter Mode (AES ICM)
+ *
+ * AES-128 ICM is the variant of counter mode that is used by
+ * Secure RTP.  This cipher uses a 32-octet key concatenated with a
+ * 14-octet offset (or salt) value.
  */
 #define SRTP_AES_256_ICM        5 
 

--- a/crypto/kernel/crypto_kernel.c
+++ b/crypto/kernel/crypto_kernel.c
@@ -154,11 +154,11 @@ srtp_err_status_t srtp_crypto_kernel_init ()
     if (status) {
         return status;
     }
-    status = srtp_crypto_kernel_load_cipher_type(&srtp_aes_icm_128, SRTP_AES_128_ICM);
+    status = srtp_crypto_kernel_load_cipher_type(&srtp_aes_icm_128, SRTP_AES_ICM_128);
     if (status) {
         return status;
     }
-    status = srtp_crypto_kernel_load_cipher_type(&srtp_aes_icm_256, SRTP_AES_256_ICM);
+    status = srtp_crypto_kernel_load_cipher_type(&srtp_aes_icm_256, SRTP_AES_ICM_256);
     if (status) {
         return status;
     }
@@ -167,15 +167,15 @@ srtp_err_status_t srtp_crypto_kernel_init ()
         return status;
     }
 #ifdef OPENSSL
-    status = srtp_crypto_kernel_load_cipher_type(&srtp_aes_icm_192, SRTP_AES_192_ICM);
+    status = srtp_crypto_kernel_load_cipher_type(&srtp_aes_icm_192, SRTP_AES_ICM_192);
     if (status) {
         return status;
     }
-    status = srtp_crypto_kernel_load_cipher_type(&srtp_aes_gcm_128_openssl, SRTP_AES_128_GCM);
+    status = srtp_crypto_kernel_load_cipher_type(&srtp_aes_gcm_128_openssl, SRTP_AES_GCM_128);
     if (status) {
         return status;
     }
-    status = srtp_crypto_kernel_load_cipher_type(&srtp_aes_gcm_256_openssl, SRTP_AES_256_GCM);
+    status = srtp_crypto_kernel_load_cipher_type(&srtp_aes_gcm_256_openssl, SRTP_AES_GCM_256);
     if (status) {
         return status;
     }

--- a/crypto/kernel/crypto_kernel.c
+++ b/crypto/kernel/crypto_kernel.c
@@ -72,10 +72,10 @@ extern srtp_debug_module_t mod_alloc;
  */
 
 extern srtp_cipher_type_t srtp_null_cipher;
-extern srtp_cipher_type_t srtp_aes_icm;
+extern srtp_cipher_type_t srtp_aes_icm_128;
+extern srtp_cipher_type_t srtp_aes_icm_256;
 #ifdef OPENSSL
 extern srtp_cipher_type_t srtp_aes_icm_192;
-extern srtp_cipher_type_t srtp_aes_icm_256;
 extern srtp_cipher_type_t srtp_aes_gcm_128_openssl;
 extern srtp_cipher_type_t srtp_aes_gcm_256_openssl;
 #endif
@@ -154,7 +154,11 @@ srtp_err_status_t srtp_crypto_kernel_init ()
     if (status) {
         return status;
     }
-    status = srtp_crypto_kernel_load_cipher_type(&srtp_aes_icm, SRTP_AES_ICM);
+    status = srtp_crypto_kernel_load_cipher_type(&srtp_aes_icm_128, SRTP_AES_128_ICM);
+    if (status) {
+        return status;
+    }
+    status = srtp_crypto_kernel_load_cipher_type(&srtp_aes_icm_256, SRTP_AES_256_ICM);
     if (status) {
         return status;
     }
@@ -164,10 +168,6 @@ srtp_err_status_t srtp_crypto_kernel_init ()
     }
 #ifdef OPENSSL
     status = srtp_crypto_kernel_load_cipher_type(&srtp_aes_icm_192, SRTP_AES_192_ICM);
-    if (status) {
-        return status;
-    }
-    status = srtp_crypto_kernel_load_cipher_type(&srtp_aes_icm_256, SRTP_AES_256_ICM);
     if (status) {
         return status;
     }

--- a/crypto/test/cipher_driver.c
+++ b/crypto/test/cipher_driver.c
@@ -121,10 +121,10 @@ check_status(srtp_err_status_t s) {
  */
 
 extern srtp_cipher_type_t srtp_null_cipher;
-extern srtp_cipher_type_t srtp_aes_icm;
+extern srtp_cipher_type_t srtp_aes_icm_128;
+extern srtp_cipher_type_t srtp_aes_icm_256;
 #ifdef OPENSSL
 extern srtp_cipher_type_t srtp_aes_icm_192;
-extern srtp_cipher_type_t srtp_aes_icm_256;
 extern srtp_cipher_type_t srtp_aes_gcm_128_openssl;
 extern srtp_cipher_type_t srtp_aes_gcm_256_openssl;
 #endif
@@ -182,34 +182,31 @@ main(int argc, char *argv[]) {
       cipher_driver_test_array_throughput(&srtp_null_cipher, 0, num_cipher); 
 
     for (num_cipher=1; num_cipher < max_num_cipher; num_cipher *=8)
-      cipher_driver_test_array_throughput(&srtp_aes_icm, 30, num_cipher); 
-
-#ifndef OPENSSL
-    for (num_cipher=1; num_cipher < max_num_cipher; num_cipher *=8)
-      cipher_driver_test_array_throughput(&srtp_aes_icm, 46, num_cipher); 
-#else
-    for (num_cipher=1; num_cipher < max_num_cipher; num_cipher *=8)
-      cipher_driver_test_array_throughput(&srtp_aes_icm_192, 38, num_cipher); 
+      cipher_driver_test_array_throughput(&srtp_aes_icm_128, 30, num_cipher);
 
     for (num_cipher=1; num_cipher < max_num_cipher; num_cipher *=8)
-      cipher_driver_test_array_throughput(&srtp_aes_icm_256, 46, num_cipher); 
+      cipher_driver_test_array_throughput(&srtp_aes_icm_256, 46, num_cipher);
+
+#ifdef OPENSSL
+    for (num_cipher=1; num_cipher < max_num_cipher; num_cipher *=8)
+      cipher_driver_test_array_throughput(&srtp_aes_icm_192, 38, num_cipher);
 
     for (num_cipher=1; num_cipher < max_num_cipher; num_cipher *=8) {
-	cipher_driver_test_array_throughput(&srtp_aes_gcm_128_openssl, SRTP_AES_128_GCM_KEYSIZE_WSALT, num_cipher);         
+      cipher_driver_test_array_throughput(&srtp_aes_gcm_128_openssl, SRTP_AES_128_GCM_KEYSIZE_WSALT, num_cipher);
     }
 
     for (num_cipher=1; num_cipher < max_num_cipher; num_cipher *=8) {
-	cipher_driver_test_array_throughput(&srtp_aes_gcm_256_openssl, SRTP_AES_256_GCM_KEYSIZE_WSALT, num_cipher);         
+      cipher_driver_test_array_throughput(&srtp_aes_gcm_256_openssl, SRTP_AES_256_GCM_KEYSIZE_WSALT, num_cipher);
     }
 #endif
   }
 
   if (do_validation) {
     cipher_driver_self_test(&srtp_null_cipher);
-    cipher_driver_self_test(&srtp_aes_icm);
+    cipher_driver_self_test(&srtp_aes_icm_128);
+    cipher_driver_self_test(&srtp_aes_icm_256);
 #ifdef OPENSSL
     cipher_driver_self_test(&srtp_aes_icm_192);
-    cipher_driver_self_test(&srtp_aes_icm_256);
     cipher_driver_self_test(&srtp_aes_gcm_128_openssl);
     cipher_driver_self_test(&srtp_aes_gcm_256_openssl);
 #endif
@@ -233,7 +230,7 @@ main(int argc, char *argv[]) {
   
 
   /* run the throughput test on the aes_icm cipher (128-bit key) */
-    status = srtp_cipher_type_alloc(&srtp_aes_icm, &c, 30, 0);  
+    status = srtp_cipher_type_alloc(&srtp_aes_icm_128, &c, 30, 0);
     if (status) {
       fprintf(stderr, "error: can't allocate cipher\n");
       exit(status);
@@ -254,11 +251,7 @@ main(int argc, char *argv[]) {
     check_status(status);
 
   /* repeat the tests with 256-bit keys */
-#ifndef OPENSSL
-    status = srtp_cipher_type_alloc(&srtp_aes_icm, &c, 46, 0);  
-#else
     status = srtp_cipher_type_alloc(&srtp_aes_icm_256, &c, 46, 0);  
-#endif
     if (status) {
       fprintf(stderr, "error: can't allocate cipher\n");
       exit(status);

--- a/crypto/test/cipher_driver.c
+++ b/crypto/test/cipher_driver.c
@@ -192,11 +192,11 @@ main(int argc, char *argv[]) {
       cipher_driver_test_array_throughput(&srtp_aes_icm_192, 38, num_cipher);
 
     for (num_cipher=1; num_cipher < max_num_cipher; num_cipher *=8) {
-      cipher_driver_test_array_throughput(&srtp_aes_gcm_128_openssl, SRTP_AES_128_GCM_KEYSIZE_WSALT, num_cipher);
+      cipher_driver_test_array_throughput(&srtp_aes_gcm_128_openssl, SRTP_AES_GCM_128_KEYSIZE_WSALT, num_cipher);
     }
 
     for (num_cipher=1; num_cipher < max_num_cipher; num_cipher *=8) {
-      cipher_driver_test_array_throughput(&srtp_aes_gcm_256_openssl, SRTP_AES_256_GCM_KEYSIZE_WSALT, num_cipher);
+      cipher_driver_test_array_throughput(&srtp_aes_gcm_256_openssl, SRTP_AES_GCM_256_KEYSIZE_WSALT, num_cipher);
     }
 #endif
   }
@@ -273,7 +273,7 @@ main(int argc, char *argv[]) {
 
 #ifdef OPENSSL
     /* run the throughput test on the aes_gcm_128_openssl cipher */
-    status = srtp_cipher_type_alloc(&srtp_aes_gcm_128_openssl, &c, SRTP_AES_128_GCM_KEYSIZE_WSALT, 8);
+    status = srtp_cipher_type_alloc(&srtp_aes_gcm_128_openssl, &c, SRTP_AES_GCM_128_KEYSIZE_WSALT, 8);
     if (status) {
         fprintf(stderr, "error: can't allocate GCM 128 cipher\n");
         exit(status);
@@ -292,7 +292,7 @@ main(int argc, char *argv[]) {
     check_status(status);
 
     /* run the throughput test on the aes_gcm_256_openssl cipher */
-    status = srtp_cipher_type_alloc(&srtp_aes_gcm_256_openssl, &c, SRTP_AES_256_GCM_KEYSIZE_WSALT, 16);
+    status = srtp_cipher_type_alloc(&srtp_aes_gcm_256_openssl, &c, SRTP_AES_GCM_256_KEYSIZE_WSALT, 16);
     if (status) {
         fprintf(stderr, "error: can't allocate GCM 256 cipher\n");
         exit(status);

--- a/crypto/test/stat_driver.c
+++ b/crypto/test/stat_driver.c
@@ -75,7 +75,8 @@ main (int argc, char *argv[]) {
   uint8_t buffer[2532];
   unsigned int buf_len = 2500;
   int i, j;
-  extern srtp_cipher_type_t srtp_aes_icm;
+  extern srtp_cipher_type_t srtp_aes_icm_128;
+  extern srtp_cipher_type_t srtp_aes_icm_256;
 #ifdef OPENSSL
   extern srtp_cipher_type_t srtp_aes_gcm_128_openssl;
   extern srtp_cipher_type_t srtp_aes_gcm_256_openssl;
@@ -116,7 +117,7 @@ main (int argc, char *argv[]) {
   /* set buffer to cipher output */
   for (i=0; i < 2500; i++)
     buffer[i] = 0;
-  err_check(srtp_cipher_type_alloc(&srtp_aes_icm, &c, 30, 0));
+  err_check(srtp_cipher_type_alloc(&srtp_aes_icm_128, &c, 30, 0));
   err_check(srtp_cipher_init(c, key));
   err_check(srtp_cipher_set_iv(c, (uint8_t*)&nonce, srtp_direction_encrypt));
   err_check(srtp_cipher_encrypt(c, buffer, &buf_len));
@@ -150,7 +151,7 @@ main (int argc, char *argv[]) {
   /* set buffer to cipher output */
   for (i=0; i < 2500; i++)
     buffer[i] = 0;
-  err_check(srtp_cipher_type_alloc(&srtp_aes_icm, &c, 46, 0));
+  err_check(srtp_cipher_type_alloc(&srtp_aes_icm_256, &c, 46, 0));
   err_check(srtp_cipher_init(c, key));
   err_check(srtp_cipher_set_iv(c, (uint8_t*)&nonce, srtp_direction_encrypt));
   err_check(srtp_cipher_encrypt(c, buffer, &buf_len));

--- a/crypto/test/stat_driver.c
+++ b/crypto/test/stat_driver.c
@@ -182,7 +182,7 @@ main (int argc, char *argv[]) {
     for (i=0; i < 2500; i++) {
 	buffer[i] = 0;
     }
-    err_check(srtp_cipher_type_alloc(&srtp_aes_gcm_128_openssl, &c, SRTP_AES_128_GCM_KEYSIZE_WSALT, 8));
+    err_check(srtp_cipher_type_alloc(&srtp_aes_gcm_128_openssl, &c, SRTP_AES_GCM_128_KEYSIZE_WSALT, 8));
     err_check(srtp_cipher_init(c, key));
     err_check(srtp_cipher_set_iv(c, (uint8_t*)&nonce, srtp_direction_encrypt));
     err_check(srtp_cipher_encrypt(c, buffer, &buf_len));
@@ -211,7 +211,7 @@ main (int argc, char *argv[]) {
     for (i=0; i < 2500; i++) {
 	buffer[i] = 0;
     }
-    err_check(srtp_cipher_type_alloc(&srtp_aes_gcm_256_openssl, &c, SRTP_AES_256_GCM_KEYSIZE_WSALT, 16));
+    err_check(srtp_cipher_type_alloc(&srtp_aes_gcm_256_openssl, &c, SRTP_AES_GCM_256_KEYSIZE_WSALT, 16));
     err_check(srtp_cipher_init(c, key));
     err_check(srtp_cipher_set_iv(c, (uint8_t*)&nonce, srtp_direction_encrypt));
     err_check(srtp_cipher_encrypt(c, buffer, &buf_len));

--- a/include/srtp.h
+++ b/include/srtp.h
@@ -108,9 +108,9 @@ extern "C" {
  * as part of the IV formation logic applied to each RTP packet.
  */
 #define SRTP_AEAD_SALT_LEN	12
-#define SRTP_AES_128_GCM_KEYSIZE_WSALT   SRTP_AEAD_SALT_LEN + 16
-#define SRTP_AES_192_GCM_KEYSIZE_WSALT   SRTP_AEAD_SALT_LEN + 24
-#define SRTP_AES_256_GCM_KEYSIZE_WSALT   SRTP_AEAD_SALT_LEN + 32
+#define SRTP_AES_GCM_128_KEYSIZE_WSALT   SRTP_AEAD_SALT_LEN + 16
+#define SRTP_AES_GCM_192_KEYSIZE_WSALT   SRTP_AEAD_SALT_LEN + 24
+#define SRTP_AES_GCM_256_KEYSIZE_WSALT   SRTP_AEAD_SALT_LEN + 32
 
 /*
  * an srtp_hdr_t represents the srtp header

--- a/include/srtp.h
+++ b/include/srtp.h
@@ -1046,6 +1046,95 @@ void srtp_crypto_policy_set_aes_cm_256_hmac_sha1_32(srtp_crypto_policy_t *p);
  */
 void srtp_crypto_policy_set_aes_cm_256_null_auth(srtp_crypto_policy_t *p);
 
+
+/**
+ * @brief srtp_crypto_policy_set_aes_cm_192_hmac_sha1_80() sets a crypto
+ * policy structure to a encryption and authentication policy using AES-192
+ * for RTP protection.
+ *
+ * @param p is a pointer to the policy structure to be set
+ *
+ * The function call srtp_crypto_policy_set_aes_cm_192_hmac_sha1_80(&p)
+ * sets the crypto_policy_t at location p to use policy
+ * AES_CM_192_HMAC_SHA1_80 as defined in
+ * draft-ietf-avt-srtp-big-aes-03.txt.  This policy uses AES-192
+ * Counter Mode encryption and HMAC-SHA1 authentication, with an 80 bit
+ * authentication tag.
+ *
+ * This function is a convenience that helps to avoid dealing directly
+ * with the policy data structure.  You are encouraged to initialize
+ * policy elements with this function call.  Doing so may allow your
+ * code to be forward compatible with later versions of libSRTP that
+ * include more elements in the crypto_policy_t datatype.
+ *
+ * @return void.
+ *
+ */
+void srtp_crypto_policy_set_aes_cm_192_hmac_sha1_80(srtp_crypto_policy_t *p);
+
+
+/**
+ * @brief srtp_crypto_policy_set_aes_cm_192_hmac_sha1_32() sets a crypto
+ * policy structure to a short-authentication tag policy using AES-192
+ * encryption.
+ *
+ * @param p is a pointer to the policy structure to be set
+ *
+ * The function call srtp_crypto_policy_set_aes_cm_192_hmac_sha1_32(&p)
+ * sets the crypto_policy_t at location p to use policy
+ * AES_CM_192_HMAC_SHA1_32 as defined in
+ * draft-ietf-avt-srtp-big-aes-03.txt.  This policy uses AES-192
+ * Counter Mode encryption and HMAC-SHA1 authentication, with an
+ * authentication tag that is only 32 bits long.  This length is
+ * considered adequate only for protecting audio and video media that
+ * use a stateless playback function.  See Section 7.5 of RFC 3711
+ * (http://www.ietf.org/rfc/rfc3711.txt).
+ *
+ * This function is a convenience that helps to avoid dealing directly
+ * with the policy data structure.  You are encouraged to initialize
+ * policy elements with this function call.  Doing so may allow your
+ * code to be forward compatible with later versions of libSRTP that
+ * include more elements in the crypto_policy_t datatype.
+ *
+ * @warning This crypto policy is intended for use in SRTP, but not in
+ * SRTCP.  It is recommended that a policy that uses longer
+ * authentication tags be used for SRTCP.  See Section 7.5 of RFC 3711
+ * (http://www.ietf.org/rfc/rfc3711.txt).
+ *
+ * @return void.
+ *
+ */
+void srtp_crypto_policy_set_aes_cm_192_hmac_sha1_32(srtp_crypto_policy_t *p);
+
+
+/**
+ * @brief srtp_crypto_policy_set_aes_cm_192_null_auth() sets a crypto
+ * policy structure to an encryption-only policy
+ *
+ * @param p is a pointer to the policy structure to be set
+ *
+ * The function call srtp_crypto_policy_set_aes_cm_192_null_auth(&p) sets
+ * the crypto_policy_t at location p to use the SRTP default cipher
+ * (AES-192 Counter Mode), but to use no authentication method.  This
+ * policy is NOT RECOMMENDED unless it is unavoidable; see Section 7.5
+ * of RFC 3711 (http://www.ietf.org/rfc/rfc3711.txt).
+ *
+ * This function is a convenience that helps to avoid dealing directly
+ * with the policy data structure.  You are encouraged to initialize
+ * policy elements with this function call.  Doing so may allow your
+ * code to be forward compatible with later versions of libSRTP that
+ * include more elements in the crypto_policy_t datatype.
+ *
+ * @warning This policy is NOT RECOMMENDED for SRTP unless it is
+ * unavoidable, and it is NOT RECOMMENDED at all for SRTCP; see
+ * Section 7.5 of RFC 3711 (http://www.ietf.org/rfc/rfc3711.txt).
+ *
+ * @return void.
+ *
+ */
+void srtp_crypto_policy_set_aes_cm_192_null_auth(srtp_crypto_policy_t *p);
+
+
 /**
  * @brief srtp_crypto_policy_set_aes_gcm_128_8_auth() sets a crypto
  * policy structure to an AEAD encryption policy.

--- a/srtp/srtp.c
+++ b/srtp/srtp.c
@@ -311,12 +311,12 @@ srtp_stream_alloc(srtp_stream_ctx_t **str_ptr,
 
     /* For GCM ciphers, the corresponding ICM cipher is used for header extensions encryption. */
     switch (p->rtp.cipher_type) {
-    case SRTP_AES_128_GCM:
-      enc_xtn_hdr_cipher_type = SRTP_AES_128_ICM;
+    case SRTP_AES_GCM_128:
+      enc_xtn_hdr_cipher_type = SRTP_AES_ICM_128;
       enc_xtn_hdr_cipher_key_len = 30;
       break;
-    case SRTP_AES_256_GCM:
-      enc_xtn_hdr_cipher_type = SRTP_AES_256_ICM;
+    case SRTP_AES_GCM_256:
+      enc_xtn_hdr_cipher_type = SRTP_AES_ICM_256;
       enc_xtn_hdr_cipher_key_len = 46;
       break;
     default:
@@ -698,13 +698,13 @@ static srtp_err_status_t srtp_kdf_init(srtp_kdf_t *kdf, const uint8_t *key, int 
     srtp_cipher_type_id_t cipher_id;
     switch (key_len) {
     case 46:
-        cipher_id = SRTP_AES_256_ICM;
+        cipher_id = SRTP_AES_ICM_256;
         break;
     case 38:
-        cipher_id = SRTP_AES_192_ICM;
+        cipher_id = SRTP_AES_ICM_192;
         break;
     case 30:
-        cipher_id = SRTP_AES_128_ICM;
+        cipher_id = SRTP_AES_ICM_128;
         break;
     default:
         return srtp_err_status_bad_param;
@@ -764,17 +764,17 @@ static srtp_err_status_t srtp_kdf_clear(srtp_kdf_t *kdf) {
 static inline int base_key_length(const srtp_cipher_type_t *cipher, int key_length)
 {
   switch (cipher->id) {
-  case SRTP_AES_128_ICM:
-  case SRTP_AES_192_ICM:
-  case SRTP_AES_256_ICM:
+  case SRTP_AES_ICM_128:
+  case SRTP_AES_ICM_192:
+  case SRTP_AES_ICM_256:
     /* The legacy modes are derived from
      * the configured key length on the policy */
     return key_length - 14;
     break;
-  case SRTP_AES_128_GCM:
+  case SRTP_AES_GCM_128:
     return 16;
     break;
-  case SRTP_AES_256_GCM:
+  case SRTP_AES_GCM_256:
     return 32;
     break;
   default:
@@ -1497,8 +1497,8 @@ srtp_get_session_keys(srtp_stream_ctx_t *stream, uint8_t* hdr,
   unsigned int i = 0;
 
   // Determine the authentication tag size
-  if (stream->session_keys[0].rtp_cipher->algorithm == SRTP_AES_128_GCM ||
-      stream->session_keys[0].rtp_cipher->algorithm == SRTP_AES_256_GCM) {
+  if (stream->session_keys[0].rtp_cipher->algorithm == SRTP_AES_GCM_128 ||
+      stream->session_keys[0].rtp_cipher->algorithm == SRTP_AES_GCM_256) {
       tag_len = 0;
   } else {
       tag_len = srtp_auth_get_tag_length(stream->session_keys[0].rtp_auth);
@@ -1964,8 +1964,8 @@ srtp_protect_mki(srtp_ctx_t *ctx, void *rtp_hdr, int *pkt_octet_len,
     * Check if this is an AEAD stream (GCM mode).  If so, then dispatch
     * the request to our AEAD handler.
     */
-  if (session_keys->rtp_cipher->algorithm == SRTP_AES_128_GCM ||
-      session_keys->rtp_cipher->algorithm == SRTP_AES_256_GCM) {
+  if (session_keys->rtp_cipher->algorithm == SRTP_AES_GCM_128 ||
+      session_keys->rtp_cipher->algorithm == SRTP_AES_GCM_256) {
       return srtp_protect_aead(ctx, stream, rtp_hdr,
                                (unsigned int*)pkt_octet_len, session_keys,
                                use_mki);
@@ -2055,9 +2055,9 @@ srtp_protect_mki(srtp_ctx_t *ctx, void *rtp_hdr, int *pkt_octet_len,
    /* 
     * if we're using rindael counter mode, set nonce and seq 
     */
-   if (session_keys->rtp_cipher->type->id == SRTP_AES_128_ICM ||
-       session_keys->rtp_cipher->type->id == SRTP_AES_192_ICM ||
-       session_keys->rtp_cipher->type->id == SRTP_AES_256_ICM) {
+   if (session_keys->rtp_cipher->type->id == SRTP_AES_ICM_128 ||
+       session_keys->rtp_cipher->type->id == SRTP_AES_ICM_192 ||
+       session_keys->rtp_cipher->type->id == SRTP_AES_ICM_256) {
      v128_t iv;
 
      iv.v32[0] = 0;
@@ -2279,8 +2279,8 @@ srtp_unprotect_mki(srtp_ctx_t *ctx, void *srtp_hdr, int *pkt_octet_len,
    * Check if this is an AEAD stream (GCM mode).  If so, then dispatch
    * the request to our AEAD handler.
    */
-  if (session_keys->rtp_cipher->algorithm == SRTP_AES_128_GCM ||
-      session_keys->rtp_cipher->algorithm == SRTP_AES_256_GCM) {
+  if (session_keys->rtp_cipher->algorithm == SRTP_AES_GCM_128 ||
+      session_keys->rtp_cipher->algorithm == SRTP_AES_GCM_256) {
       return srtp_unprotect_aead(ctx, stream, delta, est, srtp_hdr,
                                  (unsigned int*)pkt_octet_len, session_keys,
                                  mki_size);
@@ -2293,9 +2293,9 @@ srtp_unprotect_mki(srtp_ctx_t *ctx, void *srtp_hdr, int *pkt_octet_len,
    * set the cipher's IV properly, depending on whatever cipher we
    * happen to be using
    */
-  if (session_keys->rtp_cipher->type->id == SRTP_AES_128_ICM ||
-      session_keys->rtp_cipher->type->id == SRTP_AES_192_ICM ||
-      session_keys->rtp_cipher->type->id == SRTP_AES_256_ICM) {
+  if (session_keys->rtp_cipher->type->id == SRTP_AES_ICM_128 ||
+      session_keys->rtp_cipher->type->id == SRTP_AES_ICM_192 ||
+      session_keys->rtp_cipher->type->id == SRTP_AES_ICM_256) {
     /* aes counter mode */
     iv.v32[0] = 0;
     iv.v32[1] = hdr->ssrc;  /* still in network order */
@@ -2958,7 +2958,7 @@ srtp_update_stream(srtp_t session, const srtp_policy_t *policy) {
 void
 srtp_crypto_policy_set_rtp_default(srtp_crypto_policy_t *p) {
 
-  p->cipher_type     = SRTP_AES_128_ICM;
+  p->cipher_type     = SRTP_AES_ICM_128;
   p->cipher_key_len  = 30;                /* default 128 bits per RFC 3711 */
   p->auth_type       = SRTP_HMAC_SHA1;             
   p->auth_key_len    = 20;                /* default 160 bits per RFC 3711 */
@@ -2970,7 +2970,7 @@ srtp_crypto_policy_set_rtp_default(srtp_crypto_policy_t *p) {
 void
 srtp_crypto_policy_set_rtcp_default(srtp_crypto_policy_t *p) {
 
-  p->cipher_type     = SRTP_AES_128_ICM;
+  p->cipher_type     = SRTP_AES_ICM_128;
   p->cipher_key_len  = 30;                 /* default 128 bits per RFC 3711 */
   p->auth_type       = SRTP_HMAC_SHA1;             
   p->auth_key_len    = 20;                 /* default 160 bits per RFC 3711 */
@@ -2988,7 +2988,7 @@ srtp_crypto_policy_set_aes_cm_128_hmac_sha1_32(srtp_crypto_policy_t *p) {
    * note that this crypto policy is intended for SRTP, but not SRTCP
    */
 
-  p->cipher_type     = SRTP_AES_128_ICM;
+  p->cipher_type     = SRTP_AES_ICM_128;
   p->cipher_key_len  = 30;                /* 128 bit key, 112 bit salt */
   p->auth_type       = SRTP_HMAC_SHA1;             
   p->auth_key_len    = 20;                /* 160 bit key               */
@@ -3007,7 +3007,7 @@ srtp_crypto_policy_set_aes_cm_128_null_auth(srtp_crypto_policy_t *p) {
    * note that this crypto policy is intended for SRTP, but not SRTCP
    */
 
-  p->cipher_type     = SRTP_AES_128_ICM;
+  p->cipher_type     = SRTP_AES_ICM_128;
   p->cipher_key_len  = 30;                /* 128 bit key, 112 bit salt */
   p->auth_type       = SRTP_NULL_AUTH;             
   p->auth_key_len    = 0; 
@@ -3057,7 +3057,7 @@ srtp_crypto_policy_set_aes_cm_256_hmac_sha1_80(srtp_crypto_policy_t *p) {
    * corresponds to draft-ietf-avt-big-aes-03.txt
    */
 
-  p->cipher_type     = SRTP_AES_256_ICM;
+  p->cipher_type     = SRTP_AES_ICM_256;
   p->cipher_key_len  = 46;
   p->auth_type       = SRTP_HMAC_SHA1;             
   p->auth_key_len    = 20;                /* default 160 bits per RFC 3711 */
@@ -3075,7 +3075,7 @@ srtp_crypto_policy_set_aes_cm_256_hmac_sha1_32(srtp_crypto_policy_t *p) {
    * note that this crypto policy is intended for SRTP, but not SRTCP
    */
 
-  p->cipher_type     = SRTP_AES_256_ICM;
+  p->cipher_type     = SRTP_AES_ICM_256;
   p->cipher_key_len  = 46;
   p->auth_type       = SRTP_HMAC_SHA1;             
   p->auth_key_len    = 20;                /* default 160 bits per RFC 3711 */
@@ -3089,7 +3089,7 @@ srtp_crypto_policy_set_aes_cm_256_hmac_sha1_32(srtp_crypto_policy_t *p) {
 void
 srtp_crypto_policy_set_aes_cm_256_null_auth (srtp_crypto_policy_t *p)
 {
-    p->cipher_type     = SRTP_AES_256_ICM;
+    p->cipher_type     = SRTP_AES_ICM_256;
     p->cipher_key_len  = 46;
     p->auth_type       = SRTP_NULL_AUTH;
     p->auth_key_len    = 0;
@@ -3105,7 +3105,7 @@ srtp_crypto_policy_set_aes_cm_192_hmac_sha1_80(srtp_crypto_policy_t *p) {
    * corresponds to draft-ietf-avt-big-aes-03.txt
    */
 
-  p->cipher_type     = SRTP_AES_192_ICM;
+  p->cipher_type     = SRTP_AES_ICM_192;
   p->cipher_key_len  = 38;
   p->auth_type       = SRTP_HMAC_SHA1;
   p->auth_key_len    = 20;                /* default 160 bits per RFC 3711 */
@@ -3123,7 +3123,7 @@ srtp_crypto_policy_set_aes_cm_192_hmac_sha1_32(srtp_crypto_policy_t *p) {
    * note that this crypto policy is intended for SRTP, but not SRTCP
    */
 
-  p->cipher_type     = SRTP_AES_192_ICM;
+  p->cipher_type     = SRTP_AES_ICM_192;
   p->cipher_key_len  = 38;
   p->auth_type       = SRTP_HMAC_SHA1;
   p->auth_key_len    = 20;                /* default 160 bits per RFC 3711 */
@@ -3137,7 +3137,7 @@ srtp_crypto_policy_set_aes_cm_192_hmac_sha1_32(srtp_crypto_policy_t *p) {
 void
 srtp_crypto_policy_set_aes_cm_192_null_auth (srtp_crypto_policy_t *p)
 {
-    p->cipher_type     = SRTP_AES_192_ICM;
+    p->cipher_type     = SRTP_AES_ICM_192;
     p->cipher_key_len  = 38;
     p->auth_type       = SRTP_NULL_AUTH;
     p->auth_key_len    = 0;
@@ -3150,8 +3150,8 @@ srtp_crypto_policy_set_aes_cm_192_null_auth (srtp_crypto_policy_t *p)
  */
 void
 srtp_crypto_policy_set_aes_gcm_128_8_auth(srtp_crypto_policy_t *p) {
-  p->cipher_type     = SRTP_AES_128_GCM;           
-  p->cipher_key_len  = SRTP_AES_128_GCM_KEYSIZE_WSALT; 
+  p->cipher_type     = SRTP_AES_GCM_128;
+  p->cipher_key_len  = SRTP_AES_GCM_128_KEYSIZE_WSALT;
   p->auth_type       = SRTP_NULL_AUTH; /* GCM handles the auth for us */            
   p->auth_key_len    = 0; 
   p->auth_tag_len    = 8;   /* 8 octet tag length */
@@ -3163,8 +3163,8 @@ srtp_crypto_policy_set_aes_gcm_128_8_auth(srtp_crypto_policy_t *p) {
  */
 void
 srtp_crypto_policy_set_aes_gcm_256_8_auth(srtp_crypto_policy_t *p) {
-  p->cipher_type     = SRTP_AES_256_GCM;           
-  p->cipher_key_len  = SRTP_AES_256_GCM_KEYSIZE_WSALT; 
+  p->cipher_type     = SRTP_AES_GCM_256;
+  p->cipher_key_len  = SRTP_AES_GCM_256_KEYSIZE_WSALT;
   p->auth_type       = SRTP_NULL_AUTH; /* GCM handles the auth for us */ 
   p->auth_key_len    = 0; 
   p->auth_tag_len    = 8;   /* 8 octet tag length */
@@ -3176,8 +3176,8 @@ srtp_crypto_policy_set_aes_gcm_256_8_auth(srtp_crypto_policy_t *p) {
  */
 void
 srtp_crypto_policy_set_aes_gcm_128_8_only_auth(srtp_crypto_policy_t *p) {
-  p->cipher_type     = SRTP_AES_128_GCM;           
-  p->cipher_key_len  = SRTP_AES_128_GCM_KEYSIZE_WSALT; 
+  p->cipher_type     = SRTP_AES_GCM_128;
+  p->cipher_key_len  = SRTP_AES_GCM_128_KEYSIZE_WSALT;
   p->auth_type       = SRTP_NULL_AUTH; /* GCM handles the auth for us */ 
   p->auth_key_len    = 0; 
   p->auth_tag_len    = 8;   /* 8 octet tag length */
@@ -3189,8 +3189,8 @@ srtp_crypto_policy_set_aes_gcm_128_8_only_auth(srtp_crypto_policy_t *p) {
  */
 void
 srtp_crypto_policy_set_aes_gcm_256_8_only_auth(srtp_crypto_policy_t *p) {
-  p->cipher_type     = SRTP_AES_256_GCM;           
-  p->cipher_key_len  = SRTP_AES_256_GCM_KEYSIZE_WSALT; 
+  p->cipher_type     = SRTP_AES_GCM_256;
+  p->cipher_key_len  = SRTP_AES_GCM_256_KEYSIZE_WSALT;
   p->auth_type       = SRTP_NULL_AUTH; /* GCM handles the auth for us */ 
   p->auth_key_len    = 0; 
   p->auth_tag_len    = 8;   /* 8 octet tag length */
@@ -3202,8 +3202,8 @@ srtp_crypto_policy_set_aes_gcm_256_8_only_auth(srtp_crypto_policy_t *p) {
  */
 void
 srtp_crypto_policy_set_aes_gcm_128_16_auth(srtp_crypto_policy_t *p) {
-  p->cipher_type     = SRTP_AES_128_GCM;           
-  p->cipher_key_len  = SRTP_AES_128_GCM_KEYSIZE_WSALT; 
+  p->cipher_type     = SRTP_AES_GCM_128;
+  p->cipher_key_len  = SRTP_AES_GCM_128_KEYSIZE_WSALT;
   p->auth_type       = SRTP_NULL_AUTH; /* GCM handles the auth for us */            
   p->auth_key_len    = 0; 
   p->auth_tag_len    = 16;   /* 16 octet tag length */
@@ -3215,8 +3215,8 @@ srtp_crypto_policy_set_aes_gcm_128_16_auth(srtp_crypto_policy_t *p) {
  */
 void
 srtp_crypto_policy_set_aes_gcm_256_16_auth(srtp_crypto_policy_t *p) {
-  p->cipher_type     = SRTP_AES_256_GCM;           
-  p->cipher_key_len  = SRTP_AES_256_GCM_KEYSIZE_WSALT; 
+  p->cipher_type     = SRTP_AES_GCM_256;
+  p->cipher_key_len  = SRTP_AES_GCM_256_KEYSIZE_WSALT;
   p->auth_type       = SRTP_NULL_AUTH; /* GCM handles the auth for us */ 
   p->auth_key_len    = 0; 
   p->auth_tag_len    = 16;   /* 16 octet tag length */
@@ -3708,8 +3708,8 @@ srtp_protect_rtcp_mki(srtp_t ctx, void *rtcp_hdr, int *pkt_octet_len,
    * Check if this is an AEAD stream (GCM mode).  If so, then dispatch
    * the request to our AEAD handler.
    */
-  if (session_keys->rtp_cipher->algorithm == SRTP_AES_128_GCM ||
-      session_keys->rtp_cipher->algorithm == SRTP_AES_256_GCM) {
+  if (session_keys->rtp_cipher->algorithm == SRTP_AES_GCM_128 ||
+      session_keys->rtp_cipher->algorithm == SRTP_AES_GCM_256) {
       return srtp_protect_rtcp_aead(ctx, stream, rtcp_hdr,
                                     (unsigned int*)pkt_octet_len, session_keys,
                                     use_mki);
@@ -3770,9 +3770,9 @@ srtp_protect_rtcp_mki(srtp_t ctx, void *rtcp_hdr, int *pkt_octet_len,
   /* 
    * if we're using rindael counter mode, set nonce and seq 
    */
-  if (session_keys->rtcp_cipher->type->id == SRTP_AES_128_ICM ||
-      session_keys->rtcp_cipher->type->id == SRTP_AES_192_ICM ||
-      session_keys->rtcp_cipher->type->id == SRTP_AES_256_ICM) {
+  if (session_keys->rtcp_cipher->type->id == SRTP_AES_ICM_128 ||
+      session_keys->rtcp_cipher->type->id == SRTP_AES_ICM_192 ||
+      session_keys->rtcp_cipher->type->id == SRTP_AES_ICM_256) {
     v128_t iv;
     
     iv.v32[0] = 0;
@@ -3949,8 +3949,8 @@ srtp_unprotect_rtcp_mki(srtp_t ctx, void *srtcp_hdr, int *pkt_octet_len,
    * Check if this is an AEAD stream (GCM mode).  If so, then dispatch
    * the request to our AEAD handler.
    */
-  if (session_keys->rtp_cipher->algorithm == SRTP_AES_128_GCM ||
-      session_keys->rtp_cipher->algorithm == SRTP_AES_256_GCM) {
+  if (session_keys->rtp_cipher->algorithm == SRTP_AES_GCM_128 ||
+      session_keys->rtp_cipher->algorithm == SRTP_AES_GCM_256) {
       return srtp_unprotect_rtcp_aead(ctx, stream, srtcp_hdr,
                                       (unsigned int*)pkt_octet_len, session_keys,
                                       mki_size);
@@ -4029,9 +4029,9 @@ srtp_unprotect_rtcp_mki(srtp_t ctx, void *srtcp_hdr, int *pkt_octet_len,
   /* 
    * if we're using aes counter mode, set nonce and seq 
    */
-  if (session_keys->rtcp_cipher->type->id == SRTP_AES_128_ICM ||
-      session_keys->rtcp_cipher->type->id == SRTP_AES_192_ICM ||
-      session_keys->rtcp_cipher->type->id == SRTP_AES_256_ICM) {
+  if (session_keys->rtcp_cipher->type->id == SRTP_AES_ICM_128 ||
+      session_keys->rtcp_cipher->type->id == SRTP_AES_ICM_192 ||
+      session_keys->rtcp_cipher->type->id == SRTP_AES_ICM_256) {
     v128_t iv;
 
     iv.v32[0] = 0;

--- a/srtp/srtp.c
+++ b/srtp/srtp.c
@@ -3082,6 +3082,53 @@ srtp_crypto_policy_set_aes_cm_256_null_auth (srtp_crypto_policy_t *p)
 }
 
 #ifdef OPENSSL
+void
+srtp_crypto_policy_set_aes_cm_192_hmac_sha1_80(srtp_crypto_policy_t *p) {
+
+  /*
+   * corresponds to draft-ietf-avt-big-aes-03.txt
+   */
+
+  p->cipher_type     = SRTP_AES_ICM;
+  p->cipher_key_len  = 38;
+  p->auth_type       = SRTP_HMAC_SHA1;
+  p->auth_key_len    = 20;                /* default 160 bits per RFC 3711 */
+  p->auth_tag_len    = 10;                /* default 80 bits per RFC 3711 */
+  p->sec_serv        = sec_serv_conf_and_auth;
+}
+
+
+void
+srtp_crypto_policy_set_aes_cm_192_hmac_sha1_32(srtp_crypto_policy_t *p) {
+
+  /*
+   * corresponds to draft-ietf-avt-big-aes-03.txt
+   *
+   * note that this crypto policy is intended for SRTP, but not SRTCP
+   */
+
+  p->cipher_type     = SRTP_AES_ICM;
+  p->cipher_key_len  = 38;
+  p->auth_type       = SRTP_HMAC_SHA1;
+  p->auth_key_len    = 20;                /* default 160 bits per RFC 3711 */
+  p->auth_tag_len    = 4;                 /* default 80 bits per RFC 3711 */
+  p->sec_serv        = sec_serv_conf_and_auth;
+}
+
+/*
+ * AES-192 with no authentication.
+ */
+void
+srtp_crypto_policy_set_aes_cm_192_null_auth (srtp_crypto_policy_t *p)
+{
+    p->cipher_type     = SRTP_AES_ICM;
+    p->cipher_key_len  = 38;
+    p->auth_type       = SRTP_NULL_AUTH;
+    p->auth_key_len    = 0;
+    p->auth_tag_len    = 0;
+    p->sec_serv        = sec_serv_conf;
+}
+
 /*
  * AES-128 GCM mode with 8 octet auth tag. 
  */

--- a/srtp/srtp.c
+++ b/srtp/srtp.c
@@ -2039,7 +2039,8 @@ srtp_protect_mki(srtp_ctx_t *ctx, void *rtp_hdr, int *pkt_octet_len,
    /* 
     * if we're using rindael counter mode, set nonce and seq 
     */
-   if (session_keys->rtp_cipher->type->id == SRTP_AES_ICM ||
+   if (session_keys->rtp_cipher->type->id == SRTP_AES_128_ICM ||
+       session_keys->rtp_cipher->type->id == SRTP_AES_192_ICM ||
        session_keys->rtp_cipher->type->id == SRTP_AES_256_ICM) {
      v128_t iv;
 
@@ -2276,9 +2277,9 @@ srtp_unprotect_mki(srtp_ctx_t *ctx, void *srtp_hdr, int *pkt_octet_len,
    * set the cipher's IV properly, depending on whatever cipher we
    * happen to be using
    */
-  if (session_keys->rtp_cipher->type->id == SRTP_AES_ICM ||
+  if (session_keys->rtp_cipher->type->id == SRTP_AES_128_ICM ||
+      session_keys->rtp_cipher->type->id == SRTP_AES_192_ICM ||
       session_keys->rtp_cipher->type->id == SRTP_AES_256_ICM) {
-
     /* aes counter mode */
     iv.v32[0] = 0;
     iv.v32[1] = hdr->ssrc;  /* still in network order */
@@ -3706,7 +3707,9 @@ srtp_protect_rtcp_mki(srtp_t ctx, void *rtcp_hdr, int *pkt_octet_len,
   /* 
    * if we're using rindael counter mode, set nonce and seq 
    */
-  if (session_keys->rtcp_cipher->type->id == SRTP_AES_ICM) {
+  if (session_keys->rtcp_cipher->type->id == SRTP_AES_128_ICM ||
+      session_keys->rtcp_cipher->type->id == SRTP_AES_192_ICM ||
+      session_keys->rtcp_cipher->type->id == SRTP_AES_256_ICM) {
     v128_t iv;
     
     iv.v32[0] = 0;
@@ -3963,7 +3966,9 @@ srtp_unprotect_rtcp_mki(srtp_t ctx, void *srtcp_hdr, int *pkt_octet_len,
   /* 
    * if we're using aes counter mode, set nonce and seq 
    */
-  if (session_keys->rtcp_cipher->type->id == SRTP_AES_ICM) {
+  if (session_keys->rtcp_cipher->type->id == SRTP_AES_128_ICM ||
+      session_keys->rtcp_cipher->type->id == SRTP_AES_192_ICM ||
+      session_keys->rtcp_cipher->type->id == SRTP_AES_256_ICM) {
     v128_t iv;
 
     iv.v32[0] = 0;

--- a/test/srtp_driver.c
+++ b/test/srtp_driver.c
@@ -2966,7 +2966,7 @@ unsigned char test_mki_id_2[TEST_MKI_ID_SIZE] = {
 const srtp_policy_t default_policy = {
     { ssrc_any_outbound, 0 },  /* SSRC                           */
     {                          /* SRTP policy                    */
-        SRTP_AES_128_ICM,           /* cipher type                 */
+        SRTP_AES_ICM_128,           /* cipher type                 */
         30,                    /* cipher key length in octets */
         SRTP_HMAC_SHA1,             /* authentication func type    */
         16,                    /* auth key length in octets   */
@@ -2974,7 +2974,7 @@ const srtp_policy_t default_policy = {
         sec_serv_conf_and_auth /* security services flag      */
     },
     {                          /* SRTCP policy                   */
-        SRTP_AES_128_ICM,           /* cipher type                 */
+        SRTP_AES_ICM_128,           /* cipher type                 */
         30,                    /* cipher key length in octets */
         SRTP_HMAC_SHA1,             /* authentication func type    */
         16,                    /* auth key length in octets   */
@@ -2995,7 +2995,7 @@ const srtp_policy_t default_policy = {
 const srtp_policy_t aes_only_policy = {
     { ssrc_any_outbound, 0 }, /* SSRC                        */
     {
-        SRTP_AES_128_ICM,          /* cipher type                 */
+        SRTP_AES_ICM_128,          /* cipher type                 */
         30,                   /* cipher key length in octets */
         SRTP_NULL_AUTH,            /* authentication func type    */
         0,                    /* auth key length in octets   */
@@ -3003,7 +3003,7 @@ const srtp_policy_t aes_only_policy = {
         sec_serv_conf         /* security services flag      */
     },
     {
-        SRTP_AES_128_ICM,        /* cipher type                 */
+        SRTP_AES_ICM_128,        /* cipher type                 */
         30,                 /* cipher key length in octets */
         SRTP_NULL_AUTH,          /* authentication func type    */
         0,                  /* auth key length in octets   */
@@ -3054,16 +3054,16 @@ const srtp_policy_t hmac_only_policy = {
 const srtp_policy_t aes128_gcm_8_policy = {
     { ssrc_any_outbound, 0 },           /* SSRC                           */
     {                                   /* SRTP policy                    */
-        SRTP_AES_128_GCM,                    /* cipher type                 */
-        SRTP_AES_128_GCM_KEYSIZE_WSALT, /* cipher key length in octets */
+        SRTP_AES_GCM_128,                    /* cipher type                 */
+        SRTP_AES_GCM_128_KEYSIZE_WSALT, /* cipher key length in octets */
         SRTP_NULL_AUTH,                      /* authentication func type    */
         0,                              /* auth key length in octets   */
         8,                              /* auth tag length in octets   */
         sec_serv_conf_and_auth          /* security services flag      */
     },
     {                                   /* SRTCP policy                   */
-        SRTP_AES_128_GCM,                    /* cipher type                 */
-        SRTP_AES_128_GCM_KEYSIZE_WSALT, /* cipher key length in octets */
+        SRTP_AES_GCM_128,                    /* cipher type                 */
+        SRTP_AES_GCM_128_KEYSIZE_WSALT, /* cipher key length in octets */
         SRTP_NULL_AUTH,                      /* authentication func type    */
         0,                              /* auth key length in octets   */
         8,                              /* auth tag length in octets   */
@@ -3083,16 +3083,16 @@ const srtp_policy_t aes128_gcm_8_policy = {
 const srtp_policy_t aes128_gcm_8_cauth_policy = {
     { ssrc_any_outbound, 0 },           /* SSRC                           */
     {                                   /* SRTP policy                    */
-        SRTP_AES_128_GCM,                    /* cipher type                 */
-        SRTP_AES_128_GCM_KEYSIZE_WSALT, /* cipher key length in octets */
+        SRTP_AES_GCM_128,                    /* cipher type                 */
+        SRTP_AES_GCM_128_KEYSIZE_WSALT, /* cipher key length in octets */
         SRTP_NULL_AUTH,                      /* authentication func type    */
         0,                              /* auth key length in octets   */
         8,                              /* auth tag length in octets   */
         sec_serv_conf_and_auth          /* security services flag      */
     },
     {                                   /* SRTCP policy                   */
-        SRTP_AES_128_GCM,                    /* cipher type                 */
-        SRTP_AES_128_GCM_KEYSIZE_WSALT, /* cipher key length in octets */
+        SRTP_AES_GCM_128,                    /* cipher type                 */
+        SRTP_AES_GCM_128_KEYSIZE_WSALT, /* cipher key length in octets */
         SRTP_NULL_AUTH,                      /* authentication func type    */
         0,                              /* auth key length in octets   */
         8,                              /* auth tag length in octets   */
@@ -3112,16 +3112,16 @@ const srtp_policy_t aes128_gcm_8_cauth_policy = {
 const srtp_policy_t aes256_gcm_8_policy = {
     { ssrc_any_outbound, 0 },           /* SSRC                           */
     {                                   /* SRTP policy                    */
-        SRTP_AES_256_GCM,                    /* cipher type                 */
-        SRTP_AES_256_GCM_KEYSIZE_WSALT, /* cipher key length in octets */
+        SRTP_AES_GCM_256,                    /* cipher type                 */
+        SRTP_AES_GCM_256_KEYSIZE_WSALT, /* cipher key length in octets */
         SRTP_NULL_AUTH,                      /* authentication func type    */
         0,                              /* auth key length in octets   */
         8,                              /* auth tag length in octets   */
         sec_serv_conf_and_auth          /* security services flag      */
     },
     {                                   /* SRTCP policy                   */
-        SRTP_AES_256_GCM,                    /* cipher type                 */
-        SRTP_AES_256_GCM_KEYSIZE_WSALT, /* cipher key length in octets */
+        SRTP_AES_GCM_256,                    /* cipher type                 */
+        SRTP_AES_GCM_256_KEYSIZE_WSALT, /* cipher key length in octets */
         SRTP_NULL_AUTH,                      /* authentication func type    */
         0,                              /* auth key length in octets   */
         8,                              /* auth tag length in octets   */
@@ -3141,16 +3141,16 @@ const srtp_policy_t aes256_gcm_8_policy = {
 const srtp_policy_t aes256_gcm_8_cauth_policy = {
     { ssrc_any_outbound, 0 },           /* SSRC                           */
     {                                   /* SRTP policy                    */
-        SRTP_AES_256_GCM,                    /* cipher type                 */
-        SRTP_AES_256_GCM_KEYSIZE_WSALT, /* cipher key length in octets */
+        SRTP_AES_GCM_256,                    /* cipher type                 */
+        SRTP_AES_GCM_256_KEYSIZE_WSALT, /* cipher key length in octets */
         SRTP_NULL_AUTH,                      /* authentication func type    */
         0,                              /* auth key length in octets   */
         8,                              /* auth tag length in octets   */
         sec_serv_conf_and_auth          /* security services flag      */
     },
     {                                   /* SRTCP policy                   */
-        SRTP_AES_256_GCM,                    /* cipher type                 */
-        SRTP_AES_256_GCM_KEYSIZE_WSALT, /* cipher key length in octets */
+        SRTP_AES_GCM_256,                    /* cipher type                 */
+        SRTP_AES_GCM_256_KEYSIZE_WSALT, /* cipher key length in octets */
         SRTP_NULL_AUTH,                      /* authentication func type    */
         0,                              /* auth key length in octets   */
         8,                              /* auth tag length in octets   */
@@ -3236,7 +3236,7 @@ srtp_master_key_t *test_256_keys[2] = {
 const srtp_policy_t aes_256_hmac_policy = {
     { ssrc_any_outbound, 0 },  /* SSRC                           */
     {                          /* SRTP policy                    */
-        SRTP_AES_256_ICM,               /* cipher type                 */
+        SRTP_AES_ICM_256,               /* cipher type                 */
         46,                    /* cipher key length in octets */
         SRTP_HMAC_SHA1,             /* authentication func type    */
         20,                    /* auth key length in octets   */
@@ -3244,7 +3244,7 @@ const srtp_policy_t aes_256_hmac_policy = {
         sec_serv_conf_and_auth /* security services flag      */
     },
     {                          /* SRTCP policy                   */
-        SRTP_AES_256_ICM,               /* cipher type                 */
+        SRTP_AES_ICM_256,               /* cipher type                 */
         46,                    /* cipher key length in octets */
         SRTP_HMAC_SHA1,             /* authentication func type    */
         20,                    /* auth key length in octets   */
@@ -3336,7 +3336,7 @@ policy_array[] = {
 const srtp_policy_t wildcard_policy = {
     { ssrc_any_outbound, 0 },  /* SSRC                        */
     {                          /* SRTP policy                    */
-        SRTP_AES_128_ICM,           /* cipher type                 */
+        SRTP_AES_ICM_128,           /* cipher type                 */
         30,                    /* cipher key length in octets */
         SRTP_HMAC_SHA1,             /* authentication func type    */
         16,                    /* auth key length in octets   */
@@ -3344,7 +3344,7 @@ const srtp_policy_t wildcard_policy = {
         sec_serv_conf_and_auth /* security services flag      */
     },
     {                          /* SRTCP policy                   */
-        SRTP_AES_128_ICM,           /* cipher type                 */
+        SRTP_AES_ICM_128,           /* cipher type                 */
         30,                    /* cipher key length in octets */
         SRTP_HMAC_SHA1,             /* authentication func type    */
         16,                    /* auth key length in octets   */

--- a/test/srtp_driver.c
+++ b/test/srtp_driver.c
@@ -3236,7 +3236,7 @@ srtp_master_key_t *test_256_keys[2] = {
 const srtp_policy_t aes_256_hmac_policy = {
     { ssrc_any_outbound, 0 },  /* SSRC                           */
     {                          /* SRTP policy                    */
-        SRTP_AES_ICM,               /* cipher type                 */
+        SRTP_AES_256_ICM,               /* cipher type                 */
         46,                    /* cipher key length in octets */
         SRTP_HMAC_SHA1,             /* authentication func type    */
         20,                    /* auth key length in octets   */
@@ -3244,7 +3244,7 @@ const srtp_policy_t aes_256_hmac_policy = {
         sec_serv_conf_and_auth /* security services flag      */
     },
     {                          /* SRTCP policy                   */
-        SRTP_AES_ICM,               /* cipher type                 */
+        SRTP_AES_256_ICM,               /* cipher type                 */
         46,                    /* cipher key length in octets */
         SRTP_HMAC_SHA1,             /* authentication func type    */
         20,                    /* auth key length in octets   */


### PR DESCRIPTION
This applies #170 & #172  on to master as well as making more consistent use of the srtp AES_XXX_ICM defines.