### PR TITLE
Add strict-prototypes warning if supported.

### DIFF
--- a/configure
+++ b/configure
@@ -4812,8 +4812,8 @@ fi
 WERROR=""
 for w in -Werror -errwarn; do
   if test "x$WERROR" = "x"; then
-    { $as_echo "$as_me:${as_lineno-$LINENO}: checking whether the compiler supports $w" >&5
-$as_echo_n "checking whether the compiler supports $w... " >&6; }
+    { $as_echo "$as_me:${as_lineno-$LINENO}: checking whether ${CC-c} accepts $w" >&5
+$as_echo_n "checking whether ${CC-c} accepts $w... " >&6; }
     save_cflags="$CFLAGS"
     if test "x$CFLAGS" = "x"; then :
   CFLAGS="$w"
@@ -4822,14 +4822,7 @@ else
 fi
     cat confdefs.h - <<_ACEOF >conftest.$ac_ext
 /* end confdefs.h.  */
-
-int
-main ()
-{
-
-  ;
-  return 0;
-}
+int main(void) { return 0; }
 _ACEOF
 if ac_fn_c_try_compile "$LINENO"; then :
   WERROR="$w"
@@ -4844,8 +4837,8 @@ rm -f core conftest.err conftest.$ac_objext conftest.$ac_ext
   fi
 done
 
-{ $as_echo "$as_me:${as_lineno-$LINENO}: checking whether the compiler supports -fPIC" >&5
-$as_echo_n "checking whether the compiler supports -fPIC... " >&6; }
+{ $as_echo "$as_me:${as_lineno-$LINENO}: checking whether ${CC-c} accepts -fPIC" >&5
+$as_echo_n "checking whether ${CC-c} accepts -fPIC... " >&6; }
 save_cflags="$CFLAGS"
 if test "x$CFLAGS" = "x"; then :
   CFLAGS="-fPIC"
@@ -4854,14 +4847,7 @@ else
 fi
 cat confdefs.h - <<_ACEOF >conftest.$ac_ext
 /* end confdefs.h.  */
-
-int
-main ()
-{
-
-  ;
-  return 0;
-}
+int main(void) { return 0; }
 _ACEOF
 if ac_fn_c_try_compile "$LINENO"; then :
   if test "x$supported_cflags" = "x"; then :
@@ -4884,9 +4870,9 @@ fi
 rm -f core conftest.err conftest.$ac_objext conftest.$ac_ext
 
 if test "$EMPTY_CFLAGS" = "yes"; then
-  for f in -Wall -pedantic; do
-    { $as_echo "$as_me:${as_lineno-$LINENO}: checking whether the compiler supports $f" >&5
-$as_echo_n "checking whether the compiler supports $f... " >&6; }
+  for f in -Wall -pedantic -Wstrict-prototypes; do
+    { $as_echo "$as_me:${as_lineno-$LINENO}: checking whether ${CC-c} accepts $f" >&5
+$as_echo_n "checking whether ${CC-c} accepts $f... " >&6; }
     save_cflags="$CFLAGS"
     if test "x$CFLAGS" = "x"; then :
   CFLAGS="$f"
@@ -4895,14 +4881,7 @@ else
 fi
     cat confdefs.h - <<_ACEOF >conftest.$ac_ext
 /* end confdefs.h.  */
-
-int
-main ()
-{
-
-  ;
-  return 0;
-}
+int main(void) { return 0; }
 _ACEOF
 if ac_fn_c_try_compile "$LINENO"; then :
   if test "x$supported_cflags" = "x"; then :
@@ -4923,8 +4902,8 @@ rm -f core conftest.err conftest.$ac_objext conftest.$ac_ext
   OOPT=""
   for f in -O4 -O3; do
     if test "x$OOPT" = "x"; then
-      { $as_echo "$as_me:${as_lineno-$LINENO}: checking whether the compiler supports $f" >&5
-$as_echo_n "checking whether the compiler supports $f... " >&6; }
+      { $as_echo "$as_me:${as_lineno-$LINENO}: checking whether ${CC-c} accepts $f" >&5
+$as_echo_n "checking whether ${CC-c} accepts $f... " >&6; }
       save_cflags="$CFLAGS"
       if test "x$CFLAGS" = "x"; then :
   CFLAGS="$f"
@@ -4933,14 +4912,7 @@ else
 fi
       cat confdefs.h - <<_ACEOF >conftest.$ac_ext
 /* end confdefs.h.  */
-
-int
-main ()
-{
-
-  ;
-  return 0;
-}
+int main(void) { return 0; }
 _ACEOF
 if ac_fn_c_try_compile "$LINENO"; then :
   if test "x$supported_cflags" = "x"; then :
@@ -4961,8 +4933,8 @@ rm -f core conftest.err conftest.$ac_objext conftest.$ac_ext
   done
 
   for f in -fexpensive-optimizations -funroll-loops; do
-    { $as_echo "$as_me:${as_lineno-$LINENO}: checking whether the compiler supports $f" >&5
-$as_echo_n "checking whether the compiler supports $f... " >&6; }
+    { $as_echo "$as_me:${as_lineno-$LINENO}: checking whether ${CC-c} accepts $f" >&5
+$as_echo_n "checking whether ${CC-c} accepts $f... " >&6; }
     save_cflags="$CFLAGS"
     if test "x$CFLAGS" = "x"; then :
   CFLAGS="$f"
@@ -4971,14 +4943,7 @@ else
 fi
     cat confdefs.h - <<_ACEOF >conftest.$ac_ext
 /* end confdefs.h.  */
-
-int
-main ()
-{
-
-  ;
-  return 0;
-}
+int main(void) { return 0; }
 _ACEOF
 if ac_fn_c_try_compile "$LINENO"; then :
   if test "x$supported_cflags" = "x"; then :
@@ -4998,8 +4963,8 @@ rm -f core conftest.err conftest.$ac_objext conftest.$ac_ext
 fi
 
 for f in -Wno-language-extension-token; do
-  { $as_echo "$as_me:${as_lineno-$LINENO}: checking whether the compiler supports $f" >&5
-$as_echo_n "checking whether the compiler supports $f... " >&6; }
+  { $as_echo "$as_me:${as_lineno-$LINENO}: checking whether ${CC-c} accepts $f" >&5
+$as_echo_n "checking whether ${CC-c} accepts $f... " >&6; }
   save_cflags="$CFLAGS"
   testf=$(echo "$f" | $SED 's|-Wno-\(.*\)|-W\1|g')
   if test "x$CFLAGS" = "x"; then :
@@ -5009,14 +4974,7 @@ else
 fi
   cat confdefs.h - <<_ACEOF >conftest.$ac_ext
 /* end confdefs.h.  */
-
-int
-main ()
-{
-
-  ;
-  return 0;
-}
+int main(void) { return 0; }
 _ACEOF
 if ac_fn_c_try_compile "$LINENO"; then :
   if test "x$supported_cflags" = "x"; then :
@@ -5536,24 +5494,23 @@ $as_echo_n "checking for socket in -lwsock32... " >&6; }
 /* end confdefs.h.  */
 
 #include <winsock2.h>
-
-int
-main ()
+int main(void)
 {
-
-socket(0, 0, 0);
-
-  ;
-  return 0;
+    int fd = socket(0, 0, 0);
+    if (fd < 0)
+      return -1;
+    else
+      return 0;
 }
+
 _ACEOF
 if ac_fn_c_try_link "$LINENO"; then :
   ac_cv_func_socket=yes
-    { $as_echo "$as_me:${as_lineno-$LINENO}: result: yes" >&5
+     { $as_echo "$as_me:${as_lineno-$LINENO}: result: yes" >&5
 $as_echo "yes" >&6; }
 else
   LIBS="$SAVELIBS"
-    { $as_echo "$as_me:${as_lineno-$LINENO}: result: no" >&5
+     { $as_echo "$as_me:${as_lineno-$LINENO}: result: no" >&5
 $as_echo "no" >&6; }
 fi
 rm -f core conftest.err conftest.$ac_objext \

--- a/configure.in
+++ b/configure.in
@@ -55,10 +55,10 @@ dnl This will be removed again once the tests are complete (see below).
 WERROR=""
 for w in -Werror -errwarn; do
   if test "x$WERROR" = "x"; then
-    AC_MSG_CHECKING([whether the compiler supports $w])
+    AC_MSG_CHECKING([whether ${CC-c} accepts $w])
     save_cflags="$CFLAGS"
     AS_IF([test "x$CFLAGS" = "x"], [CFLAGS="$w"], [CFLAGS="$CFLAGS $w"])
-    AC_COMPILE_IFELSE([AC_LANG_PROGRAM()],
+    AC_COMPILE_IFELSE([AC_LANG_SOURCE([int main(void) { return 0; }])],
       [WERROR="$w"
        AC_MSG_RESULT([yes])],
       [CFLAGS="$save_cflags"
@@ -67,10 +67,10 @@ for w in -Werror -errwarn; do
 done
 
 dnl Note that -fPIC is also added to LDFLAGS.
-AC_MSG_CHECKING([whether the compiler supports -fPIC])
+AC_MSG_CHECKING([whether ${CC-c} accepts -fPIC])
 save_cflags="$CFLAGS"
 AS_IF([test "x$CFLAGS" = "x"], [CFLAGS="-fPIC"], [CFLAGS="$CFLAGS -fPIC"])
-AC_COMPILE_IFELSE([AC_LANG_PROGRAM()],
+AC_COMPILE_IFELSE([AC_LANG_SOURCE([int main(void) { return 0; }])],
   [AS_IF([test "x$supported_cflags" = "x"], [supported_cflags="-fPIC"], [supported_cflags="$supported_cflags -fPIC"])
    AS_IF([test "x$LDFLAGS" = "x"], [LDFLAGS="-fPIC"], [LDFLAGS="$LDFLAGS -fPIC"])
    AC_MSG_RESULT([yes])],
@@ -78,11 +78,11 @@ AC_COMPILE_IFELSE([AC_LANG_PROGRAM()],
    AC_MSG_RESULT([no])])
 
 if test "$EMPTY_CFLAGS" = "yes"; then
-  for f in -Wall -pedantic; do
-    AC_MSG_CHECKING([whether the compiler supports $f])
+  for f in -Wall -pedantic -Wstrict-prototypes; do
+    AC_MSG_CHECKING([whether ${CC-c} accepts $f])
     save_cflags="$CFLAGS"
     AS_IF([test "x$CFLAGS" = "x"], [CFLAGS="$f"], [CFLAGS="$CFLAGS $f"])
-    AC_COMPILE_IFELSE([AC_LANG_PROGRAM()],
+    AC_COMPILE_IFELSE([AC_LANG_SOURCE([int main(void) { return 0; }])],
       [AS_IF([test "x$supported_cflags" = "x"], [supported_cflags="$f"], [supported_cflags="$supported_cflags $f"])
        AC_MSG_RESULT([yes])],
       [CFLAGS="$save_cflags"
@@ -92,10 +92,10 @@ if test "$EMPTY_CFLAGS" = "yes"; then
   OOPT=""
   for f in -O4 -O3; do
     if test "x$OOPT" = "x"; then
-      AC_MSG_CHECKING([whether the compiler supports $f])
+      AC_MSG_CHECKING([whether ${CC-c} accepts $f])
       save_cflags="$CFLAGS"
       AS_IF([test "x$CFLAGS" = "x"], [CFLAGS="$f"], [CFLAGS="$CFLAGS $f"])
-      AC_COMPILE_IFELSE([AC_LANG_PROGRAM()],
+      AC_COMPILE_IFELSE([AC_LANG_SOURCE([int main(void) { return 0; }])],
         [AS_IF([test "x$supported_cflags" = "x"], [supported_cflags="$f"], [supported_cflags="$supported_cflags $f"])
          OOPT="$f"
          AC_MSG_RESULT([yes])],
@@ -105,10 +105,10 @@ if test "$EMPTY_CFLAGS" = "yes"; then
   done
 
   for f in -fexpensive-optimizations -funroll-loops; do
-    AC_MSG_CHECKING([whether the compiler supports $f])
+    AC_MSG_CHECKING([whether ${CC-c} accepts $f])
     save_cflags="$CFLAGS"
     AS_IF([test "x$CFLAGS" = "x"], [CFLAGS="$f"], [CFLAGS="$CFLAGS $f"])
-    AC_COMPILE_IFELSE([AC_LANG_PROGRAM()],
+    AC_COMPILE_IFELSE([AC_LANG_SOURCE([int main(void) { return 0; }])],
       [AS_IF([test "x$supported_cflags" = "x"], [supported_cflags="$f"], [supported_cflags="$supported_cflags $f"])
        AC_MSG_RESULT([yes])],
       [CFLAGS="$save_cflags"
@@ -121,11 +121,11 @@ dnl supported. However, the -Wno-<warning> form isn't consulted unless a warning
 dnl At least that's the case for GCC. So to check which warnings we can turn off, we dnl need to check
 dnl if they can be turned on, thereby forcing GCC to take the argument into account right away.
 for f in -Wno-language-extension-token; do
-  AC_MSG_CHECKING([whether the compiler supports $f])
+  AC_MSG_CHECKING([whether ${CC-c} accepts $f])
   save_cflags="$CFLAGS"
   testf=$(echo "$f" | $SED 's|-Wno-\(.*\)|-W\1|g')
   AS_IF([test "x$CFLAGS" = "x"], [CFLAGS="$testf"], [CFLAGS="$CFLAGS $testf"])
-  AC_COMPILE_IFELSE([AC_LANG_PROGRAM()],
+  AC_COMPILE_IFELSE([AC_LANG_SOURCE([int main(void) { return 0; }])],
     [AS_IF([test "x$supported_cflags" = "x"], [supported_cflags="$f"], [supported_cflags="$supported_cflags $f"])
      AC_MSG_RESULT([yes])],
     [CFLAGS="$save_cflags"
@@ -166,13 +166,22 @@ if test "x$ac_cv_func_socket" = "xno"; then
   AC_MSG_CHECKING([for socket in -lwsock32])
   SAVELIBS="$LIBS"
   LIBS="$LIBS -lwsock32"
-  AC_LINK_IFELSE([AC_LANG_PROGRAM([[
+  AC_LINK_IFELSE(
+    [AC_LANG_SOURCE([
 #include <winsock2.h>
-]], [[
-socket(0, 0, 0);
-]])],[ac_cv_func_socket=yes
-    AC_MSG_RESULT([yes])],[LIBS="$SAVELIBS"
-    AC_MSG_RESULT([no])])
+int main(void)
+{
+    int fd = socket(0, 0, 0);
+    if (fd < 0)
+      return -1;
+    else
+      return 0;
+}
+    ])],
+    [ac_cv_func_socket=yes
+     AC_MSG_RESULT([yes])],
+    [LIBS="$SAVELIBS"
+     AC_MSG_RESULT([no])])
 fi
 
 AC_MSG_CHECKING([whether to enable debug logging in all modules])

--- a/crypto/include/err.h
+++ b/crypto/include/err.h
@@ -80,7 +80,7 @@ typedef enum {
  *
  */
 
-srtp_err_status_t srtp_err_reporting_init();
+srtp_err_status_t srtp_err_reporting_init(void);
 
 typedef void (srtp_err_report_handler_func_t)(srtp_err_reporting_level_t level, const char * msg);
 

--- a/test/test_srtp.c
+++ b/test/test_srtp.c
@@ -61,9 +61,9 @@
  * Forward declarations for all tests.
  */
 
-void srtp_calc_aead_iv_srtcp_all_zero_input_yield_zero_output();
-void srtp_calc_aead_iv_srtcp_seq_num_over_0x7FFFFFFF_bad_param();
-void srtp_calc_aead_iv_srtcp_distinct_iv_per_sequence_number();
+void srtp_calc_aead_iv_srtcp_all_zero_input_yield_zero_output(void);
+void srtp_calc_aead_iv_srtcp_seq_num_over_0x7FFFFFFF_bad_param(void);
+void srtp_calc_aead_iv_srtcp_distinct_iv_per_sequence_number(void);
 
 /*
  * NULL terminated array of tests.


### PR DESCRIPTION
Ensure that all functions are correctly declared for c.
There was one function in libsrtp that was not declared correctly.

This flags needed a custom program to check in configure, the built
in function was invalid when using this flag.