### PR TITLE
Initialize policy in the README example

### DIFF
--- a/README.md
+++ b/README.md
@@ -397,6 +397,9 @@ uint8_t key[30] = {0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07,
 // initialize libSRTP
 srtp_init();
 
+// default policy values
+memset(&policy, 0x0, sizeof(srtp_policy_t));
+
 // set policy to describe a policy for an SRTP stream
 crypto_policy_set_rtp_default(&policy.rtp);
 crypto_policy_set_rtcp_default(&policy.rtcp);


### PR DESCRIPTION
I have use the README example but it does not work for me. It is because I have not set a default parameter of the policy to 0.
To solve this I have added a memset instruction to initialize srtp_policy with zeros.
