### PR TITLE
Add log handler api to receive log messages from libSRTP

### DIFF
--- a/configure.in
+++ b/configure.in
@@ -78,7 +78,7 @@ AC_COMPILE_IFELSE([AC_LANG_PROGRAM()],
    AC_MSG_RESULT([no])])
 
 if test "$EMPTY_CFLAGS" = "yes"; then
-  for f in -Wall; do
+  for f in -Wall -pedantic; do
     AC_MSG_CHECKING([whether the compiler supports $f])
     save_cflags="$CFLAGS"
     AS_IF([test "x$CFLAGS" = "x"], [CFLAGS="$f"], [CFLAGS="$CFLAGS $f"])

--- a/configure.in
+++ b/configure.in
@@ -78,7 +78,7 @@ AC_COMPILE_IFELSE([AC_LANG_PROGRAM()],
    AC_MSG_RESULT([no])])
 
 if test "$EMPTY_CFLAGS" = "yes"; then
-  for f in -Wall -pedantic; do
+  for f in -Wall; do
     AC_MSG_CHECKING([whether the compiler supports $f])
     save_cflags="$CFLAGS"
     AS_IF([test "x$CFLAGS" = "x"], [CFLAGS="$f"], [CFLAGS="$CFLAGS $f"])

--- a/crypto/include/err.h
+++ b/crypto/include/err.h
@@ -82,6 +82,10 @@ typedef enum {
 
 srtp_err_status_t srtp_err_reporting_init();
 
+typedef void (srtp_err_report_handler_func_t)(srtp_err_reporting_level_t level, const char * msg);
+
+srtp_err_status_t srtp_install_err_report_handler(srtp_err_report_handler_func_t func);
+
 /*
  * srtp_err_report reports a 'printf' formatted error
  * string, followed by a an arg list.  The level argument

--- a/crypto/kernel/err.c
+++ b/crypto/kernel/err.c
@@ -47,6 +47,7 @@
 #endif
 
 #include "err.h"
+#include <string.h>
 
 /* srtp_err_file is the FILE to which errors are reported */
 
@@ -72,6 +73,7 @@ static srtp_err_report_handler_func_t * srtp_err_report_handler = NULL;
 srtp_err_status_t srtp_install_err_report_handler(srtp_err_report_handler_func_t func)
 {
     srtp_err_report_handler = func;
+    return srtp_err_status_ok;
 }
 
 void srtp_err_report (srtp_err_reporting_level_t level, const char *format, ...)

--- a/crypto/kernel/err.c
+++ b/crypto/kernel/err.c
@@ -94,6 +94,11 @@ void srtp_err_report (srtp_err_reporting_level_t level, const char *format, ...)
                 msg[l-1] = '\0';
             }
             srtp_err_report_handler(level, msg);
+            /*
+             * NOTE, need to be carefull, there is a potential that octet_string_set_to_zero() could
+             * call srtp_err_report() in the future, leading to recursion
+             */
+            octet_string_set_to_zero(msg, sizeof(msg));
         }
         va_end(args);
     }

--- a/include/srtp.h
+++ b/include/srtp.h
@@ -1699,12 +1699,12 @@ typedef enum {
  * the log handler.
  *
  * The typedef srtp_event_handler_func_t is the prototype for the
- * event handler function.  It has as srtp_log_level_t and log
- * message as arguments.
+ * event handler function.  It has as srtp_log_level_t, log
+ * message and data as arguments.
  * There can only be a single, global handler for all log messages in
  * libSRTP.
  */
-typedef void (srtp_log_handler_func_t)(srtp_log_level_t level, const char * msg);
+typedef void (srtp_log_handler_func_t)(srtp_log_level_t level, const char * msg, void *data);
 
 /**
  * @brief sets the log handler to the function supplied by the caller.
@@ -1717,8 +1717,9 @@ typedef void (srtp_log_handler_func_t)(srtp_log_level_t level, const char * msg)
  *
  * @param func is a pointer to a fuction of type srtp_log_handler_func_t.
  *             This function will be used by libSRTP to output log messages.
+ * @param data is a user pointer that will be returned as the data argument in func.
  */
-srtp_err_status_t srtp_install_log_handler(srtp_log_handler_func_t func);
+srtp_err_status_t srtp_install_log_handler(srtp_log_handler_func_t func, void *data);
 
 /**
  * @brief srtp_get_protect_trailer_length(session, use_mki, mki_index, length)

--- a/include/srtp.h
+++ b/include/srtp.h
@@ -1681,6 +1681,46 @@ srtp_err_status_t srtp_set_debug_module(char *mod_name, int v);
 srtp_err_status_t srtp_list_debug_modules(void);
 
 /**
+ * @brief srtp_log_level_t defines log levels.
+ *
+ * The enumeration srtp_log_level_t defines log levels reported
+ * in the srtp_log_handler_func_t.
+ *
+ */
+typedef enum {
+    srtp_log_level_error,   /**< log level is reporting an error message  */
+    srtp_log_level_warning, /**< log level is reporting a warning message */
+    srtp_log_level_info,    /**< log level is reporting an info message   */
+    srtp_log_level_debug    /**< log level is reporting a debug message   */
+} srtp_log_level_t;
+
+/**
+ * @brief srtp_log_handler_func_t is the function prototype for
+ * the log handler.
+ *
+ * The typedef srtp_event_handler_func_t is the prototype for the
+ * event handler function.  It has as srtp_log_level_t and log
+ * message as arguments.
+ * There can only be a single, global handler for all log messages in
+ * libSRTP.
+ */
+typedef void (srtp_log_handler_func_t)(srtp_log_level_t level, const char * msg);
+
+/**
+ * @brief sets the log handler to the function supplied by the caller.
+ *
+ * The function call srtp_install_log_handler(func) sets the log
+ * handler function to the value func.  The value NULL is acceptable
+ * as an argument; in this case, log messages will be ignored.
+ * This function can be called before srtp_init() inorder to capture
+ * any logging during start up.
+ *
+ * @param func is a pointer to a fuction of type srtp_log_handler_func_t.
+ *             This function will be used by libSRTP to output log messages.
+ */
+srtp_err_status_t srtp_install_log_handler(srtp_log_handler_func_t func);
+
+/**
  * @brief srtp_get_protect_trailer_length(session, use_mki, mki_index, length)
  *
  * Determines the length of the amount of data Lib SRTP will add to the 

--- a/srtp/srtp.c
+++ b/srtp/srtp.c
@@ -4322,3 +4322,44 @@ srtp_err_status_t srtp_list_debug_modules(void)
     return srtp_crypto_kernel_list_debug_modules();
 }
 
+/*
+ * srtp_log_handler is a global variable holding a pointer to the
+ * log handler function; this function is called for any log
+ * output.
+ */
+
+static srtp_log_handler_func_t *srtp_log_handler = NULL;
+
+void srtp_err_handler(srtp_err_reporting_level_t level, const char * msg)
+{
+    if (srtp_log_handler) {
+        srtp_log_level_t log_level;
+        switch(level) {
+            case srtp_err_level_error: log_level = srtp_log_level_error; break;
+            case srtp_err_level_warning: log_level = srtp_log_level_warning; break;
+            case srtp_err_level_info: log_level = srtp_log_level_info; break;
+            case srtp_err_level_debug: log_level = srtp_log_level_debug; break;
+        }
+
+        srtp_log_handler(log_level, msg);
+    }
+}
+
+srtp_err_status_t srtp_install_log_handler(srtp_log_handler_func_t func)
+{
+
+    /*
+     * note that we accept NULL arguments intentionally - calling this
+     * function with a NULL arguments removes a log handler that's
+     * been previously installed
+     */
+
+    if (srtp_log_handler) {
+        srtp_install_err_report_handler(NULL);
+    }
+    srtp_log_handler = func;
+    if (srtp_log_handler) {
+        srtp_install_err_report_handler(srtp_err_handler);
+    }
+    return srtp_err_status_ok;
+}

--- a/srtp/srtp.c
+++ b/srtp/srtp.c
@@ -4329,6 +4329,7 @@ srtp_err_status_t srtp_list_debug_modules(void)
  */
 
 static srtp_log_handler_func_t *srtp_log_handler = NULL;
+static void * srtp_log_handler_data = NULL;
 
 void srtp_err_handler(srtp_err_reporting_level_t level, const char * msg)
 {
@@ -4341,11 +4342,11 @@ void srtp_err_handler(srtp_err_reporting_level_t level, const char * msg)
             case srtp_err_level_debug: log_level = srtp_log_level_debug; break;
         }
 
-        srtp_log_handler(log_level, msg);
+        srtp_log_handler(log_level, msg, srtp_log_handler_data);
     }
 }
 
-srtp_err_status_t srtp_install_log_handler(srtp_log_handler_func_t func)
+srtp_err_status_t srtp_install_log_handler(srtp_log_handler_func_t func, void * data)
 {
 
     /*
@@ -4358,6 +4359,7 @@ srtp_err_status_t srtp_install_log_handler(srtp_log_handler_func_t func)
         srtp_install_err_report_handler(NULL);
     }
     srtp_log_handler = func;
+    srtp_log_handler_data = data;
     if (srtp_log_handler) {
         srtp_install_err_report_handler(srtp_err_handler);
     }

--- a/srtp/srtp.c
+++ b/srtp/srtp.c
@@ -4333,7 +4333,7 @@ static srtp_log_handler_func_t *srtp_log_handler = NULL;
 void srtp_err_handler(srtp_err_reporting_level_t level, const char * msg)
 {
     if (srtp_log_handler) {
-        srtp_log_level_t log_level;
+        srtp_log_level_t log_level = srtp_log_level_error;
         switch(level) {
             case srtp_err_level_error: log_level = srtp_log_level_error; break;
             case srtp_err_level_warning: log_level = srtp_log_level_warning; break;

--- a/test/srtp_driver.c
+++ b/test/srtp_driver.c
@@ -177,7 +177,7 @@ usage (char *prog_name)
 }
 
 void
-log_handler (srtp_log_level_t level, const char * msg)
+log_handler (srtp_log_level_t level, const char * msg, void * data)
 {
     char level_char = '?';
     switch(level) {
@@ -294,7 +294,7 @@ main (int argc, char *argv[])
     }
 
     if (do_log_stdout) {
-        status = srtp_install_log_handler(log_handler);
+        status = srtp_install_log_handler(log_handler, NULL);
         if (status) {
             printf("error: install log handler failed\n");
             exit(1);


### PR DESCRIPTION
This address the second half of #230 

This can be tested ruining the test/srtp_driver test application with the new -o option.