### PR TITLE
add AES-GCM to DTLS-SRTP Protection Profiles v2

### DIFF
--- a/include/srtp.h
+++ b/include/srtp.h
@@ -1217,8 +1217,6 @@ typedef enum {
   srtp_profile_reserved           = 0,
   srtp_profile_aes128_cm_sha1_80  = 1,
   srtp_profile_aes128_cm_sha1_32  = 2,
-  srtp_profile_aes256_cm_sha1_80  = 3,
-  srtp_profile_aes256_cm_sha1_32  = 4,
   srtp_profile_null_sha1_80       = 5,
   srtp_profile_null_sha1_32       = 6,
   srtp_profile_aead_aes_128_gcm   = 7,

--- a/include/srtp.h
+++ b/include/srtp.h
@@ -1208,8 +1208,9 @@ srtp_err_status_t srtp_dealloc(srtp_t s);
  * @brief identifies a particular SRTP profile 
  *
  * An srtp_profile_t enumeration is used to identify a particular SRTP
- * profile (that is, a set of algorithms and parameters).  These
- * profiles are defined in the DTLS-SRTP draft.
+ * profile (that is, a set of algorithms and parameters). These profiles
+ * are defined for DTLS-SRTP:
+ * https://www.iana.org/assignments/srtp-protection/srtp-protection.xhtml
  */
 
 typedef enum {
@@ -1220,6 +1221,8 @@ typedef enum {
   srtp_profile_aes256_cm_sha1_32  = 4,
   srtp_profile_null_sha1_80       = 5,
   srtp_profile_null_sha1_32       = 6,
+  srtp_profile_aead_aes_128_gcm   = 7,
+  srtp_profile_aead_aes_256_gcm   = 8,
 } srtp_profile_t;
 
 

--- a/srtp/srtp.c
+++ b/srtp/srtp.c
@@ -4131,6 +4131,12 @@ srtp_crypto_policy_set_from_profile_for_rtp(srtp_crypto_policy_t *policy,
   case srtp_profile_aes256_cm_sha1_32:
     srtp_crypto_policy_set_aes_cm_256_hmac_sha1_32(policy);
     break;
+  case srtp_profile_aead_aes_128_gcm:
+    srtp_crypto_policy_set_aes_gcm_128_16_auth(policy);
+    break;
+  case srtp_profile_aead_aes_256_gcm:
+    srtp_crypto_policy_set_aes_gcm_256_16_auth(policy);
+    break;
     /* the following profiles are not (yet) supported */
   case srtp_profile_null_sha1_32:
   default:
@@ -4165,6 +4171,12 @@ srtp_crypto_policy_set_from_profile_for_rtcp(srtp_crypto_policy_t *policy,
      * this is not compliant with RFC 3711 */
     srtp_crypto_policy_set_aes_cm_256_hmac_sha1_80(policy);
     break;
+  case srtp_profile_aead_aes_128_gcm:
+    srtp_crypto_policy_set_aes_gcm_128_16_auth(policy);
+    break;
+  case srtp_profile_aead_aes_256_gcm:
+    srtp_crypto_policy_set_aes_gcm_256_16_auth(policy);
+    break;
     /* the following profiles are not (yet) supported */
   case srtp_profile_null_sha1_32:
   default:
@@ -4183,18 +4195,16 @@ srtp_profile_get_master_key_length(srtp_profile_t profile) {
 
   switch(profile) {
   case srtp_profile_aes128_cm_sha1_80:
-    return 16;
-    break;
   case srtp_profile_aes128_cm_sha1_32:
+  case srtp_profile_aead_aes_128_gcm:
     return 16;
     break;
   case srtp_profile_null_sha1_80:
     return 16;
     break;
   case srtp_profile_aes256_cm_sha1_80:
-    return 32;
-    break;
   case srtp_profile_aes256_cm_sha1_32:
+  case srtp_profile_aead_aes_256_gcm:
     return 32;
     break;
     /* the following profiles are not (yet) supported */
@@ -4209,19 +4219,15 @@ srtp_profile_get_master_salt_length(srtp_profile_t profile) {
 
   switch(profile) {
   case srtp_profile_aes128_cm_sha1_80:
-    return 14;
-    break;
   case srtp_profile_aes128_cm_sha1_32:
-    return 14;
-    break;
   case srtp_profile_null_sha1_80:
-    return 14;
-    break;
   case srtp_profile_aes256_cm_sha1_80:
-    return 14;
-    break;
   case srtp_profile_aes256_cm_sha1_32:
     return 14;
+    break;
+  case srtp_profile_aead_aes_128_gcm:
+  case srtp_profile_aead_aes_256_gcm:
+    return 12;
     break;
     /* the following profiles are not (yet) supported */
   case srtp_profile_null_sha1_32:

--- a/srtp/srtp.c
+++ b/srtp/srtp.c
@@ -4195,15 +4195,23 @@ srtp_profile_get_master_key_length(srtp_profile_t profile) {
 
   switch(profile) {
   case srtp_profile_aes128_cm_sha1_80:
+    return 16;
+    break;
   case srtp_profile_aes128_cm_sha1_32:
-  case srtp_profile_aead_aes_128_gcm:
     return 16;
     break;
   case srtp_profile_null_sha1_80:
     return 16;
     break;
   case srtp_profile_aes256_cm_sha1_80:
+    return 32;
+    break;
   case srtp_profile_aes256_cm_sha1_32:
+    return 32;
+    break;
+  case srtp_profile_aead_aes_128_gcm:
+    return 16;
+    break;
   case srtp_profile_aead_aes_256_gcm:
     return 32;
     break;
@@ -4219,13 +4227,23 @@ srtp_profile_get_master_salt_length(srtp_profile_t profile) {
 
   switch(profile) {
   case srtp_profile_aes128_cm_sha1_80:
+    return 14;
+    break;
   case srtp_profile_aes128_cm_sha1_32:
+    return 14;
+    break;
   case srtp_profile_null_sha1_80:
+    return 14;
+    break;
   case srtp_profile_aes256_cm_sha1_80:
+    return 14;
+    break;
   case srtp_profile_aes256_cm_sha1_32:
     return 14;
     break;
   case srtp_profile_aead_aes_128_gcm:
+    return 12;
+    break;
   case srtp_profile_aead_aes_256_gcm:
     return 12;
     break;

--- a/srtp/srtp.c
+++ b/srtp/srtp.c
@@ -4131,12 +4131,14 @@ srtp_crypto_policy_set_from_profile_for_rtp(srtp_crypto_policy_t *policy,
   case srtp_profile_aes256_cm_sha1_32:
     srtp_crypto_policy_set_aes_cm_256_hmac_sha1_32(policy);
     break;
+#if defined(OPENSSL)
   case srtp_profile_aead_aes_128_gcm:
     srtp_crypto_policy_set_aes_gcm_128_16_auth(policy);
     break;
   case srtp_profile_aead_aes_256_gcm:
     srtp_crypto_policy_set_aes_gcm_256_16_auth(policy);
     break;
+#endif
     /* the following profiles are not (yet) supported */
   case srtp_profile_null_sha1_32:
   default:
@@ -4171,12 +4173,14 @@ srtp_crypto_policy_set_from_profile_for_rtcp(srtp_crypto_policy_t *policy,
      * this is not compliant with RFC 3711 */
     srtp_crypto_policy_set_aes_cm_256_hmac_sha1_80(policy);
     break;
+#if defined(OPENSSL)
   case srtp_profile_aead_aes_128_gcm:
     srtp_crypto_policy_set_aes_gcm_128_16_auth(policy);
     break;
   case srtp_profile_aead_aes_256_gcm:
     srtp_crypto_policy_set_aes_gcm_256_16_auth(policy);
     break;
+#endif
     /* the following profiles are not (yet) supported */
   case srtp_profile_null_sha1_32:
   default:

--- a/srtp/srtp.c
+++ b/srtp/srtp.c
@@ -4125,12 +4125,6 @@ srtp_crypto_policy_set_from_profile_for_rtp(srtp_crypto_policy_t *policy,
   case srtp_profile_null_sha1_80:
     srtp_crypto_policy_set_null_cipher_hmac_sha1_80(policy);
     break;
-  case srtp_profile_aes256_cm_sha1_80:
-    srtp_crypto_policy_set_aes_cm_256_hmac_sha1_80(policy);
-    break;
-  case srtp_profile_aes256_cm_sha1_32:
-    srtp_crypto_policy_set_aes_cm_256_hmac_sha1_32(policy);
-    break;
 #if defined(OPENSSL)
   case srtp_profile_aead_aes_128_gcm:
     srtp_crypto_policy_set_aes_gcm_128_16_auth(policy);
@@ -4164,14 +4158,6 @@ srtp_crypto_policy_set_from_profile_for_rtcp(srtp_crypto_policy_t *policy,
     break;
   case srtp_profile_null_sha1_80:
     srtp_crypto_policy_set_null_cipher_hmac_sha1_80(policy);
-    break;
-  case srtp_profile_aes256_cm_sha1_80:
-    srtp_crypto_policy_set_aes_cm_256_hmac_sha1_80(policy);
-    break;
-  case srtp_profile_aes256_cm_sha1_32:
-    /* We do not honor the 32-bit auth tag request since
-     * this is not compliant with RFC 3711 */
-    srtp_crypto_policy_set_aes_cm_256_hmac_sha1_80(policy);
     break;
 #if defined(OPENSSL)
   case srtp_profile_aead_aes_128_gcm:
@@ -4207,12 +4193,6 @@ srtp_profile_get_master_key_length(srtp_profile_t profile) {
   case srtp_profile_null_sha1_80:
     return 16;
     break;
-  case srtp_profile_aes256_cm_sha1_80:
-    return 32;
-    break;
-  case srtp_profile_aes256_cm_sha1_32:
-    return 32;
-    break;
   case srtp_profile_aead_aes_128_gcm:
     return 16;
     break;
@@ -4237,12 +4217,6 @@ srtp_profile_get_master_salt_length(srtp_profile_t profile) {
     return 14;
     break;
   case srtp_profile_null_sha1_80:
-    return 14;
-    break;
-  case srtp_profile_aes256_cm_sha1_80:
-    return 14;
-    break;
-  case srtp_profile_aes256_cm_sha1_32:
     return 14;
     break;
   case srtp_profile_aead_aes_128_gcm:


### PR DESCRIPTION
This is a reapplication of #188 on to master taking into account comments from both #188 & #185