### PR TITLE
Makefile.in: Add gnu as match for shared lib suffix

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -74,7 +74,7 @@ pkgconfigdir = $(libdir)/pkgconfig
 pkgconfig_DATA = libsrtp2.pc
 
 SHAREDLIBVERSION = 1
-ifeq (linux,$(findstring linux,@host@))
+ifneq (,$(or $(findstring linux,@host@), $(findstring gnu,@host@)))
 SHAREDLIB_DIR = $(libdir)
 SHAREDLIB_LDFLAGS = -shared -Wl,-soname,$@
 SHAREDLIBSUFFIXNOVER = so


### PR DESCRIPTION
This will fix issues as reported in #229 where we fail to complete builds
because the libary suffix variable is not set.