### PR TITLE
Fix incorrect result of rdb_increment on overflow

### DIFF
--- a/crypto/replay/rdb.c
+++ b/crypto/replay/rdb.c
@@ -130,9 +130,10 @@ srtp_err_status_t srtp_rdb_add_index (srtp_rdb_t *rdb, uint32_t p_index)
 srtp_err_status_t srtp_rdb_increment (srtp_rdb_t *rdb)
 {
 
-    if (rdb->window_start++ > 0x7fffffff) {
+    if (rdb->window_start >= 0x7fffffff) {
         return srtp_err_status_key_expired;
     }
+    ++rdb->window_start;
     return srtp_err_status_ok;
 }
 

--- a/test/replay_driver.c
+++ b/test/replay_driver.c
@@ -219,6 +219,29 @@ test_rdb_db() {
       return err;
   }
 
+  /* test for key expired */
+  if (srtp_rdb_init(&rdb) != srtp_err_status_ok) {
+    printf("rdb_init failed\n");
+    return srtp_err_status_fail;
+  }
+  rdb.window_start = 0x7ffffffe;
+  if (srtp_rdb_increment(&rdb) != srtp_err_status_ok) {
+    printf("srtp_rdb_increment of 0x7ffffffe failed\n");
+    return srtp_err_status_fail;
+  }
+  if (srtp_rdb_get_value(&rdb) != 0x7fffffff) {
+    printf("rdb valiue was not 0x7fffffff\n");
+    return srtp_err_status_fail;
+  }
+  if (srtp_rdb_increment(&rdb) != srtp_err_status_key_expired) {
+    printf("srtp_rdb_increment of 0x7fffffff did not return srtp_err_status_key_expired\n");
+    return srtp_err_status_fail;
+  }
+  if (srtp_rdb_get_value(&rdb) != 0x7fffffff) {
+    printf("rdb valiue was not 0x7fffffff\n");
+    return srtp_err_status_fail;
+  }
+
 
   return srtp_err_status_ok;
 }


### PR DESCRIPTION
The rdb_increment used to return err_status_ok when overflow has happened, which results in undesirable consequences in other parts of the code.