### PR TITLE
crypto/kernel/err.c: Include datatypes.h

### DIFF
--- a/crypto/kernel/err.c
+++ b/crypto/kernel/err.c
@@ -47,6 +47,7 @@
 #endif
 
 #include "err.h"
+#include "datatypes.h"
 #include <string.h>
 
 /* srtp_err_file is the FILE to which errors are reported */


### PR DESCRIPTION
Required for octet_string_set_to_zero() to silence warnings.