### PR TITLE
Use const char * for srtp_set_debug_module()

### DIFF
--- a/crypto/include/crypto_kernel.h
+++ b/crypto/include/crypto_kernel.h
@@ -201,7 +201,7 @@ srtp_err_status_t srtp_crypto_kernel_alloc_auth(srtp_auth_type_id_t id, srtp_aut
  *
  * returns srtp_err_status_ok on success, srtp_err_status_fail otherwise
  */
-srtp_err_status_t srtp_crypto_kernel_set_debug_module(char *mod_name, int v);
+srtp_err_status_t srtp_crypto_kernel_set_debug_module(const char *mod_name, int v);
 
 #ifdef __cplusplus
 }

--- a/crypto/kernel/crypto_kernel.c
+++ b/crypto/kernel/crypto_kernel.c
@@ -555,7 +555,7 @@ srtp_err_status_t srtp_crypto_kernel_load_debug_module (srtp_debug_module_t *new
     return srtp_err_status_ok;
 }
 
-srtp_err_status_t srtp_crypto_kernel_set_debug_module (char *name, int on)
+srtp_err_status_t srtp_crypto_kernel_set_debug_module (const char *name, int on)
 {
     srtp_kernel_debug_module_t *kdm;
 

--- a/include/srtp.h
+++ b/include/srtp.h
@@ -1780,7 +1780,7 @@ unsigned int srtp_get_version(void);
  *
  * returns err_status_ok on success, err_status_fail otherwise
  */
-srtp_err_status_t srtp_set_debug_module(char *mod_name, int v);
+srtp_err_status_t srtp_set_debug_module(const char *mod_name, int v);
 
 /**
  * @brief srtp_list_debug_modules() outputs a list of debugging modules

--- a/srtp/srtp.c
+++ b/srtp/srtp.c
@@ -4421,7 +4421,7 @@ srtp_get_protect_rtcp_trailer_length(srtp_t session,
 /*
  * SRTP debug interface
  */
-srtp_err_status_t srtp_set_debug_module(char *mod_name, int v)
+srtp_err_status_t srtp_set_debug_module(const char *mod_name, int v)
 {
     return srtp_crypto_kernel_set_debug_module(mod_name, v);
 }


### PR DESCRIPTION
Not sure why it was not const, but it makes calling it a pain.