### PR TITLE
Bump copyright year

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 /*
  *	
- * Copyright (c) 2001-2006 Cisco Systems, Inc.
+ * Copyright (c) 2001-2017 Cisco Systems, Inc.
  * All rights reserved.
  * 
  * Redistribution and use in source and binary forms, with or without

--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ libSRTP is distributed under the following license, which is included
 in the source code distribution. It is reproduced in the manual in
 case you got the library from another source.
 
-> Copyright (c) 2001-2005 Cisco Systems, Inc.  All rights reserved.
+> Copyright (c) 2001-2017 Cisco Systems, Inc.  All rights reserved.
 >
 > Redistribution and use in source and binary forms, with or without
 > modification, are permitted provided that the following conditions

--- a/crypto/cipher/aes.c
+++ b/crypto/cipher/aes.c
@@ -9,7 +9,7 @@
 
 /*
  *
- * Copyright (c) 2001-2006, Cisco Systems, Inc.
+ * Copyright (c) 2001-2017, Cisco Systems, Inc.
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/crypto/cipher/aes_gcm_ossl.c
+++ b/crypto/cipher/aes_gcm_ossl.c
@@ -10,7 +10,7 @@
 
 /*
  *
- * Copyright (c) 2013, Cisco Systems, Inc.
+ * Copyright (c) 2013-2017, Cisco Systems, Inc.
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/crypto/cipher/aes_icm.c
+++ b/crypto/cipher/aes_icm.c
@@ -9,7 +9,7 @@
 
 /*
  *
- * Copyright (c) 2001-2006,2013 Cisco Systems, Inc.
+ * Copyright (c) 2001-2017 Cisco Systems, Inc.
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/crypto/cipher/aes_icm_ossl.c
+++ b/crypto/cipher/aes_icm_ossl.c
@@ -14,7 +14,7 @@
 
 /*
  *
- * Copyright (c) 2013, Cisco Systems, Inc.
+ * Copyright (c) 2013-2017, Cisco Systems, Inc.
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/crypto/cipher/cipher.c
+++ b/crypto/cipher/cipher.c
@@ -10,7 +10,7 @@
 
 /*
  *
- * Copyright (c) 2001-2006,2013 Cisco Systems, Inc.
+ * Copyright (c) 2001-2017 Cisco Systems, Inc.
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/crypto/cipher/null_cipher.c
+++ b/crypto/cipher/null_cipher.c
@@ -10,7 +10,7 @@
 
 /*
  *
- * Copyright (c) 2001-2006,2013 Cisco Systems, Inc.
+ * Copyright (c) 2001-2017 Cisco Systems, Inc.
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/crypto/hash/auth.c
+++ b/crypto/hash/auth.c
@@ -9,7 +9,7 @@
 
 /*
  *
- * Copyright (c) 2001-2006, Cisco Systems, Inc.
+ * Copyright (c) 2001-2017, Cisco Systems, Inc.
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/crypto/hash/hmac.c
+++ b/crypto/hash/hmac.c
@@ -8,7 +8,7 @@
  */
 /*
  *
- * Copyright(c) 2001-2006 Cisco Systems, Inc.
+ * Copyright(c) 2001-2017 Cisco Systems, Inc.
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/crypto/hash/hmac_ossl.c
+++ b/crypto/hash/hmac_ossl.c
@@ -8,7 +8,7 @@
  */
 /*
  *
- * Copyright(c) 2013, Cisco Systems, Inc.
+ * Copyright(c) 2013-2017, Cisco Systems, Inc.
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/crypto/hash/null_auth.c
+++ b/crypto/hash/null_auth.c
@@ -10,7 +10,7 @@
 
 /*
  *
- * Copyright (c) 2001-2006, Cisco Systems, Inc.
+ * Copyright (c) 2001-2017, Cisco Systems, Inc.
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/crypto/hash/sha1.c
+++ b/crypto/hash/sha1.c
@@ -10,7 +10,7 @@
 
 /*
  *
- * Copyright (c) 2001-2006, Cisco Systems, Inc.
+ * Copyright (c) 2001-2017, Cisco Systems, Inc.
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/crypto/include/aes.h
+++ b/crypto/include/aes.h
@@ -9,7 +9,7 @@
 
 /*
  *
- * Copyright (c) 2001-2006, Cisco Systems, Inc.
+ * Copyright (c) 2001-2017, Cisco Systems, Inc.
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/crypto/include/aes_gcm_ossl.h
+++ b/crypto/include/aes_gcm_ossl.h
@@ -9,7 +9,7 @@
  */
 /*
  *
- * Copyright (c) 2013, Cisco Systems, Inc.
+ * Copyright (c) 2013-2017, Cisco Systems, Inc.
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/crypto/include/aes_icm.h
+++ b/crypto/include/aes_icm.h
@@ -10,7 +10,7 @@
 
 /*
  *	
- * Copyright (c) 2001-2006, Cisco Systems, Inc.
+ * Copyright (c) 2001-2017, Cisco Systems, Inc.
  * All rights reserved.
  * 
  * Redistribution and use in source and binary forms, with or without

--- a/crypto/include/aes_icm_ossl.h
+++ b/crypto/include/aes_icm_ossl.h
@@ -9,7 +9,7 @@
  */
 /*
  *
- * Copyright (c) 2001-2005,2012, Cisco Systems, Inc.
+ * Copyright (c) 2001-2017, Cisco Systems, Inc.
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/crypto/include/alloc.h
+++ b/crypto/include/alloc.h
@@ -8,7 +8,7 @@
  */
 /*
  *	
- * Copyright (c) 2001-2006 Cisco Systems, Inc.
+ * Copyright (c) 2001-2017 Cisco Systems, Inc.
  * All rights reserved.
  * 
  * Redistribution and use in source and binary forms, with or without

--- a/crypto/include/auth.h
+++ b/crypto/include/auth.h
@@ -9,7 +9,7 @@
 
 /*
  *
- * Copyright (c) 2001-2006, Cisco Systems, Inc.
+ * Copyright (c) 2001-2017, Cisco Systems, Inc.
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/crypto/include/cipher.h
+++ b/crypto/include/cipher.h
@@ -8,7 +8,7 @@
  */
 /*
  *
- * Copyright (c) 2001-2006,2013 Cisco Systems, Inc.
+ * Copyright (c) 2001-2017 Cisco Systems, Inc.
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/crypto/include/crypto_kernel.h
+++ b/crypto/include/crypto_kernel.h
@@ -8,7 +8,7 @@
  */
 /*
  *
- * Copyright(c) 2001-2006 Cisco Systems, Inc.
+ * Copyright(c) 2001-2017 Cisco Systems, Inc.
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/crypto/include/crypto_types.h
+++ b/crypto/include/crypto_types.h
@@ -8,7 +8,7 @@
  */
 /*
  *	
- * Copyright(c) 2001-2006,2013 Cisco Systems, Inc.
+ * Copyright(c) 2001-2017 Cisco Systems, Inc.
  * All rights reserved.
  * 
  * Redistribution and use in source and binary forms, with or without

--- a/crypto/include/datatypes.h
+++ b/crypto/include/datatypes.h
@@ -9,7 +9,7 @@
 
 /*
  *	
- * Copyright (c) 2001-2006, Cisco Systems, Inc.
+ * Copyright (c) 2001-2017, Cisco Systems, Inc.
  * All rights reserved.
  * 
  * Redistribution and use in source and binary forms, with or without

--- a/crypto/include/err.h
+++ b/crypto/include/err.h
@@ -8,7 +8,7 @@
  */
 /*
  *
- * Copyright (c) 2001-2006, Cisco Systems, Inc.
+ * Copyright (c) 2001-2017, Cisco Systems, Inc.
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/crypto/include/hmac.h
+++ b/crypto/include/hmac.h
@@ -9,7 +9,7 @@
  */
 /*
  *
- * Copyright (c) 2001-2006,2013, Cisco Systems, Inc.
+ * Copyright (c) 2001-2017, Cisco Systems, Inc.
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/crypto/include/integers.h
+++ b/crypto/include/integers.h
@@ -9,7 +9,7 @@
 
 /*
  *	
- * Copyright (c) 2001-2006, Cisco Systems, Inc.
+ * Copyright (c) 2001-2017, Cisco Systems, Inc.
  * All rights reserved.
  * 
  * Redistribution and use in source and binary forms, with or without

--- a/crypto/include/key.h
+++ b/crypto/include/key.h
@@ -8,7 +8,7 @@
  */
 /*
  *
- * Copyright (c) 2001-2006 Cisco Systems, Inc.
+ * Copyright (c) 2001-2017 Cisco Systems, Inc.
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/crypto/include/null_auth.h
+++ b/crypto/include/null_auth.h
@@ -8,7 +8,7 @@
 
 /*
  *
- * Copyright (c) 2001-2006, Cisco Systems, Inc.
+ * Copyright (c) 2001-2017, Cisco Systems, Inc.
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/crypto/include/null_cipher.h
+++ b/crypto/include/null_cipher.h
@@ -10,7 +10,7 @@
 
 /*
  *
- * Copyright (c) 2001-2006, Cisco Systems, Inc.
+ * Copyright (c) 2001-2017, Cisco Systems, Inc.
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/crypto/include/rdb.h
+++ b/crypto/include/rdb.h
@@ -10,7 +10,7 @@
 
 /*
  *	
- * Copyright (c) 2001-2006, Cisco Systems, Inc.
+ * Copyright (c) 2001-2017, Cisco Systems, Inc.
  * All rights reserved.
  * 
  * Redistribution and use in source and binary forms, with or without

--- a/crypto/include/rdbx.h
+++ b/crypto/include/rdbx.h
@@ -10,7 +10,7 @@
 
 /*
  *	
- * Copyright (c) 2001-2006, Cisco Systems, Inc.
+ * Copyright (c) 2001-2017, Cisco Systems, Inc.
  * All rights reserved.
  * 
  * Redistribution and use in source and binary forms, with or without

--- a/crypto/include/sha1.h
+++ b/crypto/include/sha1.h
@@ -10,7 +10,7 @@
 
 /*
  *
- * Copyright (c) 2001-2006, Cisco Systems, Inc.
+ * Copyright (c) 2001-2017, Cisco Systems, Inc.
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/crypto/include/stat.h
+++ b/crypto/include/stat.h
@@ -9,7 +9,7 @@
 
 /*
  *	
- * Copyright(c) 2001-2006, Cisco Systems, Inc.
+ * Copyright(c) 2001-2017, Cisco Systems, Inc.
  * All rights reserved.
  * 
  * Redistribution and use in source and binary forms, with or without

--- a/crypto/kernel/alloc.c
+++ b/crypto/kernel/alloc.c
@@ -8,7 +8,7 @@
  */
 /*
  *	
- * Copyright (c) 2001-2006 Cisco Systems, Inc.
+ * Copyright (c) 2001-2017 Cisco Systems, Inc.
  * All rights reserved.
  * 
  * Redistribution and use in source and binary forms, with or without

--- a/crypto/kernel/crypto_kernel.c
+++ b/crypto/kernel/crypto_kernel.c
@@ -8,7 +8,7 @@
  */
 /*
  *
- * Copyright(c) 2001-2006,2013 Cisco Systems, Inc.
+ * Copyright(c) 2001-2017 Cisco Systems, Inc.
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/crypto/kernel/err.c
+++ b/crypto/kernel/err.c
@@ -8,7 +8,7 @@
  */
 /*
  *
- * Copyright(c) 2001-2006 Cisco Systems, Inc.
+ * Copyright(c) 2001-2017 Cisco Systems, Inc.
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/crypto/kernel/key.c
+++ b/crypto/kernel/key.c
@@ -8,7 +8,7 @@
  */
 /*
  *
- * Copyright (c) 2001-2006 Cisco Systems, Inc.
+ * Copyright (c) 2001-2017 Cisco Systems, Inc.
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/crypto/math/datatypes.c
+++ b/crypto/math/datatypes.c
@@ -9,7 +9,7 @@
  */
 /*
  *	
- * Copyright (c) 2001-2006 Cisco Systems, Inc.
+ * Copyright (c) 2001-2017 Cisco Systems, Inc.
  * All rights reserved.
  * 
  * Redistribution and use in source and binary forms, with or without

--- a/crypto/math/stat.c
+++ b/crypto/math/stat.c
@@ -9,7 +9,7 @@
 
 /*
  *	
- * Copyright (c) 2001-2006, Cisco Systems, Inc.
+ * Copyright (c) 2001-2017, Cisco Systems, Inc.
  * All rights reserved.
  * 
  * Redistribution and use in source and binary forms, with or without

--- a/crypto/replay/rdb.c
+++ b/crypto/replay/rdb.c
@@ -9,7 +9,7 @@
 
 /*
  *
- * Copyright (c) 2001-2006, Cisco Systems, Inc.
+ * Copyright (c) 2001-2017, Cisco Systems, Inc.
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/crypto/replay/rdbx.c
+++ b/crypto/replay/rdbx.c
@@ -9,7 +9,7 @@
 
 /*
  *
- * Copyright (c) 2001-2006, Cisco Systems, Inc.
+ * Copyright (c) 2001-2017, Cisco Systems, Inc.
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/crypto/replay/ut_sim.c
+++ b/crypto/replay/ut_sim.c
@@ -10,7 +10,7 @@
 
 /*
  *	
- * Copyright (c) 2001-2006, Cisco Systems, Inc.
+ * Copyright (c) 2001-2017, Cisco Systems, Inc.
  * All rights reserved.
  * 
  * Redistribution and use in source and binary forms, with or without

--- a/crypto/test/aes_calc.c
+++ b/crypto/test/aes_calc.c
@@ -9,7 +9,7 @@
 
 /*
  *	
- * Copyright (c) 2001-2006, Cisco Systems, Inc.
+ * Copyright (c) 2001-2017, Cisco Systems, Inc.
  * All rights reserved.
  * 
  * Redistribution and use in source and binary forms, with or without

--- a/crypto/test/auth_driver.c
+++ b/crypto/test/auth_driver.c
@@ -9,7 +9,7 @@
 
 /*
  *	
- * Copyright (c) 2001-2006, Cisco Systems, Inc.
+ * Copyright (c) 2001-2017, Cisco Systems, Inc.
  * All rights reserved.
  * 
  * Redistribution and use in source and binary forms, with or without

--- a/crypto/test/cipher_driver.c
+++ b/crypto/test/cipher_driver.c
@@ -9,7 +9,7 @@
 
 /*
  *	
- * Copyright (c) 2001-2006,2013 Cisco Systems, Inc.
+ * Copyright (c) 2001-2017 Cisco Systems, Inc.
  * All rights reserved.
  * 
  * Redistribution and use in source and binary forms, with or without

--- a/crypto/test/datatypes_driver.c
+++ b/crypto/test/datatypes_driver.c
@@ -9,7 +9,7 @@
 
 /*
  *	
- * Copyright (c) 2001-2006, Cisco Systems, Inc.
+ * Copyright (c) 2001-2017, Cisco Systems, Inc.
  * All rights reserved.
  * 
  * Redistribution and use in source and binary forms, with or without

--- a/crypto/test/env.c
+++ b/crypto/test/env.c
@@ -8,7 +8,7 @@
  */
 /*
  *	
- * Copyright (c) 2001-2006 Cisco Systems, Inc.
+ * Copyright (c) 2001-2017 Cisco Systems, Inc.
  * All rights reserved.
  * 
  * Redistribution and use in source and binary forms, with or without

--- a/crypto/test/kernel_driver.c
+++ b/crypto/test/kernel_driver.c
@@ -8,7 +8,7 @@
  */
 /*
  *	
- * Copyright(c) 2001-2006 Cisco Systems, Inc.
+ * Copyright(c) 2001-2017 Cisco Systems, Inc.
  * All rights reserved.
  * 
  * Redistribution and use in source and binary forms, with or without

--- a/crypto/test/sha1_driver.c
+++ b/crypto/test/sha1_driver.c
@@ -9,7 +9,7 @@
 
 /*
  *	
- * Copyright (c) 2001-2006, Cisco Systems, Inc.
+ * Copyright (c) 2001-2017, Cisco Systems, Inc.
  * All rights reserved.
  * 
  * Redistribution and use in source and binary forms, with or without

--- a/crypto/test/stat_driver.c
+++ b/crypto/test/stat_driver.c
@@ -9,7 +9,7 @@
 
 /*
  *	
- * Copyright (c) 2001-2006, Cisco Systems, Inc.
+ * Copyright (c) 2001-2017, Cisco Systems, Inc.
  * All rights reserved.
  * 
  * Redistribution and use in source and binary forms, with or without

--- a/include/ekt.h
+++ b/include/ekt.h
@@ -8,7 +8,7 @@
  */
 /*
  *	
- * Copyright (c) 2001-2005 Cisco Systems, Inc.
+ * Copyright (c) 2001-2017 Cisco Systems, Inc.
  * All rights reserved.
  * 
  * Redistribution and use in source and binary forms, with or without

--- a/include/getopt_s.h
+++ b/include/getopt_s.h
@@ -8,7 +8,7 @@
  */
 /*
  *	
- * Copyright (c) 2001-2006 Cisco Systems, Inc.
+ * Copyright (c) 2001-2017 Cisco Systems, Inc.
  * All rights reserved.
  * 
  * Redistribution and use in source and binary forms, with or without

--- a/include/rtp.h
+++ b/include/rtp.h
@@ -16,7 +16,7 @@
 
 /*
  *	
- * Copyright (c) 2001-2006, Cisco Systems, Inc.
+ * Copyright (c) 2001-2017, Cisco Systems, Inc.
  * All rights reserved.
  * 
  * Redistribution and use in source and binary forms, with or without

--- a/include/rtp_priv.h
+++ b/include/rtp_priv.h
@@ -8,7 +8,7 @@
  */
 /*
  *	
- * Copyright (c) 2001-2006 Cisco Systems, Inc.
+ * Copyright (c) 2001-2017 Cisco Systems, Inc.
  * All rights reserved.
  * 
  * Redistribution and use in source and binary forms, with or without

--- a/include/srtp.h
+++ b/include/srtp.h
@@ -8,7 +8,7 @@
  */
 /*
  *	
- * Copyright (c) 2001-2006, Cisco Systems, Inc.
+ * Copyright (c) 2001-2017, Cisco Systems, Inc.
  * All rights reserved.
  * 
  * Redistribution and use in source and binary forms, with or without

--- a/include/srtp_priv.h
+++ b/include/srtp_priv.h
@@ -8,7 +8,7 @@
  */
 /*
  *	
- * Copyright (c) 2001-2006 Cisco Systems, Inc.
+ * Copyright (c) 2001-2017 Cisco Systems, Inc.
  * All rights reserved.
  * 
  * Redistribution and use in source and binary forms, with or without

--- a/include/ut_sim.h
+++ b/include/ut_sim.h
@@ -10,7 +10,7 @@
 
 /*
  *	
- * Copyright (c) 2001-2006, Cisco Systems, Inc.
+ * Copyright (c) 2001-2017, Cisco Systems, Inc.
  * All rights reserved.
  * 
  * Redistribution and use in source and binary forms, with or without

--- a/srtp/ekt.c
+++ b/srtp/ekt.c
@@ -8,7 +8,7 @@
  */
 /*
  *	
- * Copyright (c) 2001-2006 Cisco Systems, Inc.
+ * Copyright (c) 2001-2017 Cisco Systems, Inc.
  * All rights reserved.
  * 
  * Redistribution and use in source and binary forms, with or without

--- a/srtp/srtp.c
+++ b/srtp/srtp.c
@@ -8,7 +8,7 @@
  */
 /*
  *	
- * Copyright (c) 2001-2006, Cisco Systems, Inc.
+ * Copyright (c) 2001-2017, Cisco Systems, Inc.
  * All rights reserved.
  * 
  * Redistribution and use in source and binary forms, with or without

--- a/test/dtls_srtp_driver.c
+++ b/test/dtls_srtp_driver.c
@@ -8,7 +8,7 @@
  */
 /*
  *	
- * Copyright (c) 2001-2006 Cisco Systems, Inc.
+ * Copyright (c) 2001-2017 Cisco Systems, Inc.
  * All rights reserved.
  * 
  * Redistribution and use in source and binary forms, with or without

--- a/test/getopt_s.c
+++ b/test/getopt_s.c
@@ -8,7 +8,7 @@
  */
 /*
  *	
- * Copyright (c) 2001-2006 Cisco Systems, Inc.
+ * Copyright (c) 2001-2017 Cisco Systems, Inc.
  * All rights reserved.
  * 
  * Redistribution and use in source and binary forms, with or without

--- a/test/lfsr.c
+++ b/test/lfsr.c
@@ -5,7 +5,7 @@
 
 /*
  *	
- * Copyright (c) 2001-2006, Cisco Systems, Inc.
+ * Copyright (c) 2001-2017, Cisco Systems, Inc.
  * All rights reserved.
  * 
  * Redistribution and use in source and binary forms, with or without

--- a/test/rdbx_driver.c
+++ b/test/rdbx_driver.c
@@ -9,7 +9,7 @@
 
 /*
  *	
- * Copyright (c) 2001-2006, Cisco Systems, Inc.
+ * Copyright (c) 2001-2017, Cisco Systems, Inc.
  * All rights reserved.
  * 
  * Redistribution and use in source and binary forms, with or without

--- a/test/replay_driver.c
+++ b/test/replay_driver.c
@@ -9,7 +9,7 @@
 
 /*
  *	
- * Copyright (c) 2001-2006, Cisco Systems, Inc.
+ * Copyright (c) 2001-2017, Cisco Systems, Inc.
  * All rights reserved.
  * 
  * Redistribution and use in source and binary forms, with or without

--- a/test/roc_driver.c
+++ b/test/roc_driver.c
@@ -9,7 +9,7 @@
 
 /*
  *	
- * Copyright (c) 2001-2006, Cisco Systems, Inc.
+ * Copyright (c) 2001-2017, Cisco Systems, Inc.
  * All rights reserved.
  * 
  * Redistribution and use in source and binary forms, with or without

--- a/test/rtp.c
+++ b/test/rtp.c
@@ -9,7 +9,7 @@
 
 /*
  *	
- * Copyright (c) 2001-2006, Cisco Systems, Inc.
+ * Copyright (c) 2001-2017, Cisco Systems, Inc.
  * All rights reserved.
  * 
  * Redistribution and use in source and binary forms, with or without

--- a/test/rtp_decoder.c
+++ b/test/rtp_decoder.c
@@ -24,7 +24,7 @@
  */
 /*
  *	
- * Copyright (c) 2001-2006 Cisco Systems, Inc.
+ * Copyright (c) 2001-2017 Cisco Systems, Inc.
  * All rights reserved.
  * 
  * Redistribution and use in source and binary forms, with or without

--- a/test/rtp_decoder.h
+++ b/test/rtp_decoder.h
@@ -10,7 +10,7 @@
  */
 /*
  *	
- * Copyright (c) 2001-2006 Cisco Systems, Inc.
+ * Copyright (c) 2001-2017 Cisco Systems, Inc.
  * All rights reserved.
  * 
  * Redistribution and use in source and binary forms, with or without

--- a/test/rtpw.c
+++ b/test/rtpw.c
@@ -16,7 +16,7 @@
 
 /*
  *	
- * Copyright (c) 2001-2006, Cisco Systems, Inc.
+ * Copyright (c) 2001-2017, Cisco Systems, Inc.
  * All rights reserved.
  * 
  * Redistribution and use in source and binary forms, with or without

--- a/test/rtpw_test.sh
+++ b/test/rtpw_test.sh
@@ -4,7 +4,7 @@
 # 
 # tests the rtpw sender and receiver functions
 #
-# Copyright (c) 2001-2006, Cisco Systems, Inc.
+# Copyright (c) 2001-2017, Cisco Systems, Inc.
 # All rights reserved.
 # 
 # Redistribution and use in source and binary forms, with or without

--- a/test/rtpw_test_gcm.sh
+++ b/test/rtpw_test_gcm.sh
@@ -4,7 +4,7 @@
 # 
 # tests the rtpw sender and receiver functions
 #
-# Copyright (c) 2001-2006, Cisco Systems, Inc.
+# Copyright (c) 2001-2017, Cisco Systems, Inc.
 # All rights reserved.
 # 
 # Redistribution and use in source and binary forms, with or without

--- a/test/srtp_driver.c
+++ b/test/srtp_driver.c
@@ -10,7 +10,7 @@
  */
 /*
  *
- * Copyright (c) 2001-2006, Cisco Systems, Inc.
+ * Copyright (c) 2001-2017, Cisco Systems, Inc.
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/test/test_srtp.c
+++ b/test/test_srtp.c
@@ -9,7 +9,7 @@
 
 /*
  *
- * Copyright (c) 2001-2006, Cisco Systems, Inc.
+ * Copyright (c) 2017, Cisco Systems, Inc.
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/test/util.c
+++ b/test/util.c
@@ -8,7 +8,7 @@
  */
 /*
  *
- * Copyright (c) 2014, Cisco Systems, Inc.
+ * Copyright (c) 2014-2017, Cisco Systems, Inc.
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/test/util.h
+++ b/test/util.h
@@ -8,7 +8,7 @@
  */
 /*
  *
- * Copyright (c) 2014, Cisco Systems, Inc.
+ * Copyright (c) 2014-2017, Cisco Systems, Inc.
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without


### PR DESCRIPTION
test_srtp.c had incorrect year (copy paste error), updated to current year.

Bumped copyright year for all other instances to include current year.