### PR TITLE
Reduce literal constants

### DIFF
--- a/crypto/cipher/aes_gcm_ossl.c
+++ b/crypto/cipher/aes_gcm_ossl.c
@@ -93,8 +93,8 @@ static srtp_err_status_t srtp_aes_gcm_openssl_alloc (srtp_cipher_t **c, int key_
     /*
      * Verify the key_len is valid for one of: AES-128/256
      */
-    if (key_len != SRTP_AES_GCM_128_KEYSIZE_WSALT &&
-        key_len != SRTP_AES_GCM_256_KEYSIZE_WSALT) {
+    if (key_len != SRTP_AES_GCM_128_KEY_LEN_WSALT &&
+        key_len != SRTP_AES_GCM_256_KEY_LEN_WSALT) {
         return (srtp_err_status_bad_param);
     }
 
@@ -131,16 +131,16 @@ static srtp_err_status_t srtp_aes_gcm_openssl_alloc (srtp_cipher_t **c, int key_
 
     /* setup cipher attributes */
     switch (key_len) {
-    case SRTP_AES_GCM_128_KEYSIZE_WSALT:
+    case SRTP_AES_GCM_128_KEY_LEN_WSALT:
         (*c)->type = &srtp_aes_gcm_128_openssl;
         (*c)->algorithm = SRTP_AES_GCM_128;
-        gcm->key_size = SRTP_AES_128_KEYSIZE;
+        gcm->key_size = SRTP_AES_128_KEY_LEN;
         gcm->tag_len = tlen;
         break;
-    case SRTP_AES_GCM_256_KEYSIZE_WSALT:
+    case SRTP_AES_GCM_256_KEY_LEN_WSALT:
         (*c)->type = &srtp_aes_gcm_256_openssl;
         (*c)->algorithm = SRTP_AES_GCM_256;
-        gcm->key_size = SRTP_AES_256_KEYSIZE;
+        gcm->key_size = SRTP_AES_256_KEY_LEN;
         gcm->tag_len = tlen;
         break;
     }
@@ -189,10 +189,10 @@ static srtp_err_status_t srtp_aes_gcm_openssl_context_init (void* cv, const uint
     debug_print(srtp_mod_aes_gcm, "key:  %s", srtp_octet_string_hex_string(key, c->key_size));
 
     switch (c->key_size) {
-    case SRTP_AES_256_KEYSIZE:
+    case SRTP_AES_256_KEY_LEN:
         evp = EVP_aes_256_gcm();
         break;
-    case SRTP_AES_128_KEYSIZE:
+    case SRTP_AES_128_KEY_LEN:
         evp = EVP_aes_128_gcm();
         break;
     default:
@@ -386,7 +386,7 @@ static const char srtp_aes_gcm_256_openssl_description[] = "AES-256 GCM using op
  * values we're derived from independent test code
  * using OpenSSL.
  */
-static const uint8_t srtp_aes_gcm_test_case_0_key[SRTP_AES_GCM_128_KEYSIZE_WSALT] = {
+static const uint8_t srtp_aes_gcm_test_case_0_key[SRTP_AES_GCM_128_KEY_LEN_WSALT] = {
     0xfe, 0xff, 0xe9, 0x92, 0x86, 0x65, 0x73, 0x1c,
     0x6d, 0x6a, 0x8f, 0x94, 0x67, 0x30, 0x83, 0x08,
     0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08,
@@ -430,7 +430,7 @@ static const uint8_t srtp_aes_gcm_test_case_0_ciphertext[76] = {
 };
 
 static const srtp_cipher_test_case_t srtp_aes_gcm_test_case_0a = {
-    SRTP_AES_GCM_128_KEYSIZE_WSALT,      /* octets in key            */
+    SRTP_AES_GCM_128_KEY_LEN_WSALT,      /* octets in key            */
     srtp_aes_gcm_test_case_0_key,        /* key                      */
     srtp_aes_gcm_test_case_0_iv,         /* packet index             */
     60,                                  /* octets in plaintext      */
@@ -444,7 +444,7 @@ static const srtp_cipher_test_case_t srtp_aes_gcm_test_case_0a = {
 };
 
 static const srtp_cipher_test_case_t srtp_aes_gcm_test_case_0 = {
-    SRTP_AES_GCM_128_KEYSIZE_WSALT,      /* octets in key            */
+    SRTP_AES_GCM_128_KEY_LEN_WSALT,      /* octets in key            */
     srtp_aes_gcm_test_case_0_key,        /* key                      */
     srtp_aes_gcm_test_case_0_iv,         /* packet index             */
     60,                                  /* octets in plaintext      */
@@ -457,7 +457,7 @@ static const srtp_cipher_test_case_t srtp_aes_gcm_test_case_0 = {
     &srtp_aes_gcm_test_case_0a           /* pointer to next testcase */
 };
 
-static const uint8_t srtp_aes_gcm_test_case_1_key[SRTP_AES_GCM_256_KEYSIZE_WSALT] = {
+static const uint8_t srtp_aes_gcm_test_case_1_key[SRTP_AES_GCM_256_KEY_LEN_WSALT] = {
     0xfe, 0xff, 0xe9, 0x92, 0x86, 0x65, 0x73, 0x1c,
     0xa5, 0x59, 0x09, 0xc5, 0x54, 0x66, 0x93, 0x1c,
     0xaf, 0xf5, 0x26, 0x9a, 0x21, 0xd5, 0x14, 0xb2,
@@ -504,7 +504,7 @@ static const uint8_t srtp_aes_gcm_test_case_1_ciphertext[76] = {
 };
 
 static const srtp_cipher_test_case_t srtp_aes_gcm_test_case_1a = {
-    SRTP_AES_GCM_256_KEYSIZE_WSALT,      /* octets in key            */
+    SRTP_AES_GCM_256_KEY_LEN_WSALT,      /* octets in key            */
     srtp_aes_gcm_test_case_1_key,        /* key                      */
     srtp_aes_gcm_test_case_1_iv,         /* packet index             */
     60,                                  /* octets in plaintext      */
@@ -518,7 +518,7 @@ static const srtp_cipher_test_case_t srtp_aes_gcm_test_case_1a = {
 };
 
 static const srtp_cipher_test_case_t srtp_aes_gcm_test_case_1 = {
-    SRTP_AES_GCM_256_KEYSIZE_WSALT,      /* octets in key            */
+    SRTP_AES_GCM_256_KEY_LEN_WSALT,      /* octets in key            */
     srtp_aes_gcm_test_case_1_key,        /* key                      */
     srtp_aes_gcm_test_case_1_iv,         /* packet index             */
     60,                                  /* octets in plaintext      */

--- a/crypto/cipher/aes_icm.c
+++ b/crypto/cipher/aes_icm.c
@@ -102,12 +102,12 @@ static srtp_err_status_t srtp_aes_icm_alloc (srtp_cipher_t **c, int key_len, int
                 "allocating cipher with key length %d", key_len);
 
     /*
-     * The check for key_len = 30/38/46 does not apply. Our usage
+     * The check for key_len = 30/46 does not apply. Our usage
      * of aes functions with key_len = values other than 30
      * has not broken anything. Don't know what would be the
      * effect of skipping this check for srtp in general.
      */
-    if (key_len != 30 && key_len != 46) {
+    if (key_len != SRTP_AES_ICM_128_KEY_LEN_WSALT && key_len != SRTP_AES_ICM_256_KEY_LEN_WSALT) {
         return srtp_err_status_bad_param;
     }
 
@@ -129,7 +129,7 @@ static srtp_err_status_t srtp_aes_icm_alloc (srtp_cipher_t **c, int key_len, int
     (*c)->state = icm;
 
     switch (key_len) {
-    case 46:
+    case SRTP_AES_ICM_256_KEY_LEN_WSALT:
         (*c)->algorithm = SRTP_AES_ICM_256;
         (*c)->type = &srtp_aes_icm_256;
         break;
@@ -184,8 +184,8 @@ static srtp_err_status_t srtp_aes_icm_context_init (void *cv, const uint8_t *key
     srtp_err_status_t status;
     int base_key_len, copy_len;
 
-    if (c->key_size == 30 || c->key_size == 38 || c->key_size == 46) {
-        base_key_len = c->key_size - 14;
+    if (c->key_size == SRTP_AES_ICM_128_KEY_LEN_WSALT || c->key_size == SRTP_AES_ICM_256_KEY_LEN_WSALT) {
+        base_key_len = c->key_size - SRTP_SALT_LEN;
     } else{
         return srtp_err_status_bad_param;
     }
@@ -199,8 +199,8 @@ static srtp_err_status_t srtp_aes_icm_context_init (void *cv, const uint8_t *key
 
     copy_len = c->key_size - base_key_len;
     /* force last two octets of the offset to be left zero (for srtp compatibility) */
-    if (copy_len > 14) {
-        copy_len = 14;
+    if (copy_len > SRTP_SALT_LEN) {
+        copy_len = SRTP_SALT_LEN;
     }
 
     memcpy(&c->counter, key + base_key_len, copy_len);
@@ -404,7 +404,7 @@ static srtp_err_status_t srtp_aes_icm_encrypt (void *cv,
 static const char srtp_aes_icm_128_description[] = "AES-128 integer counter mode";
 static const char srtp_aes_icm_256_description[] = "AES-256 integer counter mode";
 
-static const uint8_t srtp_aes_icm_128_test_case_0_key[30] = {
+static const uint8_t srtp_aes_icm_128_test_case_0_key[SRTP_AES_ICM_128_KEY_LEN_WSALT] = {
     0x2b, 0x7e, 0x15, 0x16, 0x28, 0xae, 0xd2, 0xa6,
     0xab, 0xf7, 0x15, 0x88, 0x09, 0xcf, 0x4f, 0x3c,
     0xf0, 0xf1, 0xf2, 0xf3, 0xf4, 0xf5, 0xf6, 0xf7,
@@ -431,7 +431,7 @@ static const uint8_t srtp_aes_icm_128_test_case_0_ciphertext[32] = {
 };
 
 static const srtp_cipher_test_case_t srtp_aes_icm_128_test_case_0 = {
-    30,                                  /* octets in key            */
+    SRTP_AES_ICM_128_KEY_LEN_WSALT,              /* octets in key            */
     srtp_aes_icm_128_test_case_0_key,        /* key                      */
     srtp_aes_icm_128_test_case_0_nonce,      /* packet index             */
     32,                                  /* octets in plaintext      */
@@ -444,7 +444,7 @@ static const srtp_cipher_test_case_t srtp_aes_icm_128_test_case_0 = {
     NULL                                 /* pointer to next testcase */
 };
 
-static const uint8_t srtp_aes_icm_256_test_case_0_key[46] = {
+static const uint8_t srtp_aes_icm_256_test_case_0_key[SRTP_AES_ICM_256_KEY_LEN_WSALT] = {
     0x57, 0xf8, 0x2f, 0xe3, 0x61, 0x3f, 0xd1, 0x70,
     0xa8, 0x5e, 0xc9, 0x3c, 0x40, 0xb1, 0xf0, 0x92,
     0x2e, 0xc4, 0xcb, 0x0d, 0xc0, 0x25, 0xb5, 0x82,
@@ -473,7 +473,7 @@ static const uint8_t srtp_aes_icm_256_test_case_0_ciphertext[32] = {
 };
 
 static const srtp_cipher_test_case_t srtp_aes_icm_256_test_case_0 = {
-    46,                                  /* octets in key            */
+    SRTP_AES_ICM_256_KEY_LEN_WSALT,              /* octets in key            */
     srtp_aes_icm_256_test_case_0_key,        /* key                      */
     srtp_aes_icm_256_test_case_0_nonce,      /* packet index             */
     32,                                  /* octets in plaintext      */

--- a/crypto/cipher/aes_icm_ossl.c
+++ b/crypto/cipher/aes_icm_ossl.c
@@ -118,8 +118,8 @@ static srtp_err_status_t srtp_aes_icm_openssl_alloc (srtp_cipher_t **c, int key_
     /*
      * Verify the key_len is valid for one of: AES-128/192/256
      */
-    if (key_len != SRTP_AES_128_KEYSIZE_WSALT && key_len != SRTP_AES_192_KEYSIZE_WSALT &&
-        key_len != SRTP_AES_256_KEYSIZE_WSALT) {
+    if (key_len != SRTP_AES_ICM_128_KEY_LEN_WSALT && key_len != SRTP_AES_ICM_192_KEY_LEN_WSALT &&
+        key_len != SRTP_AES_ICM_256_KEY_LEN_WSALT) {
         return srtp_err_status_bad_param;
     }
 
@@ -151,20 +151,20 @@ static srtp_err_status_t srtp_aes_icm_openssl_alloc (srtp_cipher_t **c, int key_
 
     /* setup cipher parameters */
     switch (key_len) {
-    case SRTP_AES_128_KEYSIZE_WSALT:
+    case SRTP_AES_ICM_128_KEY_LEN_WSALT:
         (*c)->algorithm = SRTP_AES_ICM_128;
         (*c)->type = &srtp_aes_icm_128;
-        icm->key_size = SRTP_AES_128_KEYSIZE;
+        icm->key_size = SRTP_AES_128_KEY_LEN;
         break;
-    case SRTP_AES_192_KEYSIZE_WSALT:
+    case SRTP_AES_ICM_192_KEY_LEN_WSALT:
         (*c)->algorithm = SRTP_AES_ICM_192;
         (*c)->type = &srtp_aes_icm_192;
-        icm->key_size = SRTP_AES_192_KEYSIZE;
+        icm->key_size = SRTP_AES_192_KEY_LEN;
         break;
-    case SRTP_AES_256_KEYSIZE_WSALT:
+    case SRTP_AES_ICM_256_KEY_LEN_WSALT:
         (*c)->algorithm = SRTP_AES_ICM_256;
         (*c)->type = &srtp_aes_icm_256;
-        icm->key_size = SRTP_AES_256_KEYSIZE;
+        icm->key_size = SRTP_AES_256_KEY_LEN;
         break;
     }
 
@@ -223,24 +223,24 @@ static srtp_err_status_t srtp_aes_icm_openssl_context_init (void* cv, const uint
      */
     v128_set_to_zero(&c->counter);
     v128_set_to_zero(&c->offset);
-    memcpy(&c->counter, key + c->key_size, SRTP_SALT_SIZE);
-    memcpy(&c->offset, key + c->key_size, SRTP_SALT_SIZE);
+    memcpy(&c->counter, key + c->key_size, SRTP_SALT_LEN);
+    memcpy(&c->offset, key + c->key_size, SRTP_SALT_LEN);
 
     /* force last two octets of the offset to zero (for srtp compatibility) */
-    c->offset.v8[SRTP_SALT_SIZE] = c->offset.v8[SRTP_SALT_SIZE + 1] = 0;
-    c->counter.v8[SRTP_SALT_SIZE] = c->counter.v8[SRTP_SALT_SIZE + 1] = 0;
+    c->offset.v8[SRTP_SALT_LEN] = c->offset.v8[SRTP_SALT_LEN + 1] = 0;
+    c->counter.v8[SRTP_SALT_LEN] = c->counter.v8[SRTP_SALT_LEN + 1] = 0;
 
     debug_print(srtp_mod_aes_icm, "key:  %s", srtp_octet_string_hex_string(key, c->key_size));
     debug_print(srtp_mod_aes_icm, "offset: %s", v128_hex_string(&c->offset));
 
     switch (c->key_size) {
-    case SRTP_AES_256_KEYSIZE:
+    case SRTP_AES_256_KEY_LEN:
         evp = EVP_aes_256_ctr();
         break;
-    case SRTP_AES_192_KEYSIZE:
+    case SRTP_AES_192_KEY_LEN:
         evp = EVP_aes_192_ctr();
         break;
-    case SRTP_AES_128_KEYSIZE:
+    case SRTP_AES_128_KEY_LEN:
         evp = EVP_aes_128_ctr();
         break;
     default:
@@ -325,7 +325,7 @@ static const char srtp_aes_icm_256_openssl_description[] = "AES-256 counter mode
  * KAT values for AES self-test.  These
  * values came from the legacy libsrtp code.
  */
-static const uint8_t srtp_aes_icm_128_test_case_0_key[SRTP_AES_128_KEYSIZE_WSALT] = {
+static const uint8_t srtp_aes_icm_128_test_case_0_key[SRTP_AES_ICM_128_KEY_LEN_WSALT] = {
     0x2b, 0x7e, 0x15, 0x16, 0x28, 0xae, 0xd2, 0xa6,
     0xab, 0xf7, 0x15, 0x88, 0x09, 0xcf, 0x4f, 0x3c,
     0xf0, 0xf1, 0xf2, 0xf3, 0xf4, 0xf5, 0xf6, 0xf7,
@@ -352,7 +352,7 @@ static const uint8_t srtp_aes_icm_128_test_case_0_ciphertext[32] = {
 };
 
 static const srtp_cipher_test_case_t srtp_aes_icm_128_test_case_0 = {
-    SRTP_AES_128_KEYSIZE_WSALT,                 /* octets in key            */
+    SRTP_AES_ICM_128_KEY_LEN_WSALT,                 /* octets in key            */
     srtp_aes_icm_128_test_case_0_key,               /* key                      */
     srtp_aes_icm_128_test_case_0_nonce,             /* packet index             */
     32,                                    /* octets in plaintext      */
@@ -369,7 +369,7 @@ static const srtp_cipher_test_case_t srtp_aes_icm_128_test_case_0 = {
  * KAT values for AES-192-CTR self-test.  These
  * values came from section 7 of RFC 6188.
  */
-static const uint8_t srtp_aes_icm_192_test_case_0_key[SRTP_AES_192_KEYSIZE_WSALT] = {
+static const uint8_t srtp_aes_icm_192_test_case_0_key[SRTP_AES_ICM_192_KEY_LEN_WSALT] = {
     0xea, 0xb2, 0x34, 0x76, 0x4e, 0x51, 0x7b, 0x2d,
     0x3d, 0x16, 0x0d, 0x58, 0x7d, 0x8c, 0x86, 0x21,
     0x97, 0x40, 0xf6, 0x5f, 0x99, 0xb6, 0xbc, 0xf7,
@@ -397,7 +397,7 @@ static const uint8_t srtp_aes_icm_192_test_case_0_ciphertext[32] = {
 };
 
 static const srtp_cipher_test_case_t srtp_aes_icm_192_test_case_0 = {
-    SRTP_AES_192_KEYSIZE_WSALT,                 /* octets in key            */
+    SRTP_AES_ICM_192_KEY_LEN_WSALT,                 /* octets in key            */
     srtp_aes_icm_192_test_case_0_key,           /* key                      */
     srtp_aes_icm_192_test_case_0_nonce,         /* packet index             */
     32,                                    /* octets in plaintext      */
@@ -414,7 +414,7 @@ static const srtp_cipher_test_case_t srtp_aes_icm_192_test_case_0 = {
  * KAT values for AES-256-CTR self-test.  These
  * values came from section 7 of RFC 6188.
  */
-static const uint8_t srtp_aes_icm_256_test_case_0_key[SRTP_AES_256_KEYSIZE_WSALT] = {
+static const uint8_t srtp_aes_icm_256_test_case_0_key[SRTP_AES_ICM_256_KEY_LEN_WSALT] = {
     0x57, 0xf8, 0x2f, 0xe3, 0x61, 0x3f, 0xd1, 0x70,
     0xa8, 0x5e, 0xc9, 0x3c, 0x40, 0xb1, 0xf0, 0x92,
     0x2e, 0xc4, 0xcb, 0x0d, 0xc0, 0x25, 0xb5, 0x82,
@@ -443,7 +443,7 @@ static const uint8_t srtp_aes_icm_256_test_case_0_ciphertext[32] = {
 };
 
 static const srtp_cipher_test_case_t srtp_aes_icm_256_test_case_0 = {
-    SRTP_AES_256_KEYSIZE_WSALT,                 /* octets in key            */
+    SRTP_AES_ICM_256_KEY_LEN_WSALT,                 /* octets in key            */
     srtp_aes_icm_256_test_case_0_key,           /* key                      */
     srtp_aes_icm_256_test_case_0_nonce,         /* packet index             */
     32,                                    /* octets in plaintext      */

--- a/crypto/include/aes_icm_ossl.h
+++ b/crypto/include/aes_icm_ossl.h
@@ -51,14 +51,6 @@
 #include <openssl/evp.h>
 #include <openssl/aes.h>
 
-#define     SRTP_SALT_SIZE               14
-#define     SRTP_AES_128_KEYSIZE         AES_BLOCK_SIZE
-#define     SRTP_AES_256_KEYSIZE         AES_BLOCK_SIZE * 2
-#define     SRTP_AES_128_KEYSIZE_WSALT   SRTP_AES_128_KEYSIZE + SRTP_SALT_SIZE
-#define     SRTP_AES_256_KEYSIZE_WSALT   SRTP_AES_256_KEYSIZE + SRTP_SALT_SIZE
-#define     SRTP_AES_192_KEYSIZE         AES_BLOCK_SIZE + AES_BLOCK_SIZE / 2
-#define     SRTP_AES_192_KEYSIZE_WSALT   SRTP_AES_192_KEYSIZE + SRTP_SALT_SIZE
-
 typedef struct {
     v128_t counter;                /* holds the counter value          */
     v128_t offset;                 /* initial offset value             */

--- a/crypto/test/cipher_driver.c
+++ b/crypto/test/cipher_driver.c
@@ -192,11 +192,11 @@ main(int argc, char *argv[]) {
       cipher_driver_test_array_throughput(&srtp_aes_icm_192, 38, num_cipher);
 
     for (num_cipher=1; num_cipher < max_num_cipher; num_cipher *=8) {
-      cipher_driver_test_array_throughput(&srtp_aes_gcm_128_openssl, SRTP_AES_GCM_128_KEYSIZE_WSALT, num_cipher);
+      cipher_driver_test_array_throughput(&srtp_aes_gcm_128_openssl, SRTP_AES_GCM_128_KEY_LEN_WSALT, num_cipher);
     }
 
     for (num_cipher=1; num_cipher < max_num_cipher; num_cipher *=8) {
-      cipher_driver_test_array_throughput(&srtp_aes_gcm_256_openssl, SRTP_AES_GCM_256_KEYSIZE_WSALT, num_cipher);
+      cipher_driver_test_array_throughput(&srtp_aes_gcm_256_openssl, SRTP_AES_GCM_256_KEY_LEN_WSALT, num_cipher);
     }
 #endif
   }
@@ -273,7 +273,7 @@ main(int argc, char *argv[]) {
 
 #ifdef OPENSSL
     /* run the throughput test on the aes_gcm_128_openssl cipher */
-    status = srtp_cipher_type_alloc(&srtp_aes_gcm_128_openssl, &c, SRTP_AES_GCM_128_KEYSIZE_WSALT, 8);
+    status = srtp_cipher_type_alloc(&srtp_aes_gcm_128_openssl, &c, SRTP_AES_GCM_128_KEY_LEN_WSALT, 8);
     if (status) {
         fprintf(stderr, "error: can't allocate GCM 128 cipher\n");
         exit(status);
@@ -292,7 +292,7 @@ main(int argc, char *argv[]) {
     check_status(status);
 
     /* run the throughput test on the aes_gcm_256_openssl cipher */
-    status = srtp_cipher_type_alloc(&srtp_aes_gcm_256_openssl, &c, SRTP_AES_GCM_256_KEYSIZE_WSALT, 16);
+    status = srtp_cipher_type_alloc(&srtp_aes_gcm_256_openssl, &c, SRTP_AES_GCM_256_KEY_LEN_WSALT, 16);
     if (status) {
         fprintf(stderr, "error: can't allocate GCM 256 cipher\n");
         exit(status);

--- a/crypto/test/cipher_driver.c
+++ b/crypto/test/cipher_driver.c
@@ -182,14 +182,14 @@ main(int argc, char *argv[]) {
       cipher_driver_test_array_throughput(&srtp_null_cipher, 0, num_cipher); 
 
     for (num_cipher=1; num_cipher < max_num_cipher; num_cipher *=8)
-      cipher_driver_test_array_throughput(&srtp_aes_icm_128, 30, num_cipher);
+      cipher_driver_test_array_throughput(&srtp_aes_icm_128, SRTP_AES_ICM_128_KEY_LEN_WSALT, num_cipher);
 
     for (num_cipher=1; num_cipher < max_num_cipher; num_cipher *=8)
-      cipher_driver_test_array_throughput(&srtp_aes_icm_256, 46, num_cipher);
+      cipher_driver_test_array_throughput(&srtp_aes_icm_256, SRTP_AES_ICM_256_KEY_LEN_WSALT, num_cipher);
 
 #ifdef OPENSSL
     for (num_cipher=1; num_cipher < max_num_cipher; num_cipher *=8)
-      cipher_driver_test_array_throughput(&srtp_aes_icm_192, 38, num_cipher);
+      cipher_driver_test_array_throughput(&srtp_aes_icm_192, SRTP_AES_ICM_192_KEY_LEN_WSALT, num_cipher);
 
     for (num_cipher=1; num_cipher < max_num_cipher; num_cipher *=8) {
       cipher_driver_test_array_throughput(&srtp_aes_gcm_128_openssl, SRTP_AES_GCM_128_KEY_LEN_WSALT, num_cipher);
@@ -230,7 +230,7 @@ main(int argc, char *argv[]) {
   
 
   /* run the throughput test on the aes_icm cipher (128-bit key) */
-    status = srtp_cipher_type_alloc(&srtp_aes_icm_128, &c, 30, 0);
+    status = srtp_cipher_type_alloc(&srtp_aes_icm_128, &c, SRTP_AES_ICM_128_KEY_LEN_WSALT, 0);
     if (status) {
       fprintf(stderr, "error: can't allocate cipher\n");
       exit(status);
@@ -251,7 +251,7 @@ main(int argc, char *argv[]) {
     check_status(status);
 
   /* repeat the tests with 256-bit keys */
-    status = srtp_cipher_type_alloc(&srtp_aes_icm_256, &c, 46, 0);  
+    status = srtp_cipher_type_alloc(&srtp_aes_icm_256, &c, SRTP_AES_ICM_256_KEY_LEN_WSALT, 0);
     if (status) {
       fprintf(stderr, "error: can't allocate cipher\n");
       exit(status);

--- a/crypto/test/stat_driver.c
+++ b/crypto/test/stat_driver.c
@@ -182,7 +182,7 @@ main (int argc, char *argv[]) {
     for (i=0; i < 2500; i++) {
 	buffer[i] = 0;
     }
-    err_check(srtp_cipher_type_alloc(&srtp_aes_gcm_128_openssl, &c, SRTP_AES_GCM_128_KEYSIZE_WSALT, 8));
+    err_check(srtp_cipher_type_alloc(&srtp_aes_gcm_128_openssl, &c, SRTP_AES_GCM_128_KEY_LEN_WSALT, 8));
     err_check(srtp_cipher_init(c, key));
     err_check(srtp_cipher_set_iv(c, (uint8_t*)&nonce, srtp_direction_encrypt));
     err_check(srtp_cipher_encrypt(c, buffer, &buf_len));
@@ -211,7 +211,7 @@ main (int argc, char *argv[]) {
     for (i=0; i < 2500; i++) {
 	buffer[i] = 0;
     }
-    err_check(srtp_cipher_type_alloc(&srtp_aes_gcm_256_openssl, &c, SRTP_AES_GCM_256_KEYSIZE_WSALT, 16));
+    err_check(srtp_cipher_type_alloc(&srtp_aes_gcm_256_openssl, &c, SRTP_AES_GCM_256_KEY_LEN_WSALT, 16));
     err_check(srtp_cipher_init(c, key));
     err_check(srtp_cipher_set_iv(c, (uint8_t*)&nonce, srtp_direction_encrypt));
     err_check(srtp_cipher_encrypt(c, buffer, &buf_len));

--- a/crypto/test/stat_driver.c
+++ b/crypto/test/stat_driver.c
@@ -117,7 +117,7 @@ main (int argc, char *argv[]) {
   /* set buffer to cipher output */
   for (i=0; i < 2500; i++)
     buffer[i] = 0;
-  err_check(srtp_cipher_type_alloc(&srtp_aes_icm_128, &c, 30, 0));
+  err_check(srtp_cipher_type_alloc(&srtp_aes_icm_128, &c, SRTP_AES_ICM_128_KEY_LEN_WSALT, 0));
   err_check(srtp_cipher_init(c, key));
   err_check(srtp_cipher_set_iv(c, (uint8_t*)&nonce, srtp_direction_encrypt));
   err_check(srtp_cipher_encrypt(c, buffer, &buf_len));
@@ -151,7 +151,7 @@ main (int argc, char *argv[]) {
   /* set buffer to cipher output */
   for (i=0; i < 2500; i++)
     buffer[i] = 0;
-  err_check(srtp_cipher_type_alloc(&srtp_aes_icm_256, &c, 46, 0));
+  err_check(srtp_cipher_type_alloc(&srtp_aes_icm_256, &c, SRTP_AES_ICM_256_KEY_LEN_WSALT, 0));
   err_check(srtp_cipher_init(c, key));
   err_check(srtp_cipher_set_iv(c, (uint8_t*)&nonce, srtp_direction_encrypt));
   err_check(srtp_cipher_encrypt(c, buffer, &buf_len));

--- a/include/srtp.h
+++ b/include/srtp.h
@@ -93,7 +93,7 @@ extern "C" {
  *
  * @brief the maximum number of octets added by srtp_protect().
  */
-#define SRTP_MAX_TRAILER_LEN SRTP_MAX_TAG_LEN + SRTP_MAX_MKI_LEN
+#define SRTP_MAX_TRAILER_LEN (SRTP_MAX_TAG_LEN + SRTP_MAX_MKI_LEN)
 
 /**
  * SRTP_MAX_NUM_MASTER_KEYS is the maximum number of Master keys for
@@ -102,15 +102,25 @@ extern "C" {
  */
 #define SRTP_MAX_NUM_MASTER_KEYS 16
 
+#define SRTP_SALT_LEN                14
 /*
- * SRTP_AEAD_SALT_LEN is the length of the SALT values used with 
+ * SRTP_AEAD_SALT_LEN is the length of the SALT values used with
  * GCM mode.  GCM mode requires an IV.  The SALT value is used
  * as part of the IV formation logic applied to each RTP packet.
  */
-#define SRTP_AEAD_SALT_LEN	12
-#define SRTP_AES_GCM_128_KEYSIZE_WSALT   SRTP_AEAD_SALT_LEN + 16
-#define SRTP_AES_GCM_192_KEYSIZE_WSALT   SRTP_AEAD_SALT_LEN + 24
-#define SRTP_AES_GCM_256_KEYSIZE_WSALT   SRTP_AEAD_SALT_LEN + 32
+#define SRTP_AEAD_SALT_LEN               12
+
+#define SRTP_AES_128_KEY_LEN         16
+#define SRTP_AES_192_KEY_LEN         24
+#define SRTP_AES_256_KEY_LEN         32
+
+#define SRTP_AES_ICM_128_KEY_LEN_WSALT   (SRTP_SALT_LEN + SRTP_AES_128_KEY_LEN)
+#define SRTP_AES_ICM_192_KEY_LEN_WSALT   (SRTP_SALT_LEN + SRTP_AES_192_KEY_LEN)
+#define SRTP_AES_ICM_256_KEY_LEN_WSALT   (SRTP_SALT_LEN + SRTP_AES_256_KEY_LEN)
+
+#define SRTP_AES_GCM_128_KEY_LEN_WSALT   (SRTP_AEAD_SALT_LEN + SRTP_AES_128_KEY_LEN)
+#define SRTP_AES_GCM_192_KEY_LEN_WSALT   (SRTP_AEAD_SALT_LEN + SRTP_AES_192_KEY_LEN)
+#define SRTP_AES_GCM_256_KEY_LEN_WSALT   (SRTP_AEAD_SALT_LEN + SRTP_AES_256_KEY_LEN)
 
 /*
  * an srtp_hdr_t represents the srtp header

--- a/srtp/srtp.c
+++ b/srtp/srtp.c
@@ -313,11 +313,11 @@ srtp_stream_alloc(srtp_stream_ctx_t **str_ptr,
     switch (p->rtp.cipher_type) {
     case SRTP_AES_GCM_128:
       enc_xtn_hdr_cipher_type = SRTP_AES_ICM_128;
-      enc_xtn_hdr_cipher_key_len = 30;
+      enc_xtn_hdr_cipher_key_len = SRTP_AES_ICM_128_KEY_LEN_WSALT;
       break;
     case SRTP_AES_GCM_256:
       enc_xtn_hdr_cipher_type = SRTP_AES_ICM_256;
-      enc_xtn_hdr_cipher_key_len = 46;
+      enc_xtn_hdr_cipher_key_len = SRTP_AES_ICM_256_KEY_LEN_WSALT;
       break;
     default:
       enc_xtn_hdr_cipher_type = p->rtp.cipher_type;
@@ -697,13 +697,13 @@ static srtp_err_status_t srtp_kdf_init(srtp_kdf_t *kdf, const uint8_t *key, int 
 {
     srtp_cipher_type_id_t cipher_id;
     switch (key_len) {
-    case 46:
+    case SRTP_AES_ICM_256_KEY_LEN_WSALT:
         cipher_id = SRTP_AES_ICM_256;
         break;
-    case 38:
+    case SRTP_AES_ICM_192_KEY_LEN_WSALT:
         cipher_id = SRTP_AES_ICM_192;
         break;
-    case 30:
+    case SRTP_AES_ICM_128_KEY_LEN_WSALT:
         cipher_id = SRTP_AES_ICM_128;
         break;
     default:
@@ -769,13 +769,13 @@ static inline int base_key_length(const srtp_cipher_type_t *cipher, int key_leng
   case SRTP_AES_ICM_256:
     /* The legacy modes are derived from
      * the configured key length on the policy */
-    return key_length - 14;
+    return key_length - SRTP_SALT_LEN;
     break;
   case SRTP_AES_GCM_128:
-    return 16;
+    return key_length - SRTP_AEAD_SALT_LEN;
     break;
   case SRTP_AES_GCM_256:
-    return 32;
+      return key_length - SRTP_AEAD_SALT_LEN;
     break;
   default:
     return key_length;
@@ -2964,7 +2964,7 @@ void
 srtp_crypto_policy_set_rtp_default(srtp_crypto_policy_t *p) {
 
   p->cipher_type     = SRTP_AES_ICM_128;
-  p->cipher_key_len  = 30;                /* default 128 bits per RFC 3711 */
+  p->cipher_key_len  = SRTP_AES_ICM_128_KEY_LEN_WSALT; /* default 128 bits per RFC 3711 */
   p->auth_type       = SRTP_HMAC_SHA1;             
   p->auth_key_len    = 20;                /* default 160 bits per RFC 3711 */
   p->auth_tag_len    = 10;                /* default 80 bits per RFC 3711 */
@@ -2976,7 +2976,7 @@ void
 srtp_crypto_policy_set_rtcp_default(srtp_crypto_policy_t *p) {
 
   p->cipher_type     = SRTP_AES_ICM_128;
-  p->cipher_key_len  = 30;                 /* default 128 bits per RFC 3711 */
+  p->cipher_key_len  = SRTP_AES_ICM_128_KEY_LEN_WSALT; /* default 128 bits per RFC 3711 */
   p->auth_type       = SRTP_HMAC_SHA1;             
   p->auth_key_len    = 20;                 /* default 160 bits per RFC 3711 */
   p->auth_tag_len    = 10;                 /* default 80 bits per RFC 3711 */
@@ -2994,7 +2994,7 @@ srtp_crypto_policy_set_aes_cm_128_hmac_sha1_32(srtp_crypto_policy_t *p) {
    */
 
   p->cipher_type     = SRTP_AES_ICM_128;
-  p->cipher_key_len  = 30;                /* 128 bit key, 112 bit salt */
+  p->cipher_key_len  = SRTP_AES_ICM_128_KEY_LEN_WSALT; /* 128 bit key, 112 bit salt */
   p->auth_type       = SRTP_HMAC_SHA1;             
   p->auth_key_len    = 20;                /* 160 bit key               */
   p->auth_tag_len    = 4;                 /* 32 bit tag                */
@@ -3013,7 +3013,7 @@ srtp_crypto_policy_set_aes_cm_128_null_auth(srtp_crypto_policy_t *p) {
    */
 
   p->cipher_type     = SRTP_AES_ICM_128;
-  p->cipher_key_len  = 30;                /* 128 bit key, 112 bit salt */
+  p->cipher_key_len  = SRTP_AES_ICM_128_KEY_LEN_WSALT; /* 128 bit key, 112 bit salt */
   p->auth_type       = SRTP_NULL_AUTH;             
   p->auth_key_len    = 0; 
   p->auth_tag_len    = 0; 
@@ -3063,7 +3063,7 @@ srtp_crypto_policy_set_aes_cm_256_hmac_sha1_80(srtp_crypto_policy_t *p) {
    */
 
   p->cipher_type     = SRTP_AES_ICM_256;
-  p->cipher_key_len  = 46;
+  p->cipher_key_len  = SRTP_AES_ICM_256_KEY_LEN_WSALT;
   p->auth_type       = SRTP_HMAC_SHA1;             
   p->auth_key_len    = 20;                /* default 160 bits per RFC 3711 */
   p->auth_tag_len    = 10;                /* default 80 bits per RFC 3711 */
@@ -3081,7 +3081,7 @@ srtp_crypto_policy_set_aes_cm_256_hmac_sha1_32(srtp_crypto_policy_t *p) {
    */
 
   p->cipher_type     = SRTP_AES_ICM_256;
-  p->cipher_key_len  = 46;
+  p->cipher_key_len  = SRTP_AES_ICM_256_KEY_LEN_WSALT;
   p->auth_type       = SRTP_HMAC_SHA1;             
   p->auth_key_len    = 20;                /* default 160 bits per RFC 3711 */
   p->auth_tag_len    = 4;                 /* default 80 bits per RFC 3711 */
@@ -3095,7 +3095,7 @@ void
 srtp_crypto_policy_set_aes_cm_256_null_auth (srtp_crypto_policy_t *p)
 {
     p->cipher_type     = SRTP_AES_ICM_256;
-    p->cipher_key_len  = 46;
+    p->cipher_key_len  = SRTP_AES_ICM_256_KEY_LEN_WSALT;
     p->auth_type       = SRTP_NULL_AUTH;
     p->auth_key_len    = 0;
     p->auth_tag_len    = 0;
@@ -3111,7 +3111,7 @@ srtp_crypto_policy_set_aes_cm_192_hmac_sha1_80(srtp_crypto_policy_t *p) {
    */
 
   p->cipher_type     = SRTP_AES_ICM_192;
-  p->cipher_key_len  = 38;
+  p->cipher_key_len  = SRTP_AES_ICM_192_KEY_LEN_WSALT;
   p->auth_type       = SRTP_HMAC_SHA1;
   p->auth_key_len    = 20;                /* default 160 bits per RFC 3711 */
   p->auth_tag_len    = 10;                /* default 80 bits per RFC 3711 */
@@ -3129,7 +3129,7 @@ srtp_crypto_policy_set_aes_cm_192_hmac_sha1_32(srtp_crypto_policy_t *p) {
    */
 
   p->cipher_type     = SRTP_AES_ICM_192;
-  p->cipher_key_len  = 38;
+  p->cipher_key_len  = SRTP_AES_ICM_192_KEY_LEN_WSALT;
   p->auth_type       = SRTP_HMAC_SHA1;
   p->auth_key_len    = 20;                /* default 160 bits per RFC 3711 */
   p->auth_tag_len    = 4;                 /* default 80 bits per RFC 3711 */
@@ -3143,7 +3143,7 @@ void
 srtp_crypto_policy_set_aes_cm_192_null_auth (srtp_crypto_policy_t *p)
 {
     p->cipher_type     = SRTP_AES_ICM_192;
-    p->cipher_key_len  = 38;
+    p->cipher_key_len  = SRTP_AES_ICM_192_KEY_LEN_WSALT;
     p->auth_type       = SRTP_NULL_AUTH;
     p->auth_key_len    = 0;
     p->auth_tag_len    = 0;
@@ -4278,19 +4278,19 @@ srtp_profile_get_master_key_length(srtp_profile_t profile) {
 
   switch(profile) {
   case srtp_profile_aes128_cm_sha1_80:
-    return 16;
+    return SRTP_AES_128_KEY_LEN;
     break;
   case srtp_profile_aes128_cm_sha1_32:
-    return 16;
+    return SRTP_AES_128_KEY_LEN;
     break;
   case srtp_profile_null_sha1_80:
-    return 16;
+    return SRTP_AES_128_KEY_LEN;
     break;
   case srtp_profile_aead_aes_128_gcm:
-    return 16;
+    return SRTP_AES_128_KEY_LEN;
     break;
   case srtp_profile_aead_aes_256_gcm:
-    return 32;
+    return SRTP_AES_256_KEY_LEN;
     break;
     /* the following profiles are not (yet) supported */
   case srtp_profile_null_sha1_32:
@@ -4304,19 +4304,19 @@ srtp_profile_get_master_salt_length(srtp_profile_t profile) {
 
   switch(profile) {
   case srtp_profile_aes128_cm_sha1_80:
-    return 14;
+    return SRTP_SALT_LEN;
     break;
   case srtp_profile_aes128_cm_sha1_32:
-    return 14;
+    return SRTP_SALT_LEN;
     break;
   case srtp_profile_null_sha1_80:
-    return 14;
+    return SRTP_SALT_LEN;
     break;
   case srtp_profile_aead_aes_128_gcm:
-    return 12;
+    return SRTP_AEAD_SALT_LEN;
     break;
   case srtp_profile_aead_aes_256_gcm:
-    return 12;
+    return SRTP_AEAD_SALT_LEN;
     break;
     /* the following profiles are not (yet) supported */
   case srtp_profile_null_sha1_32:

--- a/srtp/srtp.c
+++ b/srtp/srtp.c
@@ -3156,7 +3156,7 @@ srtp_crypto_policy_set_aes_cm_192_null_auth (srtp_crypto_policy_t *p)
 void
 srtp_crypto_policy_set_aes_gcm_128_8_auth(srtp_crypto_policy_t *p) {
   p->cipher_type     = SRTP_AES_GCM_128;
-  p->cipher_key_len  = SRTP_AES_GCM_128_KEYSIZE_WSALT;
+  p->cipher_key_len  = SRTP_AES_GCM_128_KEY_LEN_WSALT;
   p->auth_type       = SRTP_NULL_AUTH; /* GCM handles the auth for us */            
   p->auth_key_len    = 0; 
   p->auth_tag_len    = 8;   /* 8 octet tag length */
@@ -3169,7 +3169,7 @@ srtp_crypto_policy_set_aes_gcm_128_8_auth(srtp_crypto_policy_t *p) {
 void
 srtp_crypto_policy_set_aes_gcm_256_8_auth(srtp_crypto_policy_t *p) {
   p->cipher_type     = SRTP_AES_GCM_256;
-  p->cipher_key_len  = SRTP_AES_GCM_256_KEYSIZE_WSALT;
+  p->cipher_key_len  = SRTP_AES_GCM_256_KEY_LEN_WSALT;
   p->auth_type       = SRTP_NULL_AUTH; /* GCM handles the auth for us */ 
   p->auth_key_len    = 0; 
   p->auth_tag_len    = 8;   /* 8 octet tag length */
@@ -3182,7 +3182,7 @@ srtp_crypto_policy_set_aes_gcm_256_8_auth(srtp_crypto_policy_t *p) {
 void
 srtp_crypto_policy_set_aes_gcm_128_8_only_auth(srtp_crypto_policy_t *p) {
   p->cipher_type     = SRTP_AES_GCM_128;
-  p->cipher_key_len  = SRTP_AES_GCM_128_KEYSIZE_WSALT;
+  p->cipher_key_len  = SRTP_AES_GCM_128_KEY_LEN_WSALT;
   p->auth_type       = SRTP_NULL_AUTH; /* GCM handles the auth for us */ 
   p->auth_key_len    = 0; 
   p->auth_tag_len    = 8;   /* 8 octet tag length */
@@ -3195,7 +3195,7 @@ srtp_crypto_policy_set_aes_gcm_128_8_only_auth(srtp_crypto_policy_t *p) {
 void
 srtp_crypto_policy_set_aes_gcm_256_8_only_auth(srtp_crypto_policy_t *p) {
   p->cipher_type     = SRTP_AES_GCM_256;
-  p->cipher_key_len  = SRTP_AES_GCM_256_KEYSIZE_WSALT;
+  p->cipher_key_len  = SRTP_AES_GCM_256_KEY_LEN_WSALT;
   p->auth_type       = SRTP_NULL_AUTH; /* GCM handles the auth for us */ 
   p->auth_key_len    = 0; 
   p->auth_tag_len    = 8;   /* 8 octet tag length */
@@ -3208,7 +3208,7 @@ srtp_crypto_policy_set_aes_gcm_256_8_only_auth(srtp_crypto_policy_t *p) {
 void
 srtp_crypto_policy_set_aes_gcm_128_16_auth(srtp_crypto_policy_t *p) {
   p->cipher_type     = SRTP_AES_GCM_128;
-  p->cipher_key_len  = SRTP_AES_GCM_128_KEYSIZE_WSALT;
+  p->cipher_key_len  = SRTP_AES_GCM_128_KEY_LEN_WSALT;
   p->auth_type       = SRTP_NULL_AUTH; /* GCM handles the auth for us */            
   p->auth_key_len    = 0; 
   p->auth_tag_len    = 16;   /* 16 octet tag length */
@@ -3221,7 +3221,7 @@ srtp_crypto_policy_set_aes_gcm_128_16_auth(srtp_crypto_policy_t *p) {
 void
 srtp_crypto_policy_set_aes_gcm_256_16_auth(srtp_crypto_policy_t *p) {
   p->cipher_type     = SRTP_AES_GCM_256;
-  p->cipher_key_len  = SRTP_AES_GCM_256_KEYSIZE_WSALT;
+  p->cipher_key_len  = SRTP_AES_GCM_256_KEY_LEN_WSALT;
   p->auth_type       = SRTP_NULL_AUTH; /* GCM handles the auth for us */ 
   p->auth_key_len    = 0; 
   p->auth_tag_len    = 16;   /* 16 octet tag length */

--- a/test/srtp_driver.c
+++ b/test/srtp_driver.c
@@ -2992,7 +2992,7 @@ const srtp_policy_t default_policy = {
     { ssrc_any_outbound, 0 },  /* SSRC                           */
     {                          /* SRTP policy                    */
         SRTP_AES_ICM_128,           /* cipher type                 */
-        30,                    /* cipher key length in octets */
+        SRTP_AES_ICM_128_KEY_LEN_WSALT, /* cipher key length in octets */
         SRTP_HMAC_SHA1,             /* authentication func type    */
         16,                    /* auth key length in octets   */
         10,                    /* auth tag length in octets   */
@@ -3000,7 +3000,7 @@ const srtp_policy_t default_policy = {
     },
     {                          /* SRTCP policy                   */
         SRTP_AES_ICM_128,           /* cipher type                 */
-        30,                    /* cipher key length in octets */
+        SRTP_AES_ICM_128_KEY_LEN_WSALT, /* cipher key length in octets */
         SRTP_HMAC_SHA1,             /* authentication func type    */
         16,                    /* auth key length in octets   */
         10,                    /* auth tag length in octets   */
@@ -3021,7 +3021,7 @@ const srtp_policy_t aes_only_policy = {
     { ssrc_any_outbound, 0 }, /* SSRC                        */
     {
         SRTP_AES_ICM_128,          /* cipher type                 */
-        30,                   /* cipher key length in octets */
+        SRTP_AES_ICM_128_KEY_LEN_WSALT, /* cipher key length in octets */
         SRTP_NULL_AUTH,            /* authentication func type    */
         0,                    /* auth key length in octets   */
         0,                    /* auth tag length in octets   */
@@ -3029,7 +3029,7 @@ const srtp_policy_t aes_only_policy = {
     },
     {
         SRTP_AES_ICM_128,        /* cipher type                 */
-        30,                 /* cipher key length in octets */
+        SRTP_AES_ICM_128_KEY_LEN_WSALT, /* cipher key length in octets */
         SRTP_NULL_AUTH,          /* authentication func type    */
         0,                  /* auth key length in octets   */
         0,                  /* auth tag length in octets   */
@@ -3262,7 +3262,7 @@ const srtp_policy_t aes_256_hmac_policy = {
     { ssrc_any_outbound, 0 },  /* SSRC                           */
     {                          /* SRTP policy                    */
         SRTP_AES_ICM_256,               /* cipher type                 */
-        46,                    /* cipher key length in octets */
+        SRTP_AES_ICM_256_KEY_LEN_WSALT, /* cipher key length in octets */
         SRTP_HMAC_SHA1,             /* authentication func type    */
         20,                    /* auth key length in octets   */
         10,                    /* auth tag length in octets   */
@@ -3270,7 +3270,7 @@ const srtp_policy_t aes_256_hmac_policy = {
     },
     {                          /* SRTCP policy                   */
         SRTP_AES_ICM_256,               /* cipher type                 */
-        46,                    /* cipher key length in octets */
+        SRTP_AES_ICM_256_KEY_LEN_WSALT, /* cipher key length in octets */
         SRTP_HMAC_SHA1,             /* authentication func type    */
         20,                    /* auth key length in octets   */
         10,                    /* auth tag length in octets   */
@@ -3362,7 +3362,7 @@ const srtp_policy_t wildcard_policy = {
     { ssrc_any_outbound, 0 },  /* SSRC                        */
     {                          /* SRTP policy                    */
         SRTP_AES_ICM_128,           /* cipher type                 */
-        30,                    /* cipher key length in octets */
+        SRTP_AES_ICM_128_KEY_LEN_WSALT, /* cipher key length in octets */
         SRTP_HMAC_SHA1,             /* authentication func type    */
         16,                    /* auth key length in octets   */
         10,                    /* auth tag length in octets   */
@@ -3370,7 +3370,7 @@ const srtp_policy_t wildcard_policy = {
     },
     {                          /* SRTCP policy                   */
         SRTP_AES_ICM_128,           /* cipher type                 */
-        30,                    /* cipher key length in octets */
+        SRTP_AES_ICM_128_KEY_LEN_WSALT, /* cipher key length in octets */
         SRTP_HMAC_SHA1,             /* authentication func type    */
         16,                    /* auth key length in octets   */
         10,                    /* auth tag length in octets   */

--- a/test/srtp_driver.c
+++ b/test/srtp_driver.c
@@ -3080,7 +3080,7 @@ const srtp_policy_t aes128_gcm_8_policy = {
     { ssrc_any_outbound, 0 },           /* SSRC                           */
     {                                   /* SRTP policy                    */
         SRTP_AES_GCM_128,                    /* cipher type                 */
-        SRTP_AES_GCM_128_KEYSIZE_WSALT, /* cipher key length in octets */
+        SRTP_AES_GCM_128_KEY_LEN_WSALT, /* cipher key length in octets */
         SRTP_NULL_AUTH,                      /* authentication func type    */
         0,                              /* auth key length in octets   */
         8,                              /* auth tag length in octets   */
@@ -3088,7 +3088,7 @@ const srtp_policy_t aes128_gcm_8_policy = {
     },
     {                                   /* SRTCP policy                   */
         SRTP_AES_GCM_128,                    /* cipher type                 */
-        SRTP_AES_GCM_128_KEYSIZE_WSALT, /* cipher key length in octets */
+        SRTP_AES_GCM_128_KEY_LEN_WSALT, /* cipher key length in octets */
         SRTP_NULL_AUTH,                      /* authentication func type    */
         0,                              /* auth key length in octets   */
         8,                              /* auth tag length in octets   */
@@ -3109,7 +3109,7 @@ const srtp_policy_t aes128_gcm_8_cauth_policy = {
     { ssrc_any_outbound, 0 },           /* SSRC                           */
     {                                   /* SRTP policy                    */
         SRTP_AES_GCM_128,                    /* cipher type                 */
-        SRTP_AES_GCM_128_KEYSIZE_WSALT, /* cipher key length in octets */
+        SRTP_AES_GCM_128_KEY_LEN_WSALT, /* cipher key length in octets */
         SRTP_NULL_AUTH,                      /* authentication func type    */
         0,                              /* auth key length in octets   */
         8,                              /* auth tag length in octets   */
@@ -3117,7 +3117,7 @@ const srtp_policy_t aes128_gcm_8_cauth_policy = {
     },
     {                                   /* SRTCP policy                   */
         SRTP_AES_GCM_128,                    /* cipher type                 */
-        SRTP_AES_GCM_128_KEYSIZE_WSALT, /* cipher key length in octets */
+        SRTP_AES_GCM_128_KEY_LEN_WSALT, /* cipher key length in octets */
         SRTP_NULL_AUTH,                      /* authentication func type    */
         0,                              /* auth key length in octets   */
         8,                              /* auth tag length in octets   */
@@ -3138,7 +3138,7 @@ const srtp_policy_t aes256_gcm_8_policy = {
     { ssrc_any_outbound, 0 },           /* SSRC                           */
     {                                   /* SRTP policy                    */
         SRTP_AES_GCM_256,                    /* cipher type                 */
-        SRTP_AES_GCM_256_KEYSIZE_WSALT, /* cipher key length in octets */
+        SRTP_AES_GCM_256_KEY_LEN_WSALT, /* cipher key length in octets */
         SRTP_NULL_AUTH,                      /* authentication func type    */
         0,                              /* auth key length in octets   */
         8,                              /* auth tag length in octets   */
@@ -3146,7 +3146,7 @@ const srtp_policy_t aes256_gcm_8_policy = {
     },
     {                                   /* SRTCP policy                   */
         SRTP_AES_GCM_256,                    /* cipher type                 */
-        SRTP_AES_GCM_256_KEYSIZE_WSALT, /* cipher key length in octets */
+        SRTP_AES_GCM_256_KEY_LEN_WSALT, /* cipher key length in octets */
         SRTP_NULL_AUTH,                      /* authentication func type    */
         0,                              /* auth key length in octets   */
         8,                              /* auth tag length in octets   */
@@ -3167,7 +3167,7 @@ const srtp_policy_t aes256_gcm_8_cauth_policy = {
     { ssrc_any_outbound, 0 },           /* SSRC                           */
     {                                   /* SRTP policy                    */
         SRTP_AES_GCM_256,                    /* cipher type                 */
-        SRTP_AES_GCM_256_KEYSIZE_WSALT, /* cipher key length in octets */
+        SRTP_AES_GCM_256_KEY_LEN_WSALT, /* cipher key length in octets */
         SRTP_NULL_AUTH,                      /* authentication func type    */
         0,                              /* auth key length in octets   */
         8,                              /* auth tag length in octets   */
@@ -3175,7 +3175,7 @@ const srtp_policy_t aes256_gcm_8_cauth_policy = {
     },
     {                                   /* SRTCP policy                   */
         SRTP_AES_GCM_256,                    /* cipher type                 */
-        SRTP_AES_GCM_256_KEYSIZE_WSALT, /* cipher key length in octets */
+        SRTP_AES_GCM_256_KEY_LEN_WSALT, /* cipher key length in octets */
         SRTP_NULL_AUTH,                      /* authentication func type    */
         0,                              /* auth key length in octets   */
         8,                              /* auth tag length in octets   */


### PR DESCRIPTION
Use defines for all usages of key length and salt length values.
This attempts to resolve issue #260. 