### PR TITLE
Clang format suggestion

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,0 +1,77 @@
+AccessModifierOffset: -4
+
+AlignAfterOpenBracket: Align
+AlignConsecutiveAssignments: false
+AlignConsecutiveDeclarations: false
+AlignEscapedNewlinesLeft: false
+AlignOperands:   true
+AlignTrailingComments: true
+
+AllowAllParametersOfDeclarationOnNextLine: false
+
+AllowShortBlocksOnASingleLine: false
+AllowShortCaseLabelsOnASingleLine: false
+AllowShortFunctionsOnASingleLine: Inline
+AllowShortIfStatementsOnASingleLine: false
+AllowShortLoopsOnASingleLine: false
+
+AlwaysBreakAfterDefinitionReturnType: None
+AlwaysBreakBeforeMultilineStrings: false
+AlwaysBreakTemplateDeclarations: false
+
+BinPackArguments: true
+BinPackParameters: false
+BraceWrapping:
+  AfterControlStatement: false
+  AfterEnum:       false
+  AfterFunction:   true
+  AfterStruct:     false
+  AfterUnion:      false
+  BeforeCatch:     false
+  BeforeElse:      false
+  IndentBraces:    false
+
+BreakBeforeBinaryOperators: None
+BreakBeforeBraces: Custom
+BreakBeforeTernaryOperators: true
+
+ColumnLimit:     80
+CommentPragmas:  '^ IWYU pragma:'
+ContinuationIndentWidth: 4
+DerivePointerAlignment: false
+DisableFormat:   false
+ExperimentalAutoDetectBinPacking: false
+
+IndentCaseLabels: false
+IndentWidth:     4
+IndentWrappedFunctionNames: false
+
+KeepEmptyLinesAtTheStartOfBlocks: false
+
+MaxEmptyLinesToKeep: 1
+
+PenaltyBreakBeforeFirstCallParameter: 16
+PenaltyBreakComment: 300
+PenaltyBreakFirstLessLess: 120
+PenaltyBreakString: 1000
+PenaltyExcessCharacter: 1000
+PenaltyReturnTypeOnItsOwnLine: 60
+
+PointerAlignment: Right
+
+ReflowComments:  true
+
+SortIncludes: false
+
+SpaceAfterCStyleCast: false
+SpaceBeforeAssignmentOperators: true
+SpaceBeforeParens: ControlStatements
+SpaceInEmptyParentheses: false
+SpacesBeforeTrailingComments: 1
+SpacesInAngles:  false
+SpacesInContainerLiterals: true
+SpacesInCStyleCastParentheses: false
+SpacesInParentheses: false
+SpacesInSquareBrackets: false
+TabWidth:        4
+UseTab:          Never

--- a/include/srtp.h
+++ b/include/srtp.h
@@ -7,26 +7,26 @@
  * Cisco Systems, Inc.
  */
 /*
- *	
+ *
  * Copyright (c) 2001-2017, Cisco Systems, Inc.
  * All rights reserved.
- * 
+ *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
  * are met:
- * 
+ *
  *   Redistributions of source code must retain the above copyright
  *   notice, this list of conditions and the following disclaimer.
- * 
+ *
  *   Redistributions in binary form must reproduce the above
  *   copyright notice, this list of conditions and the following
  *   disclaimer in the documentation and/or other materials provided
  *   with the distribution.
- * 
+ *
  *   Neither the name of the Cisco Systems, Inc. nor the names of its
  *   contributors may be used to endorse or promote products derived
  *   from this software without specific prior written permission.
- * 
+ *
  * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
  * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
  * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
@@ -41,7 +41,6 @@
  * OF THE POSSIBILITY OF SUCH DAMAGE.
  *
  */
-
 
 #ifndef SRTP_SRTP_H
 #define SRTP_SRTP_H
@@ -70,20 +69,19 @@ extern "C" {
 /*
  * SRTP_MAX_KEY_LEN is the maximum key length supported by libSRTP
  */
-#define SRTP_MAX_KEY_LEN      64
+#define SRTP_MAX_KEY_LEN 64
 
 /*
  * SRTP_MAX_TAG_LEN is the maximum tag length supported by libSRTP
  */
 
-#define SRTP_MAX_TAG_LEN 16 
+#define SRTP_MAX_TAG_LEN 16
 
 /**
  * SRTP_MAX_MKI_LEN is the maximum size the MKI could be which is
  * 128 bytes
  */
 #define SRTP_MAX_MKI_LEN 128
-
 
 /**
  * SRTP_MAX_TRAILER_LEN is the maximum length of the SRTP trailer
@@ -97,32 +95,36 @@ extern "C" {
 
 /**
  * SRTP_MAX_NUM_MASTER_KEYS is the maximum number of Master keys for
- * MKI supported by libSRTP.  
- *  
+ * MKI supported by libSRTP.
+ *
  */
 #define SRTP_MAX_NUM_MASTER_KEYS 16
 
-#define SRTP_SALT_LEN                14
+#define SRTP_SALT_LEN 14
+
 /*
  * SRTP_AEAD_SALT_LEN is the length of the SALT values used with
  * GCM mode.  GCM mode requires an IV.  The SALT value is used
  * as part of the IV formation logic applied to each RTP packet.
  */
-#define SRTP_AEAD_SALT_LEN               12
+#define SRTP_AEAD_SALT_LEN 12
 
-#define SRTP_AES_128_KEY_LEN         16
-#define SRTP_AES_192_KEY_LEN         24
-#define SRTP_AES_256_KEY_LEN         32
+#define SRTP_AES_128_KEY_LEN 16
+#define SRTP_AES_192_KEY_LEN 24
+#define SRTP_AES_256_KEY_LEN 32
 
-#define SRTP_AES_ICM_128_KEY_LEN_WSALT   (SRTP_SALT_LEN + SRTP_AES_128_KEY_LEN)
-#define SRTP_AES_ICM_192_KEY_LEN_WSALT   (SRTP_SALT_LEN + SRTP_AES_192_KEY_LEN)
-#define SRTP_AES_ICM_256_KEY_LEN_WSALT   (SRTP_SALT_LEN + SRTP_AES_256_KEY_LEN)
+#define SRTP_AES_ICM_128_KEY_LEN_WSALT (SRTP_SALT_LEN + SRTP_AES_128_KEY_LEN)
+#define SRTP_AES_ICM_192_KEY_LEN_WSALT (SRTP_SALT_LEN + SRTP_AES_192_KEY_LEN)
+#define SRTP_AES_ICM_256_KEY_LEN_WSALT (SRTP_SALT_LEN + SRTP_AES_256_KEY_LEN)
 
-#define SRTP_AES_GCM_128_KEY_LEN_WSALT   (SRTP_AEAD_SALT_LEN + SRTP_AES_128_KEY_LEN)
-#define SRTP_AES_GCM_192_KEY_LEN_WSALT   (SRTP_AEAD_SALT_LEN + SRTP_AES_192_KEY_LEN)
-#define SRTP_AES_GCM_256_KEY_LEN_WSALT   (SRTP_AEAD_SALT_LEN + SRTP_AES_256_KEY_LEN)
+#define SRTP_AES_GCM_128_KEY_LEN_WSALT                                         \
+    (SRTP_AEAD_SALT_LEN + SRTP_AES_128_KEY_LEN)
+#define SRTP_AES_GCM_192_KEY_LEN_WSALT                                         \
+    (SRTP_AEAD_SALT_LEN + SRTP_AES_192_KEY_LEN)
+#define SRTP_AES_GCM_256_KEY_LEN_WSALT                                         \
+    (SRTP_AEAD_SALT_LEN + SRTP_AES_256_KEY_LEN)
 
-/** 
+/**
  *  @brief A srtp_cipher_type_id_t is an identifier for a particular cipher
  *  type.
  *
@@ -131,13 +133,14 @@ extern "C" {
  *  SRTP_NULL_CIPHER is avaliable; this cipher leaves the data unchanged,
  *  and can be selected to indicate that no encryption is to take
  *  place.
- * 
+ *
  *  @ingroup Ciphers
  */
-typedef uint32_t srtp_cipher_type_id_t; 
+typedef uint32_t srtp_cipher_type_id_t;
 
 /**
- *  @brief An srtp_auth_type_id_t is an identifier for a particular authentication
+ *  @brief An srtp_auth_type_id_t is an identifier for a particular
+ * authentication
  *   function.
  *
  *  An srtp_auth_type_id_t is an integer that represents a particular
@@ -145,7 +148,7 @@ typedef uint32_t srtp_cipher_type_id_t;
  *  avaliable; this authentication function performs no computation,
  *  and can be selected to indicate that no authentication is to take
  *  place.
- *  
+ *
  *  @ingroup Authentication
  */
 typedef uint32_t srtp_auth_type_id_t;
@@ -159,119 +162,118 @@ typedef uint32_t srtp_auth_type_id_t;
  *
  */
 typedef enum {
-  srtp_err_status_ok           = 0,  /**< nothing to report                       */
-  srtp_err_status_fail         = 1,  /**< unspecified failure                     */
-  srtp_err_status_bad_param    = 2,  /**< unsupported parameter                   */
-  srtp_err_status_alloc_fail   = 3,  /**< couldn't allocate memory                */
-  srtp_err_status_dealloc_fail = 4,  /**< couldn't deallocate properly            */
-  srtp_err_status_init_fail    = 5,  /**< couldn't initialize                     */
-  srtp_err_status_terminus     = 6,  /**< can't process as much data as requested */
-  srtp_err_status_auth_fail    = 7,  /**< authentication failure                  */
-  srtp_err_status_cipher_fail  = 8,  /**< cipher failure                          */
-  srtp_err_status_replay_fail  = 9,  /**< replay check failed (bad index)         */
-  srtp_err_status_replay_old   = 10, /**< replay check failed (index too old)     */
-  srtp_err_status_algo_fail    = 11, /**< algorithm failed test routine           */
-  srtp_err_status_no_such_op   = 12, /**< unsupported operation                   */
-  srtp_err_status_no_ctx       = 13, /**< no appropriate context found            */
-  srtp_err_status_cant_check   = 14, /**< unable to perform desired validation    */
-  srtp_err_status_key_expired  = 15, /**< can't use key any more                  */
-  srtp_err_status_socket_err   = 16, /**< error in use of socket                  */
-  srtp_err_status_signal_err   = 17, /**< error in use POSIX signals              */
-  srtp_err_status_nonce_bad    = 18, /**< nonce check failed                      */
-  srtp_err_status_read_fail    = 19, /**< couldn't read data                      */
-  srtp_err_status_write_fail   = 20, /**< couldn't write data                     */
-  srtp_err_status_parse_err    = 21, /**< error parsing data                      */
-  srtp_err_status_encode_err   = 22, /**< error encoding data                     */
-  srtp_err_status_semaphore_err = 23,/**< error while using semaphores            */
-  srtp_err_status_pfkey_err    = 24, /**< error while using pfkey                 */
-  srtp_err_status_bad_mki      = 25, /**< error MKI present in packet is invalid  */
-  srtp_err_status_pkt_idx_old  = 26, /**< packet index is too old to consider     */
-  srtp_err_status_pkt_idx_adv  = 27 /**< packet index advanced, reset needed      */
+    srtp_err_status_ok = 0,             /**< nothing to report               */
+    srtp_err_status_fail = 1,           /**< unspecified failure             */
+    srtp_err_status_bad_param = 2,      /**< unsupported parameter           */
+    srtp_err_status_alloc_fail = 3,     /**< couldn't allocate memory        */
+    srtp_err_status_dealloc_fail = 4,   /**< couldn't deallocate properly    */
+    srtp_err_status_init_fail = 5,      /**< couldn't initialize             */
+    srtp_err_status_terminus = 6,       /**< can't process as much data as   */
+                                        /**< requested                       */
+    srtp_err_status_auth_fail = 7,      /**< authentication failure          */
+    srtp_err_status_cipher_fail = 8,    /**< cipher failure                  */
+    srtp_err_status_replay_fail = 9,    /**< replay check failed (bad index) */
+    srtp_err_status_replay_old = 10,    /**< replay check failed (index too  */
+                                        /**< old)                            */
+    srtp_err_status_algo_fail = 11,     /**< algorithm failed test routine   */
+    srtp_err_status_no_such_op = 12,    /**< unsupported operation           */
+    srtp_err_status_no_ctx = 13,        /**< no appropriate context found    */
+    srtp_err_status_cant_check = 14,    /**< unable to perform desired       */
+                                        /**< validation                      */
+    srtp_err_status_key_expired = 15,   /**< can't use key any more          */
+    srtp_err_status_socket_err = 16,    /**< error in use of socket          */
+    srtp_err_status_signal_err = 17,    /**< error in use POSIX signals      */
+    srtp_err_status_nonce_bad = 18,     /**< nonce check failed              */
+    srtp_err_status_read_fail = 19,     /**< couldn't read data              */
+    srtp_err_status_write_fail = 20,    /**< couldn't write data             */
+    srtp_err_status_parse_err = 21,     /**< error parsing data              */
+    srtp_err_status_encode_err = 22,    /**< error encoding data             */
+    srtp_err_status_semaphore_err = 23, /**< error while using semaphores    */
+    srtp_err_status_pfkey_err = 24,     /**< error while using pfkey         */
+    srtp_err_status_bad_mki = 25,       /**< error MKI present in packet is  */
+                                        /**< invalid                         */
+    srtp_err_status_pkt_idx_old = 26,   /**< packet index is too old to      */
+                                        /**< consider                        */
+    srtp_err_status_pkt_idx_adv = 27    /**< packet index advanced, reset    */
+                                        /**< needed                          */
 } srtp_err_status_t;
-
 
 typedef struct srtp_ctx_t_ srtp_ctx_t;
 
 /**
- * @brief srtp_sec_serv_t describes a set of security services. 
+ * @brief srtp_sec_serv_t describes a set of security services.
  *
  * A srtp_sec_serv_t enumeration is used to describe the particular
  * security services that will be applied by a particular crypto
- * policy (or other mechanism).  
+ * policy (or other mechanism).
  */
-
 typedef enum {
-  sec_serv_none          = 0, /**< no services                        */
-  sec_serv_conf          = 1, /**< confidentiality                    */
-  sec_serv_auth          = 2, /**< authentication                     */
-  sec_serv_conf_and_auth = 3  /**< confidentiality and authentication */
+    sec_serv_none = 0,         /**< no services                        */
+    sec_serv_conf = 1,         /**< confidentiality                    */
+    sec_serv_auth = 2,         /**< authentication                     */
+    sec_serv_conf_and_auth = 3 /**< confidentiality and authentication */
 } srtp_sec_serv_t;
 
-/** 
+/**
  * @brief srtp_crypto_policy_t describes a particular crypto policy that
  * can be applied to an SRTP stream.
  *
  * A srtp_crypto_policy_t describes a particular cryptographic policy that
  * can be applied to an SRTP or SRTCP stream.  An SRTP session policy
- * consists of a list of these policies, one for each SRTP stream 
+ * consists of a list of these policies, one for each SRTP stream
  * in the session.
  */
-
 typedef struct srtp_crypto_policy_t {
-  srtp_cipher_type_id_t cipher_type;    /**< An integer representing
-				         *   the type of cipher.  */
-  int              cipher_key_len; /**< The length of the cipher key
-				    *   in octets.                       */
-  srtp_auth_type_id_t   auth_type;      /**< An integer representing the
-				         *   authentication function.         */
-  int              auth_key_len;   /**< The length of the authentication 
-				    *   function key in octets.          */
-  int              auth_tag_len;   /**< The length of the authentication 
-				    *   tag in octets.                   */
-  srtp_sec_serv_t  sec_serv;       /**< The flag indicating the security
-				    *   services to be applied.          */
+    srtp_cipher_type_id_t cipher_type; /**< An integer representing          */
+                                       /**< the type of cipher.              */
+    int cipher_key_len;                /**< The length of the cipher key     */
+                                       /**< in octets.                       */
+    srtp_auth_type_id_t auth_type;     /**< An integer representing the      */
+                                       /**< authentication function.         */
+    int auth_key_len;                  /**< The length of the authentication */
+                                       /**< function key in octets.          */
+    int auth_tag_len;                  /**< The length of the authentication */
+                                       /**< tag in octets.                   */
+    srtp_sec_serv_t sec_serv;          /**< The flag indicating the security */
+                                       /**< services to be applied.          */
 } srtp_crypto_policy_t;
 
-
-/** 
+/**
  * @brief srtp_ssrc_type_t describes the type of an SSRC.
- * 
+ *
  * An srtp_ssrc_type_t enumeration is used to indicate a type of SSRC.  See
  * @ref srtp_policy_t for more informataion.
  */
-
-typedef enum { 
-  ssrc_undefined    = 0,  /**< Indicates an undefined SSRC type. */
-  ssrc_specific     = 1,  /**< Indicates a specific SSRC value   */
-  ssrc_any_inbound  = 2, /**< Indicates any inbound SSRC value 
-			    (i.e. a value that is used in the
-			    function srtp_unprotect())              */
-  ssrc_any_outbound = 3  /**< Indicates any outbound SSRC value 
-			    (i.e. a value that is used in the 
-			    function srtp_protect())		  */
+typedef enum {
+    ssrc_undefined = 0,   /**< Indicates an undefined SSRC type.    */
+    ssrc_specific = 1,    /**< Indicates a specific SSRC value      */
+    ssrc_any_inbound = 2, /**< Indicates any inbound SSRC value     */
+                          /**< (i.e. a value that is used in the    */
+                          /**< function srtp_unprotect())           */
+    ssrc_any_outbound = 3 /**< Indicates any outbound SSRC value    */
+                          /**< (i.e. a value that is used in the    */
+                          /**< function srtp_protect())             */
 } srtp_ssrc_type_t;
 
 /**
- * @brief An srtp_ssrc_t represents a particular SSRC value, or a `wildcard' SSRC.
- * 
+ * @brief An srtp_ssrc_t represents a particular SSRC value, or a `wildcard'
+ * SSRC.
+ *
  * An srtp_ssrc_t represents a particular SSRC value (if its type is
  * ssrc_specific), or a wildcard SSRC value that will match all
  * outbound SSRCs (if its type is ssrc_any_outbound) or all inbound
- * SSRCs (if its type is ssrc_any_inbound).  
- *
+ * SSRCs (if its type is ssrc_any_inbound).
  */
-
-typedef struct { 
-  srtp_ssrc_type_t type;  /**< The type of this particular SSRC */
-  unsigned int     value; /**< The value of this SSRC, if it is not a wildcard */
+typedef struct {
+    srtp_ssrc_type_t type; /**< The type of this particular SSRC */
+    unsigned int value;    /**< The value of this SSRC, if it is not a */
+                           /**< wildcard */
 } srtp_ssrc_t;
-
 
 /**
  * @brief points to an EKT policy
  */
 typedef struct srtp_ekt_policy_ctx_t *srtp_ekt_policy_t;
-
 
 /**
  * @brief points to EKT stream data
@@ -285,13 +287,13 @@ typedef struct srtp_ekt_stream_ctx_t *srtp_ekt_stream_t;
  * Index Size to correctly read it from a packet.
  */
 typedef struct srtp_master_key_t {
-  unsigned char *key;
-  unsigned char *mki_id;
-  unsigned int mki_size;
+    unsigned char *key;
+    unsigned char *mki_id;
+    unsigned int mki_size;
 } srtp_master_key_t;
 
-/** 
- * @brief represents the policy for an SRTP session.  
+/**
+ * @brief represents the policy for an SRTP session.
  *
  * A single srtp_policy_t struct represents the policy for a single
  * SRTP stream, and a linked list of these elements represents the
@@ -300,7 +302,7 @@ typedef struct srtp_master_key_t {
  * master key for that stream, the SSRC describing that stream, or a
  * flag indicating a `wildcard' SSRC value, and a `next' field that
  * holds a pointer to the next element in the list of policy elements,
- * or NULL if it is the last element. 
+ * or NULL if it is the last element.
  *
  * The wildcard value SSRC_ANY_INBOUND matches any SSRC from an
  * inbound stream that for which there is no explicit SSRC entry in
@@ -311,47 +313,44 @@ typedef struct srtp_master_key_t {
  * is intentional, and it allows libSRTP to ensure that no security
  * lapses result from accidental re-use of SSRC values during key
  * sharing.
- * 
- * 
+ *
  * @warning The final element of the list @b must have its `next' pointer
  *          set to NULL.
  */
 
 typedef struct srtp_policy_t {
-  srtp_ssrc_t   ssrc;        /**< The SSRC value of stream, or the 
-			      *   flags SSRC_ANY_INBOUND or 
-			      *   SSRC_ANY_OUTBOUND if key sharing
-			      *   is used for this policy element.
-			      */
-  srtp_crypto_policy_t rtp;    /**< SRTP crypto policy.                  */
-  srtp_crypto_policy_t rtcp;   /**< SRTCP crypto policy.                 */
-  unsigned char *key;          /**< Pointer to the SRTP master key for
-                                *    this stream.                        */
-  srtp_master_key_t **keys;    /** Array of Master Key structures */
-  unsigned long num_master_keys;  /** Number of master keys            */
-  srtp_ekt_policy_t ekt;       /**< Pointer to the EKT policy structure
-                                *   for this stream (if any)             */ 
-  unsigned long window_size;   /**< The window size to use for replay
-				*   protection. */
-  int        allow_repeat_tx;  /**< Whether retransmissions of
-				*   packets with the same sequence number
-				*   are allowed.  (Note that such repeated
-				*   transmissions must have the same RTP
-				*   payload, or a severe security weakness
-				*   is introduced!)                      */
-  int *enc_xtn_hdr;            /**< List of header ids to encrypt.       */
-  int enc_xtn_hdr_count;       /**< Number of entries in list of header ids. */
-  struct srtp_policy_t *next;  /**< Pointer to next stream policy.       */
+    srtp_ssrc_t ssrc;              /**< The SSRC value of stream, or the    */
+                                   /**< flags SSRC_ANY_INBOUND or           */
+                                   /**< SSRC_ANY_OUTBOUND if key sharing    */
+                                   /**< is used for this policy element.    */
+    srtp_crypto_policy_t rtp;      /**< SRTP crypto policy.                 */
+    srtp_crypto_policy_t rtcp;     /**< SRTCP crypto policy.                */
+    unsigned char *key;            /**< Pointer to the SRTP master key for  */
+                                   /**< this stream.                        */
+    srtp_master_key_t **keys;      /** Array of Master Key structures       */
+    unsigned long num_master_keys; /** Number of master keys                */
+    srtp_ekt_policy_t ekt;         /**< Pointer to the EKT policy structure */
+                                   /**< for this stream (if any)            */
+    unsigned long window_size;     /**< The window size to use for replay   */
+                                   /**< protection.                         */
+    int allow_repeat_tx;           /**< Whether retransmissions of          */
+                                   /**< packets with the same sequence      */
+                                   /**< number are allowed.                 */
+                                   /**< (Note that such repeated            */
+                                   /**< transmissions must have the same    */
+                                   /**< RTP payload, or a severe security   */
+                                   /**< weakness is introduced!)            */
+    int *enc_xtn_hdr;              /**< List of header ids to encrypt.      */
+    int enc_xtn_hdr_count;         /**< Number of entries in list of header */
+                                   /**<  ids.                               */
+    struct srtp_policy_t *next;    /**< Pointer to next stream policy.      */
 } srtp_policy_t;
-
-
-
 
 /**
  * @brief An srtp_t points to an SRTP session structure.
  *
  * The typedef srtp_t is a pointer to a structure that represents
- * an SRTP session.  This datatype is intentially opaque in 
+ * an SRTP session.  This datatype is intentially opaque in
  * order to separate the interface from the implementation.
  *
  * An SRTP session consists of all of the traffic sent to the RTP and
@@ -359,17 +358,14 @@ typedef struct srtp_policy_t {
  * Audio/Video Profile).  A session can be viewed as a set of SRTP
  * streams, each of which originates with a different participant.
  */
-
 typedef srtp_ctx_t *srtp_t;
 
-
 /**
- * @brief srtp_init() initializes the srtp library.  
+ * @brief srtp_init() initializes the srtp library.
  *
  * @warning This function @b must be called before any other srtp
  * functions.
  */
-
 srtp_err_status_t srtp_init(void);
 
 /**
@@ -377,20 +373,19 @@ srtp_err_status_t srtp_init(void);
  *
  * @warning No srtp functions may be called after calling this function.
  */
-
 srtp_err_status_t srtp_shutdown(void);
 
 /**
  * @brief srtp_protect() is the Secure RTP sender-side packet processing
  * function.
- * 
+ *
  * The function call srtp_protect(ctx, rtp_hdr, len_ptr) applies SRTP
  * protection to the RTP packet rtp_hdr (which has length *len_ptr) using
  * the SRTP context ctx.  If srtp_err_status_ok is returned, then rtp_hdr
  * points to the resulting SRTP packet and *len_ptr is the number of
  * octets in that packet; otherwise, no assumptions should be made
  * about the value of either data elements.
- * 
+ *
  * The sequence numbers of the RTP packets presented to this function
  * need not be consecutive, but they @b must be out of order by less
  * than 2^15 = 32,768 packets.
@@ -400,11 +395,11 @@ srtp_err_status_t srtp_shutdown(void);
  * packet, and assumes that the RTP packet is aligned on a 32-bit
  * boundary.
  *
- * @warning This function assumes that it can write SRTP_MAX_TRAILER_LEN 
- * into the location in memory immediately following the RTP packet.   
- * Callers MUST ensure that this much writable memory is available in 
+ * @warning This function assumes that it can write SRTP_MAX_TRAILER_LEN
+ * into the location in memory immediately following the RTP packet.
+ * Callers MUST ensure that this much writable memory is available in
  * the buffer that holds the RTP packet.
- * 
+ *
  * @param ctx is the SRTP context to use in processing the packet.
  *
  * @param rtp_hdr is a pointer to the RTP packet (before the call); after
@@ -415,25 +410,24 @@ srtp_err_status_t srtp_shutdown(void);
  * complete SRTP packet after the call, if srtp_err_status_ok was returned.
  * Otherwise, the value of the data to which it points is undefined.
  *
- * @return 
+ * @return
  *    - srtp_err_status_ok            no problems
  *    - srtp_err_status_replay_fail   rtp sequence number was non-increasing
  *    - @e other                 failure in cryptographic mechanisms
  */
-
 srtp_err_status_t srtp_protect(srtp_t ctx, void *rtp_hdr, int *len_ptr);
 
 /**
  * @brief srtp_protect_mki() is the Secure RTP sender-side packet processing
  * function that can utilize MKI.
- * 
+ *
  * The function call srtp_protect(ctx, rtp_hdr, len_ptr) applies SRTP
  * protection to the RTP packet rtp_hdr (which has length *len_ptr) using
  * the SRTP context ctx.  If srtp_err_status_ok is returned, then rtp_hdr
  * points to the resulting SRTP packet and *len_ptr is the number of
  * octets in that packet; otherwise, no assumptions should be made
  * about the value of either data elements.
- * 
+ *
  * The sequence numbers of the RTP packets presented to this function
  * need not be consecutive, but they @b must be out of order by less
  * than 2^15 = 32,768 packets.
@@ -443,11 +437,11 @@ srtp_err_status_t srtp_protect(srtp_t ctx, void *rtp_hdr, int *len_ptr);
  * packet, and assumes that the RTP packet is aligned on a 32-bit
  * boundary.
  *
- * @warning This function assumes that it can write SRTP_MAX_TRAILER_LEN 
- * into the location in memory immediately following the RTP packet.   
- * Callers MUST ensure that this much writable memory is available in 
+ * @warning This function assumes that it can write SRTP_MAX_TRAILER_LEN
+ * into the location in memory immediately following the RTP packet.
+ * Callers MUST ensure that this much writable memory is available in
  * the buffer that holds the RTP packet.
- * 
+ *
  * @param ctx is the SRTP context to use in processing the packet.
  *
  * @param rtp_hdr is a pointer to the RTP packet (before the call); after
@@ -458,21 +452,23 @@ srtp_err_status_t srtp_protect(srtp_t ctx, void *rtp_hdr, int *len_ptr);
  * complete SRTP packet after the call, if srtp_err_status_ok was returned.
  * Otherwise, the value of the data to which it points is undefined.
  *
- * @param use_mki is a boolean to tell the system if mki is being used.  If 
- * set to false then will use the first set of session keys.  If set to true will
+ * @param use_mki is a boolean to tell the system if mki is being used.  If
+ * set to false then will use the first set of session keys.  If set to true
+ * will
  * use the session keys identified by the mki_index
  *
  * @param mki_index integer value specifying which set of session keys should be
  * used if use_mki is set to true.
  *
- * @return 
+ * @return
  *    - srtp_err_status_ok            no problems
  *    - srtp_err_status_replay_fail   rtp sequence number was non-increasing
  *    - @e other                 failure in cryptographic mechanisms
  */
-
-srtp_err_status_t srtp_protect_mki(srtp_ctx_t *ctx, void *rtp_hdr,
-                                   int *pkt_octet_len, unsigned int use_mki,
+srtp_err_status_t srtp_protect_mki(srtp_ctx_t *ctx,
+                                   void *rtp_hdr,
+                                   int *pkt_octet_len,
+                                   unsigned int use_mki,
                                    unsigned int mki_index);
 
 /**
@@ -485,12 +481,12 @@ srtp_err_status_t srtp_protect_mki(srtp_ctx_t *ctx, void *rtp_hdr,
  * srtp_err_status_ok is returned, then srtp_hdr points to the resulting
  * RTP packet and *len_ptr is the number of octets in that packet;
  * otherwise, no assumptions should be made about the value of either
- * data elements.  
- * 
+ * data elements.
+ *
  * The sequence numbers of the RTP packets presented to this function
  * need not be consecutive, but they @b must be out of order by less
  * than 2^15 = 32,768 packets.
- * 
+ *
  * @warning This function assumes that the SRTP packet is aligned on a
  * 32-bit boundary.
  *
@@ -506,16 +502,15 @@ srtp_err_status_t srtp_protect_mki(srtp_ctx_t *ctx, void *rtp_hdr,
  * complete rtp packet after the call, if srtp_err_status_ok was returned.
  * Otherwise, the value of the data to which it points is undefined.
  *
- * @return 
+ * @return
  *    - srtp_err_status_ok          if the RTP packet is valid.
- *    - srtp_err_status_auth_fail   if the SRTP packet failed the message 
- *                             authentication check.
- *    - srtp_err_status_replay_fail if the SRTP packet is a replay (e.g. packet has
- *                             already been processed and accepted).
+ *    - srtp_err_status_auth_fail   if the SRTP packet failed the message
+ *                                  authentication check.
+ *    - srtp_err_status_replay_fail if the SRTP packet is a replay (e.g. packet
+ *                                  has already been processed and accepted).
  *    - [other]  if there has been an error in the cryptographic mechanisms.
  *
  */
-
 srtp_err_status_t srtp_unprotect(srtp_t ctx, void *srtp_hdr, int *len_ptr);
 
 /**
@@ -528,12 +523,12 @@ srtp_err_status_t srtp_unprotect(srtp_t ctx, void *srtp_hdr, int *len_ptr);
  * srtp_err_status_ok is returned, then srtp_hdr points to the resulting
  * RTP packet and *len_ptr is the number of octets in that packet;
  * otherwise, no assumptions should be made about the value of either
- * data elements.  
- * 
+ * data elements.
+ *
  * The sequence numbers of the RTP packets presented to this function
  * need not be consecutive, but they @b must be out of order by less
  * than 2^15 = 32,768 packets.
- * 
+ *
  * @warning This function assumes that the SRTP packet is aligned on a
  * 32-bit boundary.
  *
@@ -550,52 +545,52 @@ srtp_err_status_t srtp_unprotect(srtp_t ctx, void *srtp_hdr, int *len_ptr);
  * Otherwise, the value of the data to which it points is undefined.
  *
  * @param use_mki is a boolean to tell the system if mki is being used.  If
- * set to false then will use the first set of session keys.  If set to true will
+ * set to false then will use the first set of session keys.  If set to true
+ * will
  * use the session keys identified by the mki_index
  *
- * @return 
+ * @return
  *    - srtp_err_status_ok          if the RTP packet is valid.
- *    - srtp_err_status_auth_fail   if the SRTP packet failed the message 
- *                             authentication check.
- *    - srtp_err_status_replay_fail if the SRTP packet is a replay (e.g. packet has
- *                             already been processed and accepted).
+ *    - srtp_err_status_auth_fail   if the SRTP packet failed the message
+ *                                  authentication check.
+ *    - srtp_err_status_replay_fail if the SRTP packet is a replay (e.g. packet
+ *                                  has already been processed and accepted).
  *    - srtp_err_status_bad_mki if the MKI in the packet is not a known MKI id
  *    - [other]  if there has been an error in the cryptographic mechanisms.
  *
  */
-
-srtp_err_status_t srtp_unprotect_mki(srtp_t ctx, void *srtp_hdr, int *len_ptr,
+srtp_err_status_t srtp_unprotect_mki(srtp_t ctx,
+                                     void *srtp_hdr,
+                                     int *len_ptr,
                                      unsigned int use_mki);
 
 /**
  * @brief srtp_create() allocates and initializes an SRTP session.
 
  * The function call srtp_create(session, policy) allocates and
- * initializes an SRTP session context, applying the given policy. 
+ * initializes an SRTP session context, applying the given policy.
  *
  * @param session is a pointer to the SRTP session to which the policy is
  * to be added.
- * 
+ *
  * @param policy is the srtp_policy_t struct that describes the policy
  * for the session.  The struct may be a single element, or it may be
  * the head of a list, in which case each element of the list is
  * processed.  It may also be NULL, in which case streams should be added
  * later using srtp_add_stream().  The final element of the list @b must
  * have its `next' field set to NULL.
- * 
+ *
  * @return
  *    - srtp_err_status_ok           if creation succeded.
  *    - srtp_err_status_alloc_fail   if allocation failed.
  *    - srtp_err_status_init_fail    if initialization failed.
  */
-
 srtp_err_status_t srtp_create(srtp_t *session, const srtp_policy_t *policy);
-
 
 /**
  * @brief srtp_add_stream() allocates and initializes an SRTP stream
  * within a given SRTP session.
- * 
+ *
  * The function call srtp_add_stream(session, policy) allocates and
  * initializes a new SRTP stream within a given, previously created
  * session, applying the policy given as the other argument to that
@@ -606,13 +601,11 @@ srtp_err_status_t srtp_create(srtp_t *session, const srtp_policy_t *policy);
  *    - srtp_err_status_alloc_fail   if stream allocation failed
  *    - srtp_err_status_init_fail    if stream initialization failed.
  */
-
 srtp_err_status_t srtp_add_stream(srtp_t session, const srtp_policy_t *policy);
-
 
 /**
  * @brief srtp_remove_stream() deallocates an SRTP stream.
- * 
+ *
  * The function call srtp_remove_stream(session, ssrc) removes
  * the SRTP stream with the SSRC value ssrc from the SRTP session
  * context given by the argument session.
@@ -625,13 +618,12 @@ srtp_err_status_t srtp_add_stream(srtp_t session, const srtp_policy_t *policy);
  *
  * @warning Wildcard SSRC values cannot be removed from a
  *          session.
- * 
+ *
  * @return
  *    - srtp_err_status_ok     if the stream deallocation succeded.
  *    - [other]           otherwise.
  *
  */
-
 srtp_err_status_t srtp_remove_stream(srtp_t session, unsigned int ssrc);
 
 /**
@@ -658,7 +650,6 @@ srtp_err_status_t srtp_remove_stream(srtp_t session, unsigned int ssrc);
  *    - [other]                 otherwise.
  *
  */
-
 srtp_err_status_t srtp_update(srtp_t session, const srtp_policy_t *policy);
 
 /**
@@ -682,15 +673,15 @@ srtp_err_status_t srtp_update(srtp_t session, const srtp_policy_t *policy);
  *    - [other]                      otherwise.
  *
  */
-
-srtp_err_status_t srtp_update_stream(srtp_t session, const srtp_policy_t *policy);
+srtp_err_status_t srtp_update_stream(srtp_t session,
+                                     const srtp_policy_t *policy);
 
 /**
  * @brief srtp_crypto_policy_set_rtp_default() sets a crypto policy
  * structure to the SRTP default policy for RTP protection.
  *
- * @param p is a pointer to the policy structure to be set 
- * 
+ * @param p is a pointer to the policy structure to be set
+ *
  * The function call crypto_policy_set_rtp_default(&p) sets the
  * crypto_policy_t at location p to the SRTP default policy for RTP
  * protection, as defined in the specification.  This function is a
@@ -699,19 +690,18 @@ srtp_err_status_t srtp_update_stream(srtp_t session, const srtp_policy_t *policy
  * with this function call.  Doing so may allow your code to be
  * forward compatible with later versions of libSRTP that include more
  * elements in the crypto_policy_t datatype.
- * 
+ *
  * @return void.
- * 
+ *
  */
-
 void srtp_crypto_policy_set_rtp_default(srtp_crypto_policy_t *p);
 
 /**
  * @brief srtp_crypto_policy_set_rtcp_default() sets a crypto policy
  * structure to the SRTP default policy for RTCP protection.
  *
- * @param p is a pointer to the policy structure to be set 
- * 
+ * @param p is a pointer to the policy structure to be set
+ *
  * The function call srtp_crypto_policy_set_rtcp_default(&p) sets the
  * srtp_crypto_policy_t at location p to the SRTP default policy for RTCP
  * protection, as defined in the specification.  This function is a
@@ -720,37 +710,35 @@ void srtp_crypto_policy_set_rtp_default(srtp_crypto_policy_t *p);
  * with this function call.  Doing so may allow your code to be
  * forward compatible with later versions of libSRTP that include more
  * elements in the srtp_crypto_policy_t datatype.
- * 
+ *
  * @return void.
- * 
+ *
  */
-
 void srtp_crypto_policy_set_rtcp_default(srtp_crypto_policy_t *p);
 
 /**
  * @brief srtp_crypto_policy_set_aes_cm_128_hmac_sha1_80() sets a crypto
  * policy structure to the SRTP default policy for RTP protection.
  *
- * @param p is a pointer to the policy structure to be set 
- * 
+ * @param p is a pointer to the policy structure to be set
+ *
  * The function srtp_crypto_policy_set_aes_cm_128_hmac_sha1_80() is a
  * synonym for srtp_crypto_policy_set_rtp_default().  It conforms to the
  * naming convention used in RFC 4568 (SDP Security Descriptions for
  * Media Streams).
- * 
+ *
  * @return void.
- * 
+ *
  */
-
-#define srtp_crypto_policy_set_aes_cm_128_hmac_sha1_80(p) srtp_crypto_policy_set_rtp_default(p)
-
+#define srtp_crypto_policy_set_aes_cm_128_hmac_sha1_80(p)                      \
+    srtp_crypto_policy_set_rtp_default(p)
 
 /**
  * @brief srtp_crypto_policy_set_aes_cm_128_hmac_sha1_32() sets a crypto
  * policy structure to a short-authentication tag policy
  *
- * @param p is a pointer to the policy structure to be set 
- * 
+ * @param p is a pointer to the policy structure to be set
+ *
  * The function call srtp_crypto_policy_set_aes_cm_128_hmac_sha1_32(&p)
  * sets the srtp_crypto_policy_t at location p to use policy
  * AES_CM_128_HMAC_SHA1_32 as defined in RFC 4568.
@@ -760,7 +748,7 @@ void srtp_crypto_policy_set_rtcp_default(srtp_crypto_policy_t *p);
  * considered adequate only for protecting audio and video media that
  * use a stateless playback function.  See Section 7.5 of RFC 3711
  * (http://www.ietf.org/rfc/rfc3711.txt).
- * 
+ *
  * This function is a convenience that helps to avoid dealing directly
  * with the policy data structure.  You are encouraged to initialize
  * policy elements with this function call.  Doing so may allow your
@@ -773,25 +761,22 @@ void srtp_crypto_policy_set_rtcp_default(srtp_crypto_policy_t *p);
  * (http://www.ietf.org/rfc/rfc3711.txt).
  *
  * @return void.
- * 
+ *
  */
-
 void srtp_crypto_policy_set_aes_cm_128_hmac_sha1_32(srtp_crypto_policy_t *p);
-
-
 
 /**
  * @brief srtp_crypto_policy_set_aes_cm_128_null_auth() sets a crypto
  * policy structure to an encryption-only policy
  *
- * @param p is a pointer to the policy structure to be set 
- * 
+ * @param p is a pointer to the policy structure to be set
+ *
  * The function call srtp_crypto_policy_set_aes_cm_128_null_auth(&p) sets
  * the srtp_crypto_policy_t at location p to use the SRTP default cipher
  * (AES-128 Counter Mode), but to use no authentication method.  This
  * policy is NOT RECOMMENDED unless it is unavoidable; see Section 7.5
  * of RFC 3711 (http://www.ietf.org/rfc/rfc3711.txt).
- * 
+ *
  * This function is a convenience that helps to avoid dealing directly
  * with the policy data structure.  You are encouraged to initialize
  * policy elements with this function call.  Doing so may allow your
@@ -803,24 +788,22 @@ void srtp_crypto_policy_set_aes_cm_128_hmac_sha1_32(srtp_crypto_policy_t *p);
  * Section 7.5 of RFC 3711 (http://www.ietf.org/rfc/rfc3711.txt).
  *
  * @return void.
- * 
+ *
  */
-
 void srtp_crypto_policy_set_aes_cm_128_null_auth(srtp_crypto_policy_t *p);
-
 
 /**
  * @brief srtp_crypto_policy_set_null_cipher_hmac_sha1_80() sets a crypto
  * policy structure to an authentication-only policy
  *
- * @param p is a pointer to the policy structure to be set 
- * 
+ * @param p is a pointer to the policy structure to be set
+ *
  * The function call srtp_crypto_policy_set_null_cipher_hmac_sha1_80(&p)
  * sets the srtp_crypto_policy_t at location p to use HMAC-SHA1 with an 80
  * bit authentication tag to provide message authentication, but to
  * use no encryption.  This policy is NOT RECOMMENDED for SRTP unless
- * there is a requirement to forego encryption.  
- * 
+ * there is a requirement to forego encryption.
+ *
  * This function is a convenience that helps to avoid dealing directly
  * with the policy data structure.  You are encouraged to initialize
  * policy elements with this function call.  Doing so may allow your
@@ -828,24 +811,24 @@ void srtp_crypto_policy_set_aes_cm_128_null_auth(srtp_crypto_policy_t *p);
  * include more elements in the srtp_crypto_policy_t datatype.
  *
  * @warning This policy is NOT RECOMMENDED for SRTP unless there is a
- * requirement to forego encryption.  
+ * requirement to forego encryption.
  *
  * @return void.
- * 
+ *
  */
 void srtp_crypto_policy_set_null_cipher_hmac_sha1_80(srtp_crypto_policy_t *p);
 
 /**
  * @brief srtp_crypto_policy_set_null_cipher_hmac_null() sets a crypto
- * policy structure to use no encryption or authentication. 
+ * policy structure to use no encryption or authentication.
  *
- * @param p is a pointer to the policy structure to be set 
- * 
+ * @param p is a pointer to the policy structure to be set
+ *
  * The function call srtp_crypto_policy_set_null_cipher_hmac_null(&p)
  * sets the srtp_crypto_policy_t at location p to use no encryption and
  * no authentication.  This policy should only be used for testing and
- * troubleshootingl. 
- * 
+ * troubleshootingl.
+ *
  * This function is a convenience that helps to avoid dealing directly
  * with the policy data structure.  You are encouraged to initialize
  * policy elements with this function call.  Doing so may allow your
@@ -853,27 +836,26 @@ void srtp_crypto_policy_set_null_cipher_hmac_sha1_80(srtp_crypto_policy_t *p);
  * include more elements in the srtp_crypto_policy_t datatype.
  *
  * @warning This policy is NOT RECOMMENDED for SRTP unless there is a
- * requirement to forego encryption and authentication.  
+ * requirement to forego encryption and authentication.
  *
  * @return void.
- * 
+ *
  */
 void srtp_crypto_policy_set_null_cipher_hmac_null(srtp_crypto_policy_t *p);
 
-
 /**
  * @brief srtp_crypto_policy_set_aes_cm_256_hmac_sha1_80() sets a crypto
- * policy structure to a encryption and authentication policy using AES-256 
+ * policy structure to a encryption and authentication policy using AES-256
  * for RTP protection.
  *
- * @param p is a pointer to the policy structure to be set 
- * 
+ * @param p is a pointer to the policy structure to be set
+ *
  * The function call srtp_crypto_policy_set_aes_cm_256_hmac_sha1_80(&p)
  * sets the srtp_crypto_policy_t at location p to use policy
  * AES_CM_256_HMAC_SHA1_80 as defined in RFC 6188.  This policy uses AES-256
  * Counter Mode encryption and HMAC-SHA1 authentication, with an 80 bit
  * authentication tag.
- * 
+ *
  * This function is a convenience that helps to avoid dealing directly
  * with the policy data structure.  You are encouraged to initialize
  * policy elements with this function call.  Doing so may allow your
@@ -881,19 +863,17 @@ void srtp_crypto_policy_set_null_cipher_hmac_null(srtp_crypto_policy_t *p);
  * include more elements in the srtp_crypto_policy_t datatype.
  *
  * @return void.
- * 
+ *
  */
-
 void srtp_crypto_policy_set_aes_cm_256_hmac_sha1_80(srtp_crypto_policy_t *p);
-
 
 /**
  * @brief srtp_crypto_policy_set_aes_cm_256_hmac_sha1_32() sets a crypto
  * policy structure to a short-authentication tag policy using AES-256
  * encryption.
  *
- * @param p is a pointer to the policy structure to be set 
- * 
+ * @param p is a pointer to the policy structure to be set
+ *
  * The function call srtp_crypto_policy_set_aes_cm_256_hmac_sha1_32(&p)
  * sets the srtp_crypto_policy_t at location p to use policy
  * AES_CM_256_HMAC_SHA1_32 as defined in RFC 6188.  This policy uses AES-256
@@ -902,7 +882,7 @@ void srtp_crypto_policy_set_aes_cm_256_hmac_sha1_80(srtp_crypto_policy_t *p);
  * considered adequate only for protecting audio and video media that
  * use a stateless playback function.  See Section 7.5 of RFC 3711
  * (http://www.ietf.org/rfc/rfc3711.txt).
- * 
+ *
  * This function is a convenience that helps to avoid dealing directly
  * with the policy data structure.  You are encouraged to initialize
  * policy elements with this function call.  Doing so may allow your
@@ -915,9 +895,8 @@ void srtp_crypto_policy_set_aes_cm_256_hmac_sha1_80(srtp_crypto_policy_t *p);
  * (http://www.ietf.org/rfc/rfc3711.txt).
  *
  * @return void.
- * 
+ *
  */
-
 void srtp_crypto_policy_set_aes_cm_256_hmac_sha1_32(srtp_crypto_policy_t *p);
 
 /**
@@ -947,7 +926,6 @@ void srtp_crypto_policy_set_aes_cm_256_hmac_sha1_32(srtp_crypto_policy_t *p);
  */
 void srtp_crypto_policy_set_aes_cm_256_null_auth(srtp_crypto_policy_t *p);
 
-
 /**
  * @brief srtp_crypto_policy_set_aes_cm_192_hmac_sha1_80() sets a crypto
  * policy structure to a encryption and authentication policy using AES-192
@@ -971,7 +949,6 @@ void srtp_crypto_policy_set_aes_cm_256_null_auth(srtp_crypto_policy_t *p);
  *
  */
 void srtp_crypto_policy_set_aes_cm_192_hmac_sha1_80(srtp_crypto_policy_t *p);
-
 
 /**
  * @brief srtp_crypto_policy_set_aes_cm_192_hmac_sha1_32() sets a crypto
@@ -1005,7 +982,6 @@ void srtp_crypto_policy_set_aes_cm_192_hmac_sha1_80(srtp_crypto_policy_t *p);
  */
 void srtp_crypto_policy_set_aes_cm_192_hmac_sha1_32(srtp_crypto_policy_t *p);
 
-
 /**
  * @brief srtp_crypto_policy_set_aes_cm_192_null_auth() sets a crypto
  * policy structure to an encryption-only policy
@@ -1033,19 +1009,18 @@ void srtp_crypto_policy_set_aes_cm_192_hmac_sha1_32(srtp_crypto_policy_t *p);
  */
 void srtp_crypto_policy_set_aes_cm_192_null_auth(srtp_crypto_policy_t *p);
 
-
 /**
  * @brief srtp_crypto_policy_set_aes_gcm_128_8_auth() sets a crypto
  * policy structure to an AEAD encryption policy.
  *
- * @param p is a pointer to the policy structure to be set 
- * 
+ * @param p is a pointer to the policy structure to be set
+ *
  * The function call srtp_crypto_policy_set_aes_gcm_128_8_auth(&p) sets
  * the srtp_crypto_policy_t at location p to use the SRTP default cipher
  * (AES-128 Galois Counter Mode) with 8 octet auth tag.  This
  * policy applies confidentiality and authentication to both the
  * RTP and RTCP packets.
- * 
+ *
  * This function is a convenience that helps to avoid dealing directly
  * with the policy data structure.  You are encouraged to initialize
  * policy elements with this function call.  Doing so may allow your
@@ -1053,7 +1028,7 @@ void srtp_crypto_policy_set_aes_cm_192_null_auth(srtp_crypto_policy_t *p);
  * include more elements in the srtp_crypto_policy_t datatype.
  *
  * @return void.
- * 
+ *
  */
 void srtp_crypto_policy_set_aes_gcm_128_8_auth(srtp_crypto_policy_t *p);
 
@@ -1061,14 +1036,14 @@ void srtp_crypto_policy_set_aes_gcm_128_8_auth(srtp_crypto_policy_t *p);
  * @brief srtp_crypto_policy_set_aes_gcm_256_8_auth() sets a crypto
  * policy structure to an AEAD encryption policy
  *
- * @param p is a pointer to the policy structure to be set 
- * 
+ * @param p is a pointer to the policy structure to be set
+ *
  * The function call srtp_crypto_policy_set_aes_gcm_256_8_auth(&p) sets
  * the srtp_crypto_policy_t at location p to use the SRTP default cipher
- * (AES-256 Galois Counter Mode) with 8 octet auth tag.  This 
+ * (AES-256 Galois Counter Mode) with 8 octet auth tag.  This
  * policy applies confidentiality and authentication to both the
  * RTP and RTCP packets.
- * 
+ *
  * This function is a convenience that helps to avoid dealing directly
  * with the policy data structure.  You are encouraged to initialize
  * policy elements with this function call.  Doing so may allow your
@@ -1076,7 +1051,7 @@ void srtp_crypto_policy_set_aes_gcm_128_8_auth(srtp_crypto_policy_t *p);
  * include more elements in the srtp_crypto_policy_t datatype.
  *
  * @return void.
- * 
+ *
  */
 void srtp_crypto_policy_set_aes_gcm_256_8_auth(srtp_crypto_policy_t *p);
 
@@ -1084,14 +1059,14 @@ void srtp_crypto_policy_set_aes_gcm_256_8_auth(srtp_crypto_policy_t *p);
  * @brief srtp_crypto_policy_set_aes_gcm_128_8_only_auth() sets a crypto
  * policy structure to an AEAD authentication-only policy
  *
- * @param p is a pointer to the policy structure to be set 
- * 
+ * @param p is a pointer to the policy structure to be set
+ *
  * The function call srtp_crypto_policy_set_aes_gcm_128_8_only_auth(&p) sets
  * the srtp_crypto_policy_t at location p to use the SRTP default cipher
- * (AES-128 Galois Counter Mode) with 8 octet auth tag.  This policy 
- * applies confidentiality and authentication to the RTP packets, 
+ * (AES-128 Galois Counter Mode) with 8 octet auth tag.  This policy
+ * applies confidentiality and authentication to the RTP packets,
  * but only authentication to the RTCP packets.
- * 
+ *
  * This function is a convenience that helps to avoid dealing directly
  * with the policy data structure.  You are encouraged to initialize
  * policy elements with this function call.  Doing so may allow your
@@ -1099,7 +1074,7 @@ void srtp_crypto_policy_set_aes_gcm_256_8_auth(srtp_crypto_policy_t *p);
  * include more elements in the srtp_crypto_policy_t datatype.
  *
  * @return void.
- * 
+ *
  */
 void srtp_crypto_policy_set_aes_gcm_128_8_only_auth(srtp_crypto_policy_t *p);
 
@@ -1107,14 +1082,14 @@ void srtp_crypto_policy_set_aes_gcm_128_8_only_auth(srtp_crypto_policy_t *p);
  * @brief srtp_crypto_policy_set_aes_gcm_256_8_only_auth() sets a crypto
  * policy structure to an AEAD authentication-only policy
  *
- * @param p is a pointer to the policy structure to be set 
- * 
+ * @param p is a pointer to the policy structure to be set
+ *
  * The function call srtp_crypto_policy_set_aes_gcm_256_8_only_auth(&p) sets
  * the srtp_crypto_policy_t at location p to use the SRTP default cipher
- * (AES-256 Galois Counter Mode) with 8 octet auth tag.  This policy 
- * applies confidentiality and authentication to the RTP packets, 
+ * (AES-256 Galois Counter Mode) with 8 octet auth tag.  This policy
+ * applies confidentiality and authentication to the RTP packets,
  * but only authentication to the RTCP packets.
- * 
+ *
  * This function is a convenience that helps to avoid dealing directly
  * with the policy data structure.  You are encouraged to initialize
  * policy elements with this function call.  Doing so may allow your
@@ -1122,7 +1097,7 @@ void srtp_crypto_policy_set_aes_gcm_128_8_only_auth(srtp_crypto_policy_t *p);
  * include more elements in the srtp_crypto_policy_t datatype.
  *
  * @return void.
- * 
+ *
  */
 void srtp_crypto_policy_set_aes_gcm_256_8_only_auth(srtp_crypto_policy_t *p);
 
@@ -1130,14 +1105,14 @@ void srtp_crypto_policy_set_aes_gcm_256_8_only_auth(srtp_crypto_policy_t *p);
  * @brief srtp_crypto_policy_set_aes_gcm_128_16_auth() sets a crypto
  * policy structure to an AEAD encryption policy.
  *
- * @param p is a pointer to the policy structure to be set 
- * 
+ * @param p is a pointer to the policy structure to be set
+ *
  * The function call srtp_crypto_policy_set_aes_gcm_128_16_auth(&p) sets
  * the srtp_crypto_policy_t at location p to use the SRTP default cipher
  * (AES-128 Galois Counter Mode) with 16 octet auth tag.  This
  * policy applies confidentiality and authentication to both the
  * RTP and RTCP packets.
- * 
+ *
  * This function is a convenience that helps to avoid dealing directly
  * with the policy data structure.  You are encouraged to initialize
  * policy elements with this function call.  Doing so may allow your
@@ -1145,7 +1120,7 @@ void srtp_crypto_policy_set_aes_gcm_256_8_only_auth(srtp_crypto_policy_t *p);
  * include more elements in the srtp_crypto_policy_t datatype.
  *
  * @return void.
- * 
+ *
  */
 void srtp_crypto_policy_set_aes_gcm_128_16_auth(srtp_crypto_policy_t *p);
 
@@ -1153,14 +1128,14 @@ void srtp_crypto_policy_set_aes_gcm_128_16_auth(srtp_crypto_policy_t *p);
  * @brief srtp_crypto_policy_set_aes_gcm_256_16_auth() sets a crypto
  * policy structure to an AEAD encryption policy
  *
- * @param p is a pointer to the policy structure to be set 
- * 
+ * @param p is a pointer to the policy structure to be set
+ *
  * The function call srtp_crypto_policy_set_aes_gcm_256_16_auth(&p) sets
  * the srtp_crypto_policy_t at location p to use the SRTP default cipher
- * (AES-256 Galois Counter Mode) with 16 octet auth tag.  This 
+ * (AES-256 Galois Counter Mode) with 16 octet auth tag.  This
  * policy applies confidentiality and authentication to both the
  * RTP and RTCP packets.
- * 
+ *
  * This function is a convenience that helps to avoid dealing directly
  * with the policy data structure.  You are encouraged to initialize
  * policy elements with this function call.  Doing so may allow your
@@ -1168,15 +1143,14 @@ void srtp_crypto_policy_set_aes_gcm_128_16_auth(srtp_crypto_policy_t *p);
  * include more elements in the srtp_crypto_policy_t datatype.
  *
  * @return void.
- * 
+ *
  */
 void srtp_crypto_policy_set_aes_gcm_256_16_auth(srtp_crypto_policy_t *p);
-
 
 /**
  * @brief srtp_dealloc() deallocates storage for an SRTP session
  * context.
- * 
+ *
  * The function call srtp_dealloc(s) deallocates storage for the
  * SRTP session context s.  This function should be called no more
  * than one time for each of the contexts allocated by the function
@@ -1188,29 +1162,25 @@ void srtp_crypto_policy_set_aes_gcm_256_16_auth(srtp_crypto_policy_t *p);
  *    - srtp_err_status_ok             if there no problems.
  *    - srtp_err_status_dealloc_fail   a memory deallocation failure occured.
  */
-
 srtp_err_status_t srtp_dealloc(srtp_t s);
 
-
 /*
- * @brief identifies a particular SRTP profile 
+ * @brief identifies a particular SRTP profile
  *
  * An srtp_profile_t enumeration is used to identify a particular SRTP
  * profile (that is, a set of algorithms and parameters). These profiles
  * are defined for DTLS-SRTP:
  * https://www.iana.org/assignments/srtp-protection/srtp-protection.xhtml
  */
-
 typedef enum {
-  srtp_profile_reserved           = 0,
-  srtp_profile_aes128_cm_sha1_80  = 1,
-  srtp_profile_aes128_cm_sha1_32  = 2,
-  srtp_profile_null_sha1_80       = 5,
-  srtp_profile_null_sha1_32       = 6,
-  srtp_profile_aead_aes_128_gcm   = 7,
-  srtp_profile_aead_aes_256_gcm   = 8,
+    srtp_profile_reserved = 0,
+    srtp_profile_aes128_cm_sha1_80 = 1,
+    srtp_profile_aes128_cm_sha1_32 = 2,
+    srtp_profile_null_sha1_80 = 5,
+    srtp_profile_null_sha1_32 = 6,
+    srtp_profile_aead_aes_128_gcm = 7,
+    srtp_profile_aead_aes_256_gcm = 8,
 } srtp_profile_t;
-
 
 /**
  * @brief srtp_crypto_policy_set_from_profile_for_rtp() sets a crypto policy
@@ -1232,13 +1202,12 @@ typedef enum {
  *
  * @return values
  *     - srtp_err_status_ok         no problems were encountered
- *     - srtp_err_status_bad_param  the profile is not supported 
+ *     - srtp_err_status_bad_param  the profile is not supported
  *
  */
-srtp_err_status_t srtp_crypto_policy_set_from_profile_for_rtp(srtp_crypto_policy_t *policy, srtp_profile_t profile);
-
-
-
+srtp_err_status_t
+srtp_crypto_policy_set_from_profile_for_rtp(srtp_crypto_policy_t *policy,
+                                            srtp_profile_t profile);
 
 /**
  * @brief srtp_crypto_policy_set_from_profile_for_rtcp() sets a crypto policy
@@ -1263,48 +1232,43 @@ srtp_err_status_t srtp_crypto_policy_set_from_profile_for_rtp(srtp_crypto_policy
  *     - srtp_err_status_bad_param  the profile is not supported
  *
  */
-srtp_err_status_t srtp_crypto_policy_set_from_profile_for_rtcp(srtp_crypto_policy_t *policy, srtp_profile_t profile);
+srtp_err_status_t
+srtp_crypto_policy_set_from_profile_for_rtcp(srtp_crypto_policy_t *policy,
+                                             srtp_profile_t profile);
 
 /**
  * @brief returns the master key length for a given SRTP profile
  */
-unsigned int
-srtp_profile_get_master_key_length(srtp_profile_t profile);
-
+unsigned int srtp_profile_get_master_key_length(srtp_profile_t profile);
 
 /**
  * @brief returns the master salt length for a given SRTP profile
  */
-unsigned int
-srtp_profile_get_master_salt_length(srtp_profile_t profile);
+unsigned int srtp_profile_get_master_salt_length(srtp_profile_t profile);
 
 /**
  * @brief appends the salt to the key
  *
- * The function call srtp_append_salt_to_key(k, klen, s, slen) 
+ * The function call srtp_append_salt_to_key(k, klen, s, slen)
  * copies the string s to the location at klen bytes following
- * the location k.  
+ * the location k.
  *
  * @warning There must be at least bytes_in_salt + bytes_in_key bytes
  *          available at the location pointed to by key.
- * 
+ *
  */
-
-void
-srtp_append_salt_to_key(unsigned char *key, unsigned int bytes_in_key,
-	  	        unsigned char *salt, unsigned int bytes_in_salt);
-
-
+void srtp_append_salt_to_key(unsigned char *key,
+                             unsigned int bytes_in_key,
+                             unsigned char *salt,
+                             unsigned int bytes_in_salt);
 
 /**
  * @}
  */
 
-
-
 /**
  * @defgroup SRTCP Secure RTCP
- * @ingroup  SRTP 
+ * @ingroup  SRTP
  *
  * @brief Secure RTCP functions are used to protect RTCP traffic.
  *
@@ -1312,36 +1276,36 @@ srtp_append_salt_to_key(unsigned char *key, unsigned int bytes_in_key,
  * traffic in much the same way as it does RTP traffic.  The function
  * srtp_protect_rtcp() applies cryptographic protections to outbound
  * RTCP packets, and srtp_unprotect_rtcp() verifies the protections on
- * inbound RTCP packets.  
+ * inbound RTCP packets.
  *
  * A note on the naming convention: srtp_protect_rtcp() has an srtp_t
  * as its first argument, and thus has `srtp_' as its prefix.  The
- * trailing `_rtcp' indicates the protocol on which it acts.  
- * 
+ * trailing `_rtcp' indicates the protocol on which it acts.
+ *
  * @{
  */
 
 /**
  * @brief srtp_protect_rtcp() is the Secure RTCP sender-side packet
  * processing function.
- * 
+ *
  * The function call srtp_protect_rtcp(ctx, rtp_hdr, len_ptr) applies
  * SRTCP protection to the RTCP packet rtcp_hdr (which has length
  * *len_ptr) using the SRTP session context ctx.  If srtp_err_status_ok is
  * returned, then rtp_hdr points to the resulting SRTCP packet and
  * *len_ptr is the number of octets in that packet; otherwise, no
  * assumptions should be made about the value of either data elements.
- * 
+ *
  * @warning This function assumes that it can write the authentication
  * tag into the location in memory immediately following the RTCP
  * packet, and assumes that the RTCP packet is aligned on a 32-bit
  * boundary.
  *
- * @warning This function assumes that it can write SRTP_MAX_TRAILER_LEN+4 
- * into the location in memory immediately following the RTCP packet.   
- * Callers MUST ensure that this much writable memory is available in 
+ * @warning This function assumes that it can write SRTP_MAX_TRAILER_LEN+4
+ * into the location in memory immediately following the RTCP packet.
+ * Callers MUST ensure that this much writable memory is available in
  * the buffer that holds the RTCP packet.
- * 
+ *
  * @param ctx is the SRTP context to use in processing the packet.
  *
  * @param rtcp_hdr is a pointer to the RTCP packet (before the call); after
@@ -1353,37 +1317,35 @@ srtp_append_salt_to_key(unsigned char *key, unsigned int bytes_in_key,
  * was returned.  Otherwise, the value of the data to which it points
  * is undefined.
  *
- * @return 
+ * @return
  *    - srtp_err_status_ok            if there were no problems.
- *    - [other]                  if there was a failure in 
+ *    - [other]                  if there was a failure in
  *                               the cryptographic mechanisms.
  */
-	     
-
-srtp_err_status_t srtp_protect_rtcp(srtp_t ctx, void *rtcp_hdr, int *pkt_octet_len);
-
+srtp_err_status_t
+srtp_protect_rtcp(srtp_t ctx, void *rtcp_hdr, int *pkt_octet_len);
 
 /**
  * @brief srtp_protect_rtcp_mki() is the Secure RTCP sender-side packet
  * processing function that can utilize mki.
- * 
+ *
  * The function call srtp_protect_rtcp(ctx, rtp_hdr, len_ptr) applies
  * SRTCP protection to the RTCP packet rtcp_hdr (which has length
  * *len_ptr) using the SRTP session context ctx.  If srtp_err_status_ok is
  * returned, then rtp_hdr points to the resulting SRTCP packet and
  * *len_ptr is the number of octets in that packet; otherwise, no
  * assumptions should be made about the value of either data elements.
- * 
+ *
  * @warning This function assumes that it can write the authentication
  * tag into the location in memory immediately following the RTCP
  * packet, and assumes that the RTCP packet is aligned on a 32-bit
  * boundary.
  *
- * @warning This function assumes that it can write SRTP_MAX_TRAILER_LEN+4 
- * into the location in memory immediately following the RTCP packet.   
- * Callers MUST ensure that this much writable memory is available in 
+ * @warning This function assumes that it can write SRTP_MAX_TRAILER_LEN+4
+ * into the location in memory immediately following the RTCP packet.
+ * Callers MUST ensure that this much writable memory is available in
  * the buffer that holds the RTCP packet.
- * 
+ *
  * @param ctx is the SRTP context to use in processing the packet.
  *
  * @param rtcp_hdr is a pointer to the RTCP packet (before the call); after
@@ -1395,21 +1357,24 @@ srtp_err_status_t srtp_protect_rtcp(srtp_t ctx, void *rtcp_hdr, int *pkt_octet_l
  * was returned.  Otherwise, the value of the data to which it points
  * is undefined.
  *
- * @param use_mki is a boolean to tell the system if mki is being used.  If 
- * set to false then will use the first set of session keys.  If set to true will
+ * @param use_mki is a boolean to tell the system if mki is being used.  If
+ * set to false then will use the first set of session keys.  If set to true
+ * will
  * use the session keys identified by the mki_index
  *
  * @param mki_index integer value specifying which set of session kesy should be
  * used if use_mki is set to true.
  *
- * @return 
+ * @return
  *    - srtp_err_status_ok            if there were no problems.
- *    - [other]                  if there was a failure in 
+ *    - [other]                  if there was a failure in
  *                               the cryptographic mechanisms.
  */
-
-srtp_err_status_t srtp_protect_rtcp_mki(srtp_t ctx, void *rtcp_hdr, int *pkt_octet_len,
-                                        unsigned int use_mki, unsigned int mki_index);
+srtp_err_status_t srtp_protect_rtcp_mki(srtp_t ctx,
+                                        void *rtcp_hdr,
+                                        int *pkt_octet_len,
+                                        unsigned int use_mki,
+                                        unsigned int mki_index);
 
 /**
  * @brief srtp_unprotect_rtcp() is the Secure RTCP receiver-side packet
@@ -1422,7 +1387,7 @@ srtp_err_status_t srtp_protect_rtcp_mki(srtp_t ctx, void *rtcp_hdr, int *pkt_oct
  * to the resulting RTCP packet and *len_ptr is the number of octets
  * in that packet; otherwise, no assumptions should be made about the
  * value of either data elements.
- * 
+ *
  * @warning This function assumes that the SRTCP packet is aligned on a
  * 32-bit boundary.
  *
@@ -1440,17 +1405,17 @@ srtp_err_status_t srtp_protect_rtcp_mki(srtp_t ctx, void *rtcp_hdr, int *pkt_oct
  * returned.  Otherwise, the value of the data to which it points is
  * undefined.
  *
- * @return 
+ * @return
  *    - srtp_err_status_ok          if the RTCP packet is valid.
- *    - srtp_err_status_auth_fail   if the SRTCP packet failed the message 
+ *    - srtp_err_status_auth_fail   if the SRTCP packet failed the message
  *                             authentication check.
  *    - srtp_err_status_replay_fail if the SRTCP packet is a replay (e.g. has
  *                             already been processed and accepted).
  *    - [other]  if there has been an error in the cryptographic mechanisms.
  *
  */
-
-srtp_err_status_t srtp_unprotect_rtcp(srtp_t ctx, void *srtcp_hdr, int *pkt_octet_len);
+srtp_err_status_t
+srtp_unprotect_rtcp(srtp_t ctx, void *srtcp_hdr, int *pkt_octet_len);
 
 /**
  * @brief srtp_unprotect_rtcp() is the Secure RTCP receiver-side packet
@@ -1463,7 +1428,7 @@ srtp_err_status_t srtp_unprotect_rtcp(srtp_t ctx, void *srtcp_hdr, int *pkt_octe
  * to the resulting RTCP packet and *len_ptr is the number of octets
  * in that packet; otherwise, no assumptions should be made about the
  * value of either data elements.
- * 
+ *
  * @warning This function assumes that the SRTCP packet is aligned on a
  * 32-bit boundary.
  *
@@ -1482,28 +1447,29 @@ srtp_err_status_t srtp_unprotect_rtcp(srtp_t ctx, void *srtcp_hdr, int *pkt_octe
  * undefined.
  *
  * @param use_mki is a boolean to tell the system if mki is being used.  If
- * set to false then will use the first set of session keys.  If set to true will
- * use the session keys identified by the mki_index
+ * set to false then will use the first set of session keys.  If set to true
+ * will use the session keys identified by the mki_index
  *
- * @return 
+ * @return
  *    - srtp_err_status_ok          if the RTCP packet is valid.
- *    - srtp_err_status_auth_fail   if the SRTCP packet failed the message 
- *                             authentication check.
+ *    - srtp_err_status_auth_fail   if the SRTCP packet failed the message
+ *                                  authentication check.
  *    - srtp_err_status_replay_fail if the SRTCP packet is a replay (e.g. has
- *                             already been processed and accepted).
- *    - srtp_err_status_bad_mki if the MKI in the packet is not a known MKI id
- *    - [other]  if there has been an error in the cryptographic mechanisms.
+ *                                  already been processed and accepted).
+ *    - srtp_err_status_bad_mki     if the MKI in the packet is not a known MKI
+ *                                  id
+ *    - [other]                     if there has been an error in the
+ *                                  cryptographic mechanisms.
  *
  */
-
-srtp_err_status_t srtp_unprotect_rtcp_mki(srtp_t ctx, void *srtcp_hdr,
+srtp_err_status_t srtp_unprotect_rtcp_mki(srtp_t ctx,
+                                          void *srtcp_hdr,
                                           int *pkt_octet_len,
                                           unsigned int use_mki);
 
 /**
  * @}
  */
-
 
 /**
  * @defgroup User data associated to a SRTP session.
@@ -1527,9 +1493,7 @@ srtp_err_status_t srtp_unprotect_rtcp_mki(srtp_t ctx, void *srtcp_hdr,
  * @return void.
  *
  */
-
-void
-srtp_set_user_data(srtp_t ctx, void *data);
+void srtp_set_user_data(srtp_t ctx, void *data);
 
 /**
  * @brief srtp_get_user_data() retrieves the pointer to the custom data
@@ -1546,23 +1510,20 @@ srtp_set_user_data(srtp_t ctx, void *data);
  * @return void* pointer to the user data.
  *
  */
-
-void*
-srtp_get_user_data(srtp_t ctx);
+void *srtp_get_user_data(srtp_t ctx);
 
 /**
  * @}
  */
 
-
 /**
  * @defgroup SRTPevents SRTP events and callbacks
  * @ingroup  SRTP
  *
- * @brief libSRTP can use a user-provided callback function to 
+ * @brief libSRTP can use a user-provided callback function to
  * handle events.
  *
- * 
+ *
  * libSRTP allows a user to provide a callback function to handle
  * events that need to be dealt with outside of the data plane (see
  * the enum srtp_event_t for a description of these events).  Dealing
@@ -1583,8 +1544,8 @@ srtp_get_user_data(srtp_t ctx);
  * @brief srtp_event_t defines events that need to be handled
  *
  * The enum srtp_event_t defines events that need to be handled
- * outside the `data plane', such as SSRC collisions and 
- * key expirations.  
+ * outside the `data plane', such as SSRC collisions and
+ * key expirations.
  *
  * When a key expires or the maximum number of packets has been
  * reached, an SRTP stream will enter an `expired' state in which no
@@ -1596,34 +1557,28 @@ srtp_get_user_data(srtp_t ctx);
  * are unaffected, unless key sharing is used by that stream.  In the
  * latter case, all of the streams in the session will expire.
  */
-
-typedef enum { 
-  event_ssrc_collision,    /**<
-			    * An SSRC collision occured.             
-			    */
-  event_key_soft_limit,    /**< An SRTP stream reached the soft key
-			    *   usage limit and will expire soon.	   
-			    */
-  event_key_hard_limit,    /**< An SRTP stream reached the hard 
-			    *   key usage limit and has expired.
-			    */
-  event_packet_index_limit /**< An SRTP stream reached the hard 
-			    * packet limit (2^48 packets).             
-			    */
+typedef enum {
+    event_ssrc_collision,    /**< An SSRC collision occured.            */
+    event_key_soft_limit,    /**< An SRTP stream reached the soft key   */
+                             /**< usage limit and will expire soon.     */
+    event_key_hard_limit,    /**< An SRTP stream reached the hard       */
+                             /**< key usage limit and has expired.      */
+    event_packet_index_limit /**< An SRTP stream reached the hard       */
+                             /**< packet limit (2^48 packets).          */
 } srtp_event_t;
 
 /**
- * @brief srtp_event_data_t is the structure passed as a callback to 
+ * @brief srtp_event_data_t is the structure passed as a callback to
  * the event handler function
  *
  * The struct srtp_event_data_t holds the data passed to the event
- * handler function.  
+ * handler function.
  */
-
 typedef struct srtp_event_data_t {
-  srtp_t        session;  /**< The session in which the event happend. */
-  uint32_t      ssrc;     /**< The ssrc in host order of the stream in which the event happend */
-  srtp_event_t  event;    /**< An enum indicating the type of event.   */
+    srtp_t session;     /**< The session in which the event happend.        */
+    uint32_t ssrc;      /**< The ssrc in host order of the stream in which  */
+                        /**< the event happend                              */
+    srtp_event_t event; /**< An enum indicating the type of event.          */
 } srtp_event_data_t;
 
 /**
@@ -1636,12 +1591,11 @@ typedef struct srtp_event_data_t {
  * There can only be a single, global handler for all events in
  * libSRTP.
  */
-
-typedef void (srtp_event_handler_func_t)(srtp_event_data_t *data);
+typedef void(srtp_event_handler_func_t)(srtp_event_data_t *data);
 
 /**
  * @brief sets the event handler to the function supplied by the caller.
- * 
+ *
  * The function call srtp_install_event_handler(func) sets the event
  * handler function to the value func.  The value NULL is acceptable
  * as an argument; in this case, events will be ignored rather than
@@ -1651,24 +1605,23 @@ typedef void (srtp_event_handler_func_t)(srtp_event_data_t *data);
  *             pointer as an argument and returns void.  This function
  *             will be used by libSRTP to handle events.
  */
-
 srtp_err_status_t srtp_install_event_handler(srtp_event_handler_func_t func);
 
 /**
- * @brief Returns the version string of the library. 
- * 
+ * @brief Returns the version string of the library.
+ *
  */
 const char *srtp_get_version_string(void);
 
 /**
- * @brief Returns the numeric representation of the library version. 
- * 
+ * @brief Returns the numeric representation of the library version.
+ *
  */
 unsigned int srtp_get_version(void);
 
 /**
  * @brief srtp_set_debug_module(mod_name, v)
- * 
+ *
  * sets dynamic debugging to the value v (0 for off, 1 for on) for the
  * debug module with the name mod_name
  *
@@ -1706,7 +1659,9 @@ typedef enum {
  * There can only be a single, global handler for all log messages in
  * libSRTP.
  */
-typedef void (srtp_log_handler_func_t)(srtp_log_level_t level, const char * msg, void *data);
+typedef void(srtp_log_handler_func_t)(srtp_log_level_t level,
+                                      const char *msg,
+                                      void *data);
 
 /**
  * @brief sets the log handler to the function supplied by the caller.
@@ -1719,34 +1674,44 @@ typedef void (srtp_log_handler_func_t)(srtp_log_level_t level, const char * msg,
  *
  * @param func is a pointer to a fuction of type srtp_log_handler_func_t.
  *             This function will be used by libSRTP to output log messages.
- * @param data is a user pointer that will be returned as the data argument in func.
+ * @param data is a user pointer that will be returned as the data argument in
+ * func.
  */
-srtp_err_status_t srtp_install_log_handler(srtp_log_handler_func_t func, void *data);
+srtp_err_status_t srtp_install_log_handler(srtp_log_handler_func_t func,
+                                           void *data);
 
 /**
  * @brief srtp_get_protect_trailer_length(session, use_mki, mki_index, length)
  *
- * Determines the length of the amount of data Lib SRTP will add to the 
- * packet during the protect process. The length is returned in the length parameter
+ * Determines the length of the amount of data Lib SRTP will add to the
+ * packet during the protect process. The length is returned in the length
+ * parameter
  *
- * returns err_status_ok on success, err_status_bad_mki if the MKI index is invalid
+ * returns err_status_ok on success, err_status_bad_mki if the MKI index is
+ * invalid
  *
  */
-srtp_err_status_t srtp_get_protect_trailer_length(srtp_t session, uint32_t use_mki,
-                                                  uint32_t mki_index, uint32_t *length);
+srtp_err_status_t srtp_get_protect_trailer_length(srtp_t session,
+                                                  uint32_t use_mki,
+                                                  uint32_t mki_index,
+                                                  uint32_t *length);
 
 /**
- * @brief srtp_get_protect_rtcp_trailer_length(session, use_mki, mki_index, length)
+ * @brief srtp_get_protect_rtcp_trailer_length(session, use_mki, mki_index,
+ * length)
  *
- * Determines the length of the amount of data Lib SRTP will add to the 
- * packet during the protect process. The length is returned in the length parameter
+ * Determines the length of the amount of data Lib SRTP will add to the
+ * packet during the protect process. The length is returned in the length
+ * parameter
  *
- * returns err_status_ok on success, err_status_bad_mki if the MKI index is invalid
+ * returns err_status_ok on success, err_status_bad_mki if the MKI index is
+ * invalid
  *
  */
-srtp_err_status_t srtp_get_protect_rtcp_trailer_length(srtp_t session, uint32_t use_mki,
-                                                       uint32_t mki_index, uint32_t *length);
-
+srtp_err_status_t srtp_get_protect_rtcp_trailer_length(srtp_t session,
+                                                       uint32_t use_mki,
+                                                       uint32_t mki_index,
+                                                       uint32_t *length);
 
 /**
  * @brief srtp_set_stream_roc(session, ssrc, roc)
@@ -1757,7 +1722,8 @@ srtp_err_status_t srtp_get_protect_rtcp_trailer_length(srtp_t session, uint32_t 
  * stream found
  *
  */
-srtp_err_status_t srtp_set_stream_roc(srtp_t session, uint32_t ssrc, uint32_t roc);
+srtp_err_status_t
+srtp_set_stream_roc(srtp_t session, uint32_t ssrc, uint32_t roc);
 
 /**
  * @brief srtp_get_stream_roc(session, ssrc, roc)
@@ -1768,14 +1734,16 @@ srtp_err_status_t srtp_set_stream_roc(srtp_t session, uint32_t ssrc, uint32_t ro
  * stream found
  *
  */
-srtp_err_status_t srtp_get_stream_roc(srtp_t session, uint32_t ssrc, uint32_t *roc);
-
+srtp_err_status_t
+srtp_get_stream_roc(srtp_t session, uint32_t ssrc, uint32_t *roc);
 
 /**
  * @}
  */
+
 /* in host order, so outside the #if */
-#define SRTCP_E_BIT      0x80000000
+#define SRTCP_E_BIT 0x80000000
+
 /* for byte-access */
 #define SRTCP_E_BYTE_BIT 0x80
 #define SRTCP_INDEX_MASK 0x7fffffff

--- a/include/srtp_priv.h
+++ b/include/srtp_priv.h
@@ -7,26 +7,26 @@
  * Cisco Systems, Inc.
  */
 /*
- *	
+ *
  * Copyright (c) 2001-2017 Cisco Systems, Inc.
  * All rights reserved.
- * 
+ *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
  * are met:
- * 
+ *
  *   Redistributions of source code must retain the above copyright
  *   notice, this list of conditions and the following disclaimer.
- * 
+ *
  *   Redistributions in binary form must reproduce the above
  *   copyright notice, this list of conditions and the following
  *   disclaimer in the documentation and/or other materials provided
  *   with the distribution.
- * 
+ *
  *   Neither the name of the Cisco Systems, Inc. nor the names of its
  *   contributors may be used to endorse or promote products derived
  *   from this software without specific prior written permission.
- * 
+ *
  * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
  * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
  * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
@@ -62,14 +62,14 @@
 extern "C" {
 #endif
 
-#define SRTP_VER_STRING	    PACKAGE_STRING
-#define SRTP_VERSION        PACKAGE_VERSION
+#define SRTP_VER_STRING PACKAGE_STRING
+#define SRTP_VERSION PACKAGE_VERSION
 
 typedef struct srtp_stream_ctx_t_ srtp_stream_ctx_t;
 typedef srtp_stream_ctx_t *srtp_stream_t;
 
 /*
- * the following declarations are libSRTP internal functions 
+ * the following declarations are libSRTP internal functions
  */
 
 /*
@@ -77,7 +77,6 @@ typedef srtp_stream_ctx_t *srtp_stream_t;
  * to ssrc, or NULL if no stream exists for that ssrc
  */
 srtp_stream_t srtp_get_stream(srtp_t srtp, uint32_t ssrc);
-
 
 /*
  * srtp_stream_init_keys(s, k) (re)initializes the srtp_stream_t s by
@@ -88,29 +87,29 @@ srtp_err_status_t srtp_stream_init_keys(srtp_stream_ctx_t *srtp,
                                         const unsigned int current_mki_index);
 
 /*
- * srtp_stream_init_all_master_keys(s, k, m) (re)initializes the srtp_stream_t s by
- * deriving all of the needed keys for all the master keys using the KDF and the keys from k.
+ * srtp_stream_init_all_master_keys(s, k, m) (re)initializes the srtp_stream_t s
+ * by deriving all of the needed keys for all the master keys using the KDF and
+ * the keys from k.
  */
-srtp_err_status_t srtp_steam_init_all_master_keys(srtp_stream_ctx_t *srtp,
-                                                  unsigned char *key,
-                                                  srtp_master_key_t **keys,
-                                                  const unsigned int max_master_keys);
+srtp_err_status_t
+srtp_steam_init_all_master_keys(srtp_stream_ctx_t *srtp,
+                                unsigned char *key,
+                                srtp_master_key_t **keys,
+                                const unsigned int max_master_keys);
 
 /*
- * srtp_stream_init(s, p) initializes the srtp_stream_t s to 
+ * srtp_stream_init(s, p) initializes the srtp_stream_t s to
  * use the policy at the location p
  */
 srtp_err_status_t srtp_stream_init(srtp_stream_t srtp, const srtp_policy_t *p);
 
-
 /*
- * libsrtp internal datatypes 
+ * libsrtp internal datatypes
  */
-
-typedef enum direction_t { 
-  dir_unknown       = 0,
-  dir_srtp_sender   = 1, 
-  dir_srtp_receiver = 2
+typedef enum direction_t {
+    dir_unknown = 0,
+    dir_srtp_sender = 1,
+    dir_srtp_receiver = 2
 } direction_t;
 
 /*
@@ -119,55 +118,51 @@ typedef enum direction_t {
  * MKI ID which is used to identify the session keys.
  */
 typedef struct srtp_session_keys_t {
-  srtp_cipher_t *rtp_cipher;
-  srtp_cipher_t *rtp_xtn_hdr_cipher;
-  srtp_auth_t   *rtp_auth;
-  srtp_cipher_t *rtcp_cipher;
-  srtp_auth_t   *rtcp_auth;
-  uint8_t        salt[SRTP_AEAD_SALT_LEN];
-  uint8_t        c_salt[SRTP_AEAD_SALT_LEN];
-  uint8_t       *mki_id;
-  unsigned int   mki_size;
-  srtp_key_limit_ctx_t *limit;
+    srtp_cipher_t *rtp_cipher;
+    srtp_cipher_t *rtp_xtn_hdr_cipher;
+    srtp_auth_t *rtp_auth;
+    srtp_cipher_t *rtcp_cipher;
+    srtp_auth_t *rtcp_auth;
+    uint8_t salt[SRTP_AEAD_SALT_LEN];
+    uint8_t c_salt[SRTP_AEAD_SALT_LEN];
+    uint8_t *mki_id;
+    unsigned int mki_size;
+    srtp_key_limit_ctx_t *limit;
 } srtp_session_keys_t;
 
-
-/* 
+/*
  * an srtp_stream_t has its own SSRC, encryption key, authentication
  * key, sequence number, and replay database
- * 
+ *
  * note that the keys might not actually be unique, in which case the
  * srtp_cipher_t and srtp_auth_t pointers will point to the same structures
  */
-
 typedef struct srtp_stream_ctx_t_ {
-  uint32_t   ssrc;
-  srtp_session_keys_t *session_keys;
-  unsigned int num_master_keys;
-  srtp_rdbx_t     rtp_rdbx;
-  srtp_sec_serv_t rtp_services;
-  srtp_rdb_t      rtcp_rdb;
-  srtp_sec_serv_t rtcp_services;
-  direction_t direction;
-  int        allow_repeat_tx;
-  srtp_ekt_stream_t ekt; 
-  int       *enc_xtn_hdr;
-  int        enc_xtn_hdr_count;
-  uint32_t pending_roc;
-  struct srtp_stream_ctx_t_ *next;   /* linked list of streams */
+    uint32_t ssrc;
+    srtp_session_keys_t *session_keys;
+    unsigned int num_master_keys;
+    srtp_rdbx_t rtp_rdbx;
+    srtp_sec_serv_t rtp_services;
+    srtp_rdb_t rtcp_rdb;
+    srtp_sec_serv_t rtcp_services;
+    direction_t direction;
+    int allow_repeat_tx;
+    srtp_ekt_stream_t ekt;
+    int *enc_xtn_hdr;
+    int enc_xtn_hdr_count;
+    uint32_t pending_roc;
+    struct srtp_stream_ctx_t_ *next; /* linked list of streams */
 } strp_stream_ctx_t_;
-
 
 /*
  * an srtp_ctx_t holds a stream list and a service description
  */
-
 typedef struct srtp_ctx_t_ {
-  struct srtp_stream_ctx_t_ *stream_list;     /* linked list of streams            */
-  struct srtp_stream_ctx_t_ *stream_template; /* act as template for other streams */
-  void *user_data;                    /* user custom data */
+    struct srtp_stream_ctx_t_ *stream_list;     /* linked list of streams     */
+    struct srtp_stream_ctx_t_ *stream_template; /* act as template for other  */
+                                                /* streams                    */
+    void *user_data;                            /* user custom data           */
 } srtp_ctx_t_;
-
 
 /*
  * srtp_hdr_t represents an RTP or SRTP header.  The bit-fields in
@@ -211,12 +206,10 @@ typedef struct {
 
 #endif
 
-
 typedef struct {
-  uint16_t profile_specific;   /* profile-specific info               */
-  uint16_t length;             /* number of 32-bit words in extension */
+    uint16_t profile_specific; /* profile-specific info               */
+    uint16_t length;           /* number of 32-bit words in extension */
 } srtp_hdr_xtnd_t;
-
 
 /*
  * srtcp_hdr_t represents a secure rtcp header
@@ -237,10 +230,10 @@ typedef struct {
 } srtcp_hdr_t;
 
 typedef struct {
-    unsigned int index : 31;   /* srtcp packet index in network order!  */
-    unsigned int e : 1;        /* encrypted? 1=yes                      */
-                               /* optional mikey/etc go here            */
-                               /* and then the variable-length auth tag */
+    unsigned int index : 31; /* srtcp packet index in network order!  */
+    unsigned int e : 1;      /* encrypted? 1=yes                      */
+                             /* optional mikey/etc go here            */
+                             /* and then the variable-length auth tag */
 } srtcp_trailer_t;
 
 #else /*  BIG_ENDIAN */
@@ -255,31 +248,30 @@ typedef struct {
 } srtcp_hdr_t;
 
 typedef struct {
-    unsigned int e : 1;        /* encrypted? 1=yes                      */
-    unsigned int index : 31;   /* srtcp packet index                    */
-                               /* optional mikey/etc go here            */
-                               /* and then the variable-length auth tag */
+    unsigned int e : 1;      /* encrypted? 1=yes                      */
+    unsigned int index : 31; /* srtcp packet index                    */
+                             /* optional mikey/etc go here            */
+                             /* and then the variable-length auth tag */
 } srtcp_trailer_t;
 
 #endif
-
 
 /*
  * srtp_handle_event(srtp, srtm, evnt) calls the event handling
  * function, if there is one.
  *
- * This macro is not included in the documentation as it is 
+ * This macro is not included in the documentation as it is
  * an internal-only function.
  */
 
-#define srtp_handle_event(srtp, strm, evnt)         \
-   if(srtp_event_handler) {                         \
-      srtp_event_data_t data;                       \
-      data.session = srtp;                          \
-      data.ssrc    = ntohl(strm->ssrc);             \
-      data.event   = evnt;                          \
-      srtp_event_handler(&data);                    \
-}   
+#define srtp_handle_event(srtp, strm, evnt)                                    \
+    if (srtp_event_handler) {                                                  \
+        srtp_event_data_t data;                                                \
+        data.session = srtp;                                                   \
+        data.ssrc = ntohl(strm->ssrc);                                         \
+        data.event = evnt;                                                     \
+        srtp_event_handler(&data);                                             \
+    }
 
 #ifdef __cplusplus
 }

--- a/srtp/srtp.c
+++ b/srtp/srtp.c
@@ -7,26 +7,26 @@
  * Cisco Systems, Inc.
  */
 /*
- *	
+ *
  * Copyright (c) 2001-2017, Cisco Systems, Inc.
  * All rights reserved.
- * 
+ *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
  * are met:
- * 
+ *
  *   Redistributions of source code must retain the above copyright
  *   notice, this list of conditions and the following disclaimer.
- * 
+ *
  *   Redistributions in binary form must reproduce the above
  *   copyright notice, this list of conditions and the following
  *   disclaimer in the documentation and/or other materials provided
  *   with the distribution.
- * 
+ *
  *   Neither the name of the Cisco Systems, Inc. nor the names of its
  *   contributors may be used to endorse or promote products derived
  *   from this software without specific prior written permission.
- * 
+ *
  * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
  * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
  * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
@@ -48,66 +48,67 @@
 #include "srtp_priv.h"
 #include "crypto_types.h"
 #include "err.h"
-#include "ekt.h"             /* for SRTP Encrypted Key Transport */
-#include "alloc.h"           /* for srtp_crypto_alloc()          */
+#include "ekt.h"   /* for SRTP Encrypted Key Transport */
+#include "alloc.h" /* for srtp_crypto_alloc() */
+
 #ifdef OPENSSL
-#include "aes_gcm_ossl.h"    /* for AES GCM mode  */
-# ifdef OPENSSL_KDF
-# include <openssl/kdf.h>
-# include "aes_icm_ossl.h"    /* for AES GCM mode  */
-# endif
+#include "aes_gcm_ossl.h" /* for AES GCM mode */
+#ifdef OPENSSL_KDF
+#include <openssl/kdf.h>
+#include "aes_icm_ossl.h" /* for AES GCM mode */
+#endif
 #endif
 
 #include <limits.h>
 #ifdef HAVE_NETINET_IN_H
-# include <netinet/in.h>
+#include <netinet/in.h>
 #elif defined(HAVE_WINSOCK2_H)
-# include <winsock2.h>
+#include <winsock2.h>
 #endif
 
-
 /* the debug module for srtp */
-
 srtp_debug_module_t mod_srtp = {
-  0,                  /* debugging is off by default */
-  "srtp"              /* printable name for module   */
+    0,     /* debugging is off by default */
+    "srtp" /* printable name for module */
 };
 
-#define octets_in_rtp_header   12
-#define uint32s_in_rtp_header  3
-#define octets_in_rtcp_header  8
+#define octets_in_rtp_header 12
+#define uint32s_in_rtp_header 3
+#define octets_in_rtcp_header 8
 #define uint32s_in_rtcp_header 2
 #define octets_in_rtp_extn_hdr 4
 
-static srtp_err_status_t
-srtp_validate_rtp_header(void *rtp_hdr, int *pkt_octet_len) {
-  if (*pkt_octet_len < octets_in_rtp_header)
-    return srtp_err_status_bad_param;
+static srtp_err_status_t srtp_validate_rtp_header(void *rtp_hdr,
+                                                  int *pkt_octet_len)
+{
+    if (*pkt_octet_len < octets_in_rtp_header)
+        return srtp_err_status_bad_param;
 
-  srtp_hdr_t *hdr = (srtp_hdr_t *)rtp_hdr;
+    srtp_hdr_t *hdr = (srtp_hdr_t *)rtp_hdr;
 
-  /* Check RTP header length */
-  int rtp_header_len = octets_in_rtp_header + 4 * hdr->cc;
-  if (hdr->x == 1)
-    rtp_header_len += octets_in_rtp_extn_hdr;
+    /* Check RTP header length */
+    int rtp_header_len = octets_in_rtp_header + 4 * hdr->cc;
+    if (hdr->x == 1)
+        rtp_header_len += octets_in_rtp_extn_hdr;
 
-  if (*pkt_octet_len < rtp_header_len)
-    return srtp_err_status_bad_param;
-
-  /* Verifing profile length. */
-  if (hdr->x == 1) {
-    srtp_hdr_xtnd_t *xtn_hdr =
-      (srtp_hdr_xtnd_t *)((uint32_t *)hdr + uint32s_in_rtp_header + hdr->cc);
-    int profile_len = ntohs(xtn_hdr->length);
-    rtp_header_len += profile_len * 4;
-    /* profile length counts the number of 32-bit words */
     if (*pkt_octet_len < rtp_header_len)
-      return srtp_err_status_bad_param;
-  }
-  return srtp_err_status_ok;
+        return srtp_err_status_bad_param;
+
+    /* Verifing profile length. */
+    if (hdr->x == 1) {
+        srtp_hdr_xtnd_t *xtn_hdr =
+            (srtp_hdr_xtnd_t *)((uint32_t *)hdr + uint32s_in_rtp_header +
+                                hdr->cc);
+        int profile_len = ntohs(xtn_hdr->length);
+        rtp_header_len += profile_len * 4;
+        /* profile length counts the number of 32-bit words */
+        if (*pkt_octet_len < rtp_header_len)
+            return srtp_err_status_bad_param;
+    }
+    return srtp_err_status_ok;
 }
 
-const char *srtp_get_version_string ()
+const char *srtp_get_version_string()
 {
     /*
      * Simply return the autotools generated string
@@ -115,29 +116,29 @@ const char *srtp_get_version_string ()
     return SRTP_VER_STRING;
 }
 
-unsigned int srtp_get_version ()
+unsigned int srtp_get_version()
 {
     unsigned int major = 0, minor = 0, micro = 0;
     unsigned int rv = 0;
     int parse_rv;
 
     /*
-     * Parse the autotools generated version 
+     * Parse the autotools generated version
      */
     parse_rv = sscanf(SRTP_VERSION, "%u.%u.%u", &major, &minor, &micro);
     if (parse_rv != 3) {
-	/*
-	 * We're expected to parse all 3 version levels.
-	 * If not, then this must not be an official release.
-	 * Return all zeros on the version
-	 */
-	return (0);
+        /*
+         * We're expected to parse all 3 version levels.
+         * If not, then this must not be an official release.
+         * Return all zeros on the version
+         */
+        return (0);
     }
 
-    /* 
+    /*
      * We allow 8 bits for the major and minor, while
      * allowing 16 bits for the micro.  16 bits for the micro
-     * may be beneficial for a continuous delivery model 
+     * may be beneficial for a continuous delivery model
      * in the future.
      */
     rv |= (major & 0xFF) << 24;
@@ -147,444 +148,458 @@ unsigned int srtp_get_version ()
 }
 
 /* Release (maybe partially allocated) stream. */
-static void
-srtp_stream_free(srtp_stream_ctx_t *str) {
-  unsigned int i = 0;
-  srtp_session_keys_t *session_keys = NULL;
+static void srtp_stream_free(srtp_stream_ctx_t *str)
+{
+    unsigned int i = 0;
+    srtp_session_keys_t *session_keys = NULL;
 
-  for (i = 0; i < str->num_master_keys; i++) {
-    session_keys = &str->session_keys[i];
+    for (i = 0; i < str->num_master_keys; i++) {
+        session_keys = &str->session_keys[i];
 
-    if (session_keys->rtp_xtn_hdr_cipher) {
-      srtp_cipher_dealloc(session_keys->rtp_xtn_hdr_cipher);
+        if (session_keys->rtp_xtn_hdr_cipher) {
+            srtp_cipher_dealloc(session_keys->rtp_xtn_hdr_cipher);
+        }
+
+        if (session_keys->rtcp_cipher) {
+            srtp_cipher_dealloc(session_keys->rtcp_cipher);
+        }
+
+        if (session_keys->rtcp_auth) {
+            srtp_auth_dealloc(session_keys->rtcp_auth);
+        }
+
+        if (session_keys->rtp_cipher) {
+            srtp_cipher_dealloc(session_keys->rtp_cipher);
+        }
+
+        if (session_keys->rtp_auth) {
+            srtp_auth_dealloc(session_keys->rtp_auth);
+        }
+
+        if (session_keys->mki_id) {
+            srtp_crypto_free(session_keys->mki_id);
+        }
+
+        if (session_keys->limit) {
+            srtp_crypto_free(session_keys->limit);
+        }
     }
 
-    if (session_keys->rtcp_cipher) {
-      srtp_cipher_dealloc(session_keys->rtcp_cipher);
+    srtp_crypto_free(str->session_keys);
+
+    if (str->enc_xtn_hdr) {
+        srtp_crypto_free(str->enc_xtn_hdr);
     }
 
-    if (session_keys->rtcp_auth) {
-      srtp_auth_dealloc(session_keys->rtcp_auth);
-    }
-
-    if (session_keys->rtp_cipher) {
-      srtp_cipher_dealloc(session_keys->rtp_cipher);
-    }
-
-    if (session_keys->rtp_auth) {
-      srtp_auth_dealloc(session_keys->rtp_auth);
-    }
-
-    if (session_keys->mki_id) {
-      srtp_crypto_free(session_keys->mki_id);
-    }
-
-    if (session_keys->limit) {
-      srtp_crypto_free(session_keys->limit);
-    }
-  }
-
-  srtp_crypto_free(str->session_keys);
-
-  if (str->enc_xtn_hdr) {
-    srtp_crypto_free(str->enc_xtn_hdr);
-  }
-
-  srtp_crypto_free(str);
+    srtp_crypto_free(str);
 }
 
-srtp_err_status_t
-srtp_stream_alloc(srtp_stream_ctx_t **str_ptr,
-		  const srtp_policy_t *p) {
-  srtp_stream_ctx_t *str;
-  srtp_err_status_t stat;
-  unsigned int i = 0;
-  srtp_session_keys_t *session_keys = NULL;
-
-  /*
-   * This function allocates the stream context, rtp and rtcp ciphers
-   * and auth functions, and key limit structure.  If there is a
-   * failure during allocation, we free all previously allocated
-   * memory and return a failure code.  The code could probably 
-   * be improved, but it works and should be clear.
-   */
-
-  /* allocate srtp stream and set str_ptr */
-  str = (srtp_stream_ctx_t *) srtp_crypto_alloc(sizeof(srtp_stream_ctx_t));
-  if (str == NULL)
-    return srtp_err_status_alloc_fail;
-
-  memset(str, 0, sizeof(srtp_stream_ctx_t));
-  *str_ptr = str;
-
-  /* To keep backwards API compatible if someone is using multiple master
-   * keys then key should be set to NULL
-   */
-  if (p->key != NULL) {
-      str->num_master_keys = 1;
-  } else {
-      str->num_master_keys = p->num_master_keys;
-  }
-
-  str->session_keys = (srtp_session_keys_t *)srtp_crypto_alloc(
-      sizeof(srtp_session_keys_t) * str->num_master_keys);
-
-  if (str->session_keys == NULL) {
-      srtp_stream_free(str);
-      return srtp_err_status_alloc_fail;
-  }
-
-  memset(str->session_keys, 0, sizeof(srtp_session_keys_t) * str->num_master_keys);
-
-  for (i = 0; i < str->num_master_keys; i++) {
-    session_keys = &str->session_keys[i];
-
-    /* allocate cipher */ 
-    stat = srtp_crypto_kernel_alloc_cipher(p->rtp.cipher_type,
-                                           &session_keys->rtp_cipher,
-                                           p->rtp.cipher_key_len,
-				           p->rtp.auth_tag_len);
-    if (stat) {
-      srtp_stream_free(str);
-      return stat;
-    }
-
-    /* allocate auth function */
-    stat = srtp_crypto_kernel_alloc_auth(p->rtp.auth_type,
-                                         &session_keys->rtp_auth,
-                                         p->rtp.auth_key_len,
-                                         p->rtp.auth_tag_len);
-    if (stat) {
-      srtp_stream_free(str);
-      return stat;
-    }
+srtp_err_status_t srtp_stream_alloc(srtp_stream_ctx_t **str_ptr,
+                                    const srtp_policy_t *p)
+{
+    srtp_stream_ctx_t *str;
+    srtp_err_status_t stat;
+    unsigned int i = 0;
+    srtp_session_keys_t *session_keys = NULL;
 
     /*
-     * ...and now the RTCP-specific initialization - first, allocate
-     * the cipher 
+     * This function allocates the stream context, rtp and rtcp ciphers
+     * and auth functions, and key limit structure.  If there is a
+     * failure during allocation, we free all previously allocated
+     * memory and return a failure code.  The code could probably
+     * be improved, but it works and should be clear.
      */
-    stat = srtp_crypto_kernel_alloc_cipher(p->rtcp.cipher_type,
-                                           &session_keys->rtcp_cipher,
-                                           p->rtcp.cipher_key_len,
-                                           p->rtcp.auth_tag_len);
-    if (stat) {
-      srtp_stream_free(str);
-      return stat;
+
+    /* allocate srtp stream and set str_ptr */
+    str = (srtp_stream_ctx_t *)srtp_crypto_alloc(sizeof(srtp_stream_ctx_t));
+    if (str == NULL)
+        return srtp_err_status_alloc_fail;
+
+    memset(str, 0, sizeof(srtp_stream_ctx_t));
+    *str_ptr = str;
+
+    /*
+     *To keep backwards API compatible if someone is using multiple master
+     * keys then key should be set to NULL
+     */
+    if (p->key != NULL) {
+        str->num_master_keys = 1;
+    } else {
+        str->num_master_keys = p->num_master_keys;
     }
 
-    /* allocate auth function */
-    stat = srtp_crypto_kernel_alloc_auth(p->rtcp.auth_type,
-                                         &session_keys->rtcp_auth,
-                                         p->rtcp.auth_key_len,
-                                         p->rtcp.auth_tag_len);
-    if (stat) {
-      srtp_stream_free(str);
-      return stat;
-    }
-   
-    session_keys->mki_id = NULL;
+    str->session_keys = (srtp_session_keys_t *)srtp_crypto_alloc(
+        sizeof(srtp_session_keys_t) * str->num_master_keys);
 
-    /* allocate key limit structure */
-    session_keys->limit = (srtp_key_limit_ctx_t*) srtp_crypto_alloc(sizeof(srtp_key_limit_ctx_t));
-    if (session_keys->limit == NULL) {
+    if (str->session_keys == NULL) {
         srtp_stream_free(str);
         return srtp_err_status_alloc_fail;
     }
-  }
 
-  /* allocate ekt data associated with stream */
-  stat = srtp_ekt_alloc(&str->ekt, p->ekt);
-  if (stat) {
-    srtp_stream_free(str);
-    return stat;
-  }
-
-  if (p->enc_xtn_hdr && p->enc_xtn_hdr_count > 0) {
-    srtp_cipher_type_id_t enc_xtn_hdr_cipher_type;
-    int enc_xtn_hdr_cipher_key_len;
-
-    str->enc_xtn_hdr = (int*) srtp_crypto_alloc(p->enc_xtn_hdr_count * sizeof(p->enc_xtn_hdr[0]));
-    if (!str->enc_xtn_hdr) {
-      srtp_stream_free(str);
-      return srtp_err_status_alloc_fail;
-    }
-    memcpy(str->enc_xtn_hdr, p->enc_xtn_hdr, p->enc_xtn_hdr_count * sizeof(p->enc_xtn_hdr[0]));
-    str->enc_xtn_hdr_count = p->enc_xtn_hdr_count;
-
-    /* For GCM ciphers, the corresponding ICM cipher is used for header extensions encryption. */
-    switch (p->rtp.cipher_type) {
-    case SRTP_AES_GCM_128:
-      enc_xtn_hdr_cipher_type = SRTP_AES_ICM_128;
-      enc_xtn_hdr_cipher_key_len = SRTP_AES_ICM_128_KEY_LEN_WSALT;
-      break;
-    case SRTP_AES_GCM_256:
-      enc_xtn_hdr_cipher_type = SRTP_AES_ICM_256;
-      enc_xtn_hdr_cipher_key_len = SRTP_AES_ICM_256_KEY_LEN_WSALT;
-      break;
-    default:
-      enc_xtn_hdr_cipher_type = p->rtp.cipher_type;
-      enc_xtn_hdr_cipher_key_len = p->rtp.cipher_key_len;
-      break;
-    }
+    memset(str->session_keys, 0,
+           sizeof(srtp_session_keys_t) * str->num_master_keys);
 
     for (i = 0; i < str->num_master_keys; i++) {
-      session_keys = &str->session_keys[i];
+        session_keys = &str->session_keys[i];
 
-      /* allocate cipher for extensions header encryption */
-      stat = srtp_crypto_kernel_alloc_cipher(enc_xtn_hdr_cipher_type,
-                                             &session_keys->rtp_xtn_hdr_cipher,
-                                             enc_xtn_hdr_cipher_key_len,
-                                             0);
-      if (stat) {
+        /* allocate cipher */
+        stat = srtp_crypto_kernel_alloc_cipher(
+            p->rtp.cipher_type, &session_keys->rtp_cipher,
+            p->rtp.cipher_key_len, p->rtp.auth_tag_len);
+        if (stat) {
+            srtp_stream_free(str);
+            return stat;
+        }
+
+        /* allocate auth function */
+        stat = srtp_crypto_kernel_alloc_auth(
+            p->rtp.auth_type, &session_keys->rtp_auth, p->rtp.auth_key_len,
+            p->rtp.auth_tag_len);
+        if (stat) {
+            srtp_stream_free(str);
+            return stat;
+        }
+
+        /*
+         * ...and now the RTCP-specific initialization - first, allocate
+         * the cipher
+         */
+        stat = srtp_crypto_kernel_alloc_cipher(
+            p->rtcp.cipher_type, &session_keys->rtcp_cipher,
+            p->rtcp.cipher_key_len, p->rtcp.auth_tag_len);
+        if (stat) {
+            srtp_stream_free(str);
+            return stat;
+        }
+
+        /* allocate auth function */
+        stat = srtp_crypto_kernel_alloc_auth(
+            p->rtcp.auth_type, &session_keys->rtcp_auth, p->rtcp.auth_key_len,
+            p->rtcp.auth_tag_len);
+        if (stat) {
+            srtp_stream_free(str);
+            return stat;
+        }
+
+        session_keys->mki_id = NULL;
+
+        /* allocate key limit structure */
+        session_keys->limit = (srtp_key_limit_ctx_t *)srtp_crypto_alloc(
+            sizeof(srtp_key_limit_ctx_t));
+        if (session_keys->limit == NULL) {
+            srtp_stream_free(str);
+            return srtp_err_status_alloc_fail;
+        }
+    }
+
+    /* allocate ekt data associated with stream */
+    stat = srtp_ekt_alloc(&str->ekt, p->ekt);
+    if (stat) {
         srtp_stream_free(str);
         return stat;
-      }
-    }
-  } else {
-    for (i = 0; i < str->num_master_keys; i++) {
-      session_keys = &str->session_keys[i];
-      session_keys->rtp_xtn_hdr_cipher = NULL;
     }
 
-    str->enc_xtn_hdr = NULL;
-    str->enc_xtn_hdr_count = 0;
-  }
+    if (p->enc_xtn_hdr && p->enc_xtn_hdr_count > 0) {
+        srtp_cipher_type_id_t enc_xtn_hdr_cipher_type;
+        int enc_xtn_hdr_cipher_key_len;
 
-  return srtp_err_status_ok;
+        str->enc_xtn_hdr = (int *)srtp_crypto_alloc(p->enc_xtn_hdr_count *
+                                                    sizeof(p->enc_xtn_hdr[0]));
+        if (!str->enc_xtn_hdr) {
+            srtp_stream_free(str);
+            return srtp_err_status_alloc_fail;
+        }
+        memcpy(str->enc_xtn_hdr, p->enc_xtn_hdr,
+               p->enc_xtn_hdr_count * sizeof(p->enc_xtn_hdr[0]));
+        str->enc_xtn_hdr_count = p->enc_xtn_hdr_count;
+
+        /*
+         * For GCM ciphers, the corresponding ICM cipher is used for header
+         * extensions encryption.
+         */
+        switch (p->rtp.cipher_type) {
+        case SRTP_AES_GCM_128:
+            enc_xtn_hdr_cipher_type = SRTP_AES_ICM_128;
+            enc_xtn_hdr_cipher_key_len = SRTP_AES_ICM_128_KEY_LEN_WSALT;
+            break;
+        case SRTP_AES_GCM_256:
+            enc_xtn_hdr_cipher_type = SRTP_AES_ICM_256;
+            enc_xtn_hdr_cipher_key_len = SRTP_AES_ICM_256_KEY_LEN_WSALT;
+            break;
+        default:
+            enc_xtn_hdr_cipher_type = p->rtp.cipher_type;
+            enc_xtn_hdr_cipher_key_len = p->rtp.cipher_key_len;
+            break;
+        }
+
+        for (i = 0; i < str->num_master_keys; i++) {
+            session_keys = &str->session_keys[i];
+
+            /* allocate cipher for extensions header encryption */
+            stat = srtp_crypto_kernel_alloc_cipher(
+                enc_xtn_hdr_cipher_type, &session_keys->rtp_xtn_hdr_cipher,
+                enc_xtn_hdr_cipher_key_len, 0);
+            if (stat) {
+                srtp_stream_free(str);
+                return stat;
+            }
+        }
+    } else {
+        for (i = 0; i < str->num_master_keys; i++) {
+            session_keys = &str->session_keys[i];
+            session_keys->rtp_xtn_hdr_cipher = NULL;
+        }
+
+        str->enc_xtn_hdr = NULL;
+        str->enc_xtn_hdr_count = 0;
+    }
+
+    return srtp_err_status_ok;
 }
 
-srtp_err_status_t
-srtp_stream_dealloc(srtp_stream_ctx_t *stream, srtp_stream_ctx_t *stream_template) {
-  srtp_err_status_t status;
-  unsigned int i = 0;
-  srtp_session_keys_t *session_keys = NULL;
-  srtp_session_keys_t *template_session_keys = NULL;
-
-  /*
-   * we use a conservative deallocation strategy - if any deallocation
-   * fails, then we report that fact without trying to deallocate
-   * anything else
-   */
-  for ( i = 0; i < stream->num_master_keys; i++) {
-    session_keys = &stream->session_keys[i];
-
-    if (stream_template) {
-      template_session_keys = &stream_template->session_keys[i];
-    } else {
-      template_session_keys = NULL;
-    }
-
-    /* deallocate cipher, if it is not the same as that in template */
-    if (template_session_keys
-        && session_keys->rtp_cipher == template_session_keys->rtp_cipher) {
-       /* do nothing */
-    } else {
-       status = srtp_cipher_dealloc(session_keys->rtp_cipher);
-       if (status)
-         return status;
-    }
-
-    /* deallocate auth function, if it is not the same as that in template */
-    if (template_session_keys
-        && session_keys->rtp_auth == template_session_keys->rtp_auth) {
-       /* do nothing */
-    } else {
-      status = srtp_auth_dealloc(session_keys->rtp_auth);
-      if (status)
-        return status;
-    }
-
-    if (template_session_keys
-        && session_keys->rtp_xtn_hdr_cipher == template_session_keys->rtp_xtn_hdr_cipher) {
-       /* do nothing */
-    } else if (session_keys->rtp_xtn_hdr_cipher) {
-      status = srtp_cipher_dealloc(session_keys->rtp_xtn_hdr_cipher);
-      if (status)
-        return status;
-    }
+srtp_err_status_t srtp_stream_dealloc(srtp_stream_ctx_t *stream,
+                                      srtp_stream_ctx_t *stream_template)
+{
+    srtp_err_status_t status;
+    unsigned int i = 0;
+    srtp_session_keys_t *session_keys = NULL;
+    srtp_session_keys_t *template_session_keys = NULL;
 
     /*
-     * deallocate rtcp cipher, if it is not the same as that in
-     * template
+     * we use a conservative deallocation strategy - if any deallocation
+     * fails, then we report that fact without trying to deallocate
+     * anything else
      */
-    if (template_session_keys
-        && session_keys->rtcp_cipher == template_session_keys->rtcp_cipher) {
-      /* do nothing */
-    } else {
-      status = srtp_cipher_dealloc(session_keys->rtcp_cipher);
-      if (status)
-        return status;
+    for (i = 0; i < stream->num_master_keys; i++) {
+        session_keys = &stream->session_keys[i];
+
+        if (stream_template) {
+            template_session_keys = &stream_template->session_keys[i];
+        } else {
+            template_session_keys = NULL;
+        }
+
+        /*
+        * deallocate cipher, if it is not the same as that in template
+        */
+        if (template_session_keys &&
+            session_keys->rtp_cipher == template_session_keys->rtp_cipher) {
+            /* do nothing */
+        } else {
+            status = srtp_cipher_dealloc(session_keys->rtp_cipher);
+            if (status)
+                return status;
+        }
+
+        /*
+         * deallocate auth function, if it is not the same as that in template
+         */
+        if (template_session_keys &&
+            session_keys->rtp_auth == template_session_keys->rtp_auth) {
+            /* do nothing */
+        } else {
+            status = srtp_auth_dealloc(session_keys->rtp_auth);
+            if (status)
+                return status;
+        }
+
+        if (template_session_keys &&
+            session_keys->rtp_xtn_hdr_cipher ==
+                template_session_keys->rtp_xtn_hdr_cipher) {
+            /* do nothing */
+        } else if (session_keys->rtp_xtn_hdr_cipher) {
+            status = srtp_cipher_dealloc(session_keys->rtp_xtn_hdr_cipher);
+            if (status)
+                return status;
+        }
+
+        /*
+         * deallocate rtcp cipher, if it is not the same as that in
+         * template
+         */
+        if (template_session_keys &&
+            session_keys->rtcp_cipher == template_session_keys->rtcp_cipher) {
+            /* do nothing */
+        } else {
+            status = srtp_cipher_dealloc(session_keys->rtcp_cipher);
+            if (status)
+                return status;
+        }
+
+        /*
+         * deallocate rtcp auth function, if it is not the same as that in
+         * template
+         */
+        if (template_session_keys &&
+            session_keys->rtcp_auth == template_session_keys->rtcp_auth) {
+            /* do nothing */
+        } else {
+            status = srtp_auth_dealloc(session_keys->rtcp_auth);
+            if (status)
+                return status;
+        }
+
+        /*
+         * zeroize the salt value
+         */
+        octet_string_set_to_zero(session_keys->salt, SRTP_AEAD_SALT_LEN);
+        octet_string_set_to_zero(session_keys->c_salt, SRTP_AEAD_SALT_LEN);
+
+        if (session_keys->mki_id) {
+            octet_string_set_to_zero(session_keys->mki_id,
+                                     session_keys->mki_size);
+            srtp_crypto_free(session_keys->mki_id);
+            session_keys->mki_id = NULL;
+        }
+
+        /*
+         * deallocate key usage limit, if it is not the same as that in template
+         */
+        if (template_session_keys &&
+            session_keys->limit == template_session_keys->limit) {
+            /* do nothing */
+        } else {
+            srtp_crypto_free(session_keys->limit);
+        }
     }
 
-    /*
-     * deallocate rtcp auth function, if it is not the same as that in
-     * template
-     */
-    if (template_session_keys
-        && session_keys->rtcp_auth == template_session_keys->rtcp_auth) {
-      /* do nothing */
-    } else {
-      status = srtp_auth_dealloc(session_keys->rtcp_auth);
-      if (status)
-        return status;
-    }
-
-    /*
-     * zeroize the salt value
-     */
-    octet_string_set_to_zero(session_keys->salt, SRTP_AEAD_SALT_LEN);
-    octet_string_set_to_zero(session_keys->c_salt, SRTP_AEAD_SALT_LEN);
-
-    if (session_keys->mki_id) {
-      octet_string_set_to_zero(session_keys->mki_id, session_keys->mki_size);
-      srtp_crypto_free(session_keys->mki_id);
-      session_keys->mki_id = NULL;
-    }
-
-    /* deallocate key usage limit, if it is not the same as that in template */
-    if (template_session_keys
-        && session_keys->limit == template_session_keys->limit) {
+    if (stream_template &&
+        stream->session_keys == stream_template->session_keys) {
         /* do nothing */
     } else {
-      srtp_crypto_free(session_keys->limit);
+        srtp_crypto_free(stream->session_keys);
     }
 
-  }
+    status = srtp_rdbx_dealloc(&stream->rtp_rdbx);
+    if (status)
+        return status;
 
-  if (stream_template
-      && stream->session_keys == stream_template->session_keys) {
-      /* do nothing */
-  } else {
-    srtp_crypto_free(stream->session_keys);
-  }
+    /* DAM - need to deallocate EKT here */
 
-  status = srtp_rdbx_dealloc(&stream->rtp_rdbx);
-  if (status)
-    return status;
+    if (stream_template &&
+        stream->enc_xtn_hdr == stream_template->enc_xtn_hdr) {
+        /* do nothing */
+    } else if (stream->enc_xtn_hdr) {
+        srtp_crypto_free(stream->enc_xtn_hdr);
+    }
 
-  /* DAM - need to deallocate EKT here */
+    /* deallocate srtp stream context */
+    srtp_crypto_free(stream);
 
-  if (stream_template
-      && stream->enc_xtn_hdr == stream_template->enc_xtn_hdr) {
-    /* do nothing */
-  } else if (stream->enc_xtn_hdr) {
-    srtp_crypto_free(stream->enc_xtn_hdr);
-  }
-
-  /* deallocate srtp stream context */
-  srtp_crypto_free(stream);
-
-  return srtp_err_status_ok;
+    return srtp_err_status_ok;
 }
-
 
 /*
  * srtp_stream_clone(stream_template, new) allocates a new stream and
  * initializes it using the cipher and auth of the stream_template
- * 
+ *
  * the only unique data in a cloned stream is the replay database and
  * the SSRC
  */
 
-srtp_err_status_t
-srtp_stream_clone(const srtp_stream_ctx_t *stream_template, 
-		  uint32_t ssrc, 
-		  srtp_stream_ctx_t **str_ptr) {
-  srtp_err_status_t status;
-  srtp_stream_ctx_t *str;
-  unsigned int i = 0;
-  srtp_session_keys_t *session_keys = NULL;
-  const srtp_session_keys_t *template_session_keys = NULL;
+srtp_err_status_t srtp_stream_clone(const srtp_stream_ctx_t *stream_template,
+                                    uint32_t ssrc,
+                                    srtp_stream_ctx_t **str_ptr)
+{
+    srtp_err_status_t status;
+    srtp_stream_ctx_t *str;
+    unsigned int i = 0;
+    srtp_session_keys_t *session_keys = NULL;
+    const srtp_session_keys_t *template_session_keys = NULL;
 
-  debug_print(mod_srtp, "cloning stream (SSRC: 0x%08x)", ntohl(ssrc));
+    debug_print(mod_srtp, "cloning stream (SSRC: 0x%08x)", ntohl(ssrc));
 
-  /* allocate srtp stream and set str_ptr */
-  str = (srtp_stream_ctx_t *) srtp_crypto_alloc(sizeof(srtp_stream_ctx_t));
-  if (str == NULL)
-    return srtp_err_status_alloc_fail;
-  *str_ptr = str;  
+    /* allocate srtp stream and set str_ptr */
+    str = (srtp_stream_ctx_t *)srtp_crypto_alloc(sizeof(srtp_stream_ctx_t));
+    if (str == NULL)
+        return srtp_err_status_alloc_fail;
+    *str_ptr = str;
 
-  str->num_master_keys = stream_template->num_master_keys;
-  str->session_keys = (srtp_session_keys_t *)srtp_crypto_alloc(
-      sizeof(srtp_session_keys_t) * str->num_master_keys);
+    str->num_master_keys = stream_template->num_master_keys;
+    str->session_keys = (srtp_session_keys_t *)srtp_crypto_alloc(
+        sizeof(srtp_session_keys_t) * str->num_master_keys);
 
-  if (str->session_keys == NULL) {
-    srtp_crypto_free(*str_ptr);
-    *str_ptr = NULL;
-    return srtp_err_status_alloc_fail;
-  }
-
-  for (i = 0; i < stream_template->num_master_keys; i++){
-    session_keys = &str->session_keys[i];
-    template_session_keys = &stream_template->session_keys[i];
-
-    /* set cipher and auth pointers to those of the template */
-    session_keys->rtp_cipher  = template_session_keys->rtp_cipher;
-    session_keys->rtp_auth    = template_session_keys->rtp_auth;
-    session_keys->rtp_xtn_hdr_cipher = template_session_keys->rtp_xtn_hdr_cipher;
-    session_keys->rtcp_cipher = template_session_keys->rtcp_cipher;
-    session_keys->rtcp_auth   = template_session_keys->rtcp_auth;
-    session_keys->mki_size = template_session_keys->mki_size;
-
-    if (template_session_keys->mki_size == 0) {
-      session_keys->mki_id = NULL;
-    } else {
-      session_keys->mki_id = srtp_crypto_alloc(template_session_keys->mki_size);
-
-      if (session_keys->mki_id == NULL) {
-        return srtp_err_status_init_fail;
-      }
-      memset(session_keys->mki_id, 0x0, session_keys->mki_size);
-      memcpy(session_keys->mki_id, template_session_keys->mki_id, session_keys->mki_size);
+    if (str->session_keys == NULL) {
+        srtp_crypto_free(*str_ptr);
+        *str_ptr = NULL;
+        return srtp_err_status_alloc_fail;
     }
-    /* Copy the salt values */
-    memcpy(session_keys->salt, template_session_keys->salt, SRTP_AEAD_SALT_LEN);
-    memcpy(session_keys->c_salt, template_session_keys->c_salt, SRTP_AEAD_SALT_LEN);
 
-    /* set key limit to point to that of the template */
-    status = srtp_key_limit_clone(template_session_keys->limit, &session_keys->limit);
-    if (status) { 
-      srtp_crypto_free(*str_ptr);
-      *str_ptr = NULL;
-      return status;
+    for (i = 0; i < stream_template->num_master_keys; i++) {
+        session_keys = &str->session_keys[i];
+        template_session_keys = &stream_template->session_keys[i];
+
+        /* set cipher and auth pointers to those of the template */
+        session_keys->rtp_cipher = template_session_keys->rtp_cipher;
+        session_keys->rtp_auth = template_session_keys->rtp_auth;
+        session_keys->rtp_xtn_hdr_cipher =
+            template_session_keys->rtp_xtn_hdr_cipher;
+        session_keys->rtcp_cipher = template_session_keys->rtcp_cipher;
+        session_keys->rtcp_auth = template_session_keys->rtcp_auth;
+        session_keys->mki_size = template_session_keys->mki_size;
+
+        if (template_session_keys->mki_size == 0) {
+            session_keys->mki_id = NULL;
+        } else {
+            session_keys->mki_id =
+                srtp_crypto_alloc(template_session_keys->mki_size);
+
+            if (session_keys->mki_id == NULL) {
+                return srtp_err_status_init_fail;
+            }
+            memset(session_keys->mki_id, 0x0, session_keys->mki_size);
+            memcpy(session_keys->mki_id, template_session_keys->mki_id,
+                   session_keys->mki_size);
+        }
+        /* Copy the salt values */
+        memcpy(session_keys->salt, template_session_keys->salt,
+               SRTP_AEAD_SALT_LEN);
+        memcpy(session_keys->c_salt, template_session_keys->c_salt,
+               SRTP_AEAD_SALT_LEN);
+
+        /* set key limit to point to that of the template */
+        status = srtp_key_limit_clone(template_session_keys->limit,
+                                      &session_keys->limit);
+        if (status) {
+            srtp_crypto_free(*str_ptr);
+            *str_ptr = NULL;
+            return status;
+        }
     }
-  }
 
+    /* initialize replay databases */
+    status = srtp_rdbx_init(
+        &str->rtp_rdbx, srtp_rdbx_get_window_size(&stream_template->rtp_rdbx));
+    if (status) {
+        srtp_crypto_free(*str_ptr);
+        *str_ptr = NULL;
+        return status;
+    }
+    srtp_rdb_init(&str->rtcp_rdb);
+    str->allow_repeat_tx = stream_template->allow_repeat_tx;
 
-  /* initialize replay databases */
-  status = srtp_rdbx_init(&str->rtp_rdbx,
-		     srtp_rdbx_get_window_size(&stream_template->rtp_rdbx));
-  if (status) {
-    srtp_crypto_free(*str_ptr);
-    *str_ptr = NULL;
-    return status;
-  }
-  srtp_rdb_init(&str->rtcp_rdb);
-  str->allow_repeat_tx = stream_template->allow_repeat_tx;
+    /* set ssrc to that provided */
+    str->ssrc = ssrc;
 
-  /* set ssrc to that provided */
-  str->ssrc = ssrc;
+    /* reset pending ROC */
+    str->pending_roc = 0;
 
-  /* reset pending ROC */
-  str->pending_roc = 0;
+    /* set direction and security services */
+    str->direction = stream_template->direction;
+    str->rtp_services = stream_template->rtp_services;
+    str->rtcp_services = stream_template->rtcp_services;
 
-  /* set direction and security services */
-  str->direction     = stream_template->direction;
-  str->rtp_services  = stream_template->rtp_services;
-  str->rtcp_services = stream_template->rtcp_services;
+    /* set pointer to EKT data associated with stream */
+    str->ekt = stream_template->ekt;
 
-  /* set pointer to EKT data associated with stream */
-  str->ekt = stream_template->ekt;
+    /* copy information about extensions header encryption */
+    str->enc_xtn_hdr = stream_template->enc_xtn_hdr;
+    str->enc_xtn_hdr_count = stream_template->enc_xtn_hdr_count;
 
-  /* copy information about extensions header encryption */
-  str->enc_xtn_hdr = stream_template->enc_xtn_hdr;
-  str->enc_xtn_hdr_count = stream_template->enc_xtn_hdr_count;
-
-  /* defensive coding */
-  str->next = NULL;
-  return srtp_err_status_ok;
+    /* defensive coding */
+    str->next = NULL;
+    return srtp_err_status_ok;
 }
-
 
 /*
  * key derivation functions, internal to libSRTP
@@ -593,7 +608,7 @@ srtp_stream_clone(const srtp_stream_ctx_t *stream_template,
  *
  * srtp_kdf_init(&kdf, cipher_id, k, keylen) initializes kdf to use cipher
  * described by cipher_id, with the master key k with length in octets keylen.
- * 
+ *
  * srtp_kdf_generate(&kdf, l, kl, keylen) derives the key
  * corresponding to label l and puts it into kl; the length
  * of the key in octets is provided as keylen.  this function
@@ -603,39 +618,40 @@ srtp_stream_clone(const srtp_stream_ctx_t *stream_template,
  */
 
 typedef enum {
-  label_rtp_encryption  = 0x00,
-  label_rtp_msg_auth    = 0x01,
-  label_rtp_salt        = 0x02,
-  label_rtcp_encryption = 0x03,
-  label_rtcp_msg_auth   = 0x04,
-  label_rtcp_salt       = 0x05,
-  label_rtp_header_encryption = 0x06,
-  label_rtp_header_salt = 0x07
+    label_rtp_encryption = 0x00,
+    label_rtp_msg_auth = 0x01,
+    label_rtp_salt = 0x02,
+    label_rtcp_encryption = 0x03,
+    label_rtcp_msg_auth = 0x04,
+    label_rtcp_salt = 0x05,
+    label_rtp_header_encryption = 0x06,
+    label_rtp_header_salt = 0x07
 } srtp_prf_label;
 
 #define MAX_SRTP_KEY_LEN 256
 
 #if defined(OPENSSL) && defined(OPENSSL_KDF)
 #define MAX_SRTP_AESKEY_LEN 32
-#define MAX_SRTP_SALT_LEN 14 
+#define MAX_SRTP_SALT_LEN 14
 
 /*
  * srtp_kdf_t represents a key derivation function.  The SRTP
  * default KDF is the only one implemented at present.
  */
-typedef struct { 
+typedef struct {
     uint8_t master_key[MAX_SRTP_AESKEY_LEN];
     uint8_t master_salt[MAX_SRTP_SALT_LEN];
     const EVP_CIPHER *evp;
 } srtp_kdf_t;
 
-
-static srtp_err_status_t srtp_kdf_init(srtp_kdf_t *kdf, const uint8_t *key, int key_len, int salt_len) 
+static srtp_err_status_t
+srtp_kdf_init(srtp_kdf_t *kdf, const uint8_t *key, int key_len, int salt_len)
 {
     memset(kdf, 0x0, sizeof(srtp_kdf_t));
 
     /* The NULL cipher has zero key length */
-    if (key_len == 0) return srtp_err_status_ok;
+    if (key_len == 0)
+        return srtp_err_status_ok;
 
     if ((key_len > MAX_SRTP_AESKEY_LEN) || (salt_len > MAX_SRTP_SALT_LEN)) {
         return srtp_err_status_bad_param;
@@ -654,17 +670,21 @@ static srtp_err_status_t srtp_kdf_init(srtp_kdf_t *kdf, const uint8_t *key, int 
         return srtp_err_status_bad_param;
         break;
     }
-    memcpy(kdf->master_key, key, key_len); 
-    memcpy(kdf->master_salt, key+key_len, salt_len); 
+    memcpy(kdf->master_key, key, key_len);
+    memcpy(kdf->master_salt, key + key_len, salt_len);
     return srtp_err_status_ok;
 }
 
-static srtp_err_status_t srtp_kdf_generate(srtp_kdf_t *kdf, srtp_prf_label label, uint8_t *key, unsigned int length) 
+static srtp_err_status_t srtp_kdf_generate(srtp_kdf_t *kdf,
+                                           srtp_prf_label label,
+                                           uint8_t *key,
+                                           unsigned int length)
 {
     int ret;
 
     /* The NULL cipher will not have an EVP */
-    if (!kdf->evp) return srtp_err_status_ok;
+    if (!kdf->evp)
+        return srtp_err_status_ok;
     octet_string_set_to_zero(key, length);
 
     /*
@@ -672,7 +692,8 @@ static srtp_err_status_t srtp_kdf_generate(srtp_kdf_t *kdf, srtp_prf_label label
      * This is useful if OpenSSL is in FIPS mode and FIP
      * compliance is required for SRTP.
      */
-    ret = kdf_srtp(kdf->evp, (char *)&kdf->master_key, (char *)&kdf->master_salt, NULL, NULL, label, (char *)key);
+    ret = kdf_srtp(kdf->evp, (char *)&kdf->master_key,
+                   (char *)&kdf->master_salt, NULL, NULL, label, (char *)key);
     if (ret == -1) {
         return (srtp_err_status_algo_fail);
     }
@@ -680,25 +701,27 @@ static srtp_err_status_t srtp_kdf_generate(srtp_kdf_t *kdf, srtp_prf_label label
     return srtp_err_status_ok;
 }
 
-static srtp_err_status_t srtp_kdf_clear(srtp_kdf_t *kdf) {
+static srtp_err_status_t srtp_kdf_clear(srtp_kdf_t *kdf)
+{
     octet_string_set_to_zero(kdf->master_key, MAX_SRTP_AESKEY_LEN);
     octet_string_set_to_zero(kdf->master_salt, MAX_SRTP_SALT_LEN);
     kdf->evp = NULL;
 
-    return srtp_err_status_ok;  
+    return srtp_err_status_ok;
 }
 
-#else /* if OPENSSL_KDF */
+#else  /* if OPENSSL_KDF */
 
 /*
  * srtp_kdf_t represents a key derivation function.  The SRTP
  * default KDF is the only one implemented at present.
  */
-typedef struct { 
-    srtp_cipher_t *cipher;    /* cipher used for key derivation  */  
+typedef struct {
+    srtp_cipher_t *cipher; /* cipher used for key derivation  */
 } srtp_kdf_t;
 
-static srtp_err_status_t srtp_kdf_init(srtp_kdf_t *kdf, const uint8_t *key, int key_len)
+static srtp_err_status_t
+srtp_kdf_init(srtp_kdf_t *kdf, const uint8_t *key, int key_len)
 {
     srtp_cipher_type_id_t cipher_id;
     switch (key_len) {
@@ -718,7 +741,8 @@ static srtp_err_status_t srtp_kdf_init(srtp_kdf_t *kdf, const uint8_t *key, int 
 
     srtp_err_status_t stat;
     stat = srtp_crypto_kernel_alloc_cipher(cipher_id, &kdf->cipher, key_len, 0);
-    if (stat) return stat;
+    if (stat)
+        return stat;
 
     stat = srtp_cipher_init(kdf->cipher, key);
     if (stat) {
@@ -728,68 +752,74 @@ static srtp_err_status_t srtp_kdf_init(srtp_kdf_t *kdf, const uint8_t *key, int 
     return srtp_err_status_ok;
 }
 
-static srtp_err_status_t srtp_kdf_generate(srtp_kdf_t *kdf, srtp_prf_label label, uint8_t *key, unsigned int length) 
+static srtp_err_status_t srtp_kdf_generate(srtp_kdf_t *kdf,
+                                           srtp_prf_label label,
+                                           uint8_t *key,
+                                           unsigned int length)
 {
     srtp_err_status_t status;
     v128_t nonce;
-  
+
     /* set eigth octet of nonce to <label>, set the rest of it to zero */
     v128_set_to_zero(&nonce);
     nonce.v8[7] = label;
- 
-    status = srtp_cipher_set_iv(kdf->cipher, (uint8_t*)&nonce, srtp_direction_encrypt);
-    if (status) return status;
-  
+
+    status = srtp_cipher_set_iv(kdf->cipher, (uint8_t *)&nonce,
+                                srtp_direction_encrypt);
+    if (status)
+        return status;
+
     /* generate keystream output */
     octet_string_set_to_zero(key, length);
     status = srtp_cipher_encrypt(kdf->cipher, key, &length);
-    if (status) return status;
+    if (status)
+        return status;
 
     return srtp_err_status_ok;
 }
 
-static srtp_err_status_t srtp_kdf_clear(srtp_kdf_t *kdf) {
+static srtp_err_status_t srtp_kdf_clear(srtp_kdf_t *kdf)
+{
     srtp_err_status_t status;
     status = srtp_cipher_dealloc(kdf->cipher);
-    if (status) return status;
+    if (status)
+        return status;
     kdf->cipher = NULL;
-    return srtp_err_status_ok;  
+    return srtp_err_status_ok;
 }
 #endif /* else OPENSSL_KDF */
 
 /*
- *  end of key derivation functions 
+ *  end of key derivation functions
  */
-
-
 
 /* Get the base key length corresponding to a given combined key+salt
  * length for the given cipher.
  * TODO: key and salt lengths should be separate fields in the policy.  */
-static inline int base_key_length(const srtp_cipher_type_t *cipher, int key_length)
+static inline int base_key_length(const srtp_cipher_type_t *cipher,
+                                  int key_length)
 {
-  switch (cipher->id) {
-  case SRTP_AES_ICM_128:
-  case SRTP_AES_ICM_192:
-  case SRTP_AES_ICM_256:
-    /* The legacy modes are derived from
-     * the configured key length on the policy */
-    return key_length - SRTP_SALT_LEN;
-    break;
-  case SRTP_AES_GCM_128:
-    return key_length - SRTP_AEAD_SALT_LEN;
-    break;
-  case SRTP_AES_GCM_256:
-      return key_length - SRTP_AEAD_SALT_LEN;
-    break;
-  default:
-    return key_length;
-    break;
-  }
+    switch (cipher->id) {
+    case SRTP_AES_ICM_128:
+    case SRTP_AES_ICM_192:
+    case SRTP_AES_ICM_256:
+        /* The legacy modes are derived from
+         * the configured key length on the policy */
+        return key_length - SRTP_SALT_LEN;
+        break;
+    case SRTP_AES_GCM_128:
+        return key_length - SRTP_AEAD_SALT_LEN;
+        break;
+    case SRTP_AES_GCM_256:
+        return key_length - SRTP_AEAD_SALT_LEN;
+        break;
+    default:
+        return key_length;
+        break;
+    }
 }
 
-unsigned int
-srtp_validate_policy_master_keys(const srtp_policy_t *policy)
+unsigned int srtp_validate_policy_master_keys(const srtp_policy_t *policy)
 {
     int i = 0;
 
@@ -798,23 +828,24 @@ srtp_validate_policy_master_keys(const srtp_policy_t *policy)
             return 0;
 
         if (policy->num_master_keys > SRTP_MAX_NUM_MASTER_KEYS)
-	    return 0;
-	
+            return 0;
+
         for (i = 0; i < policy->num_master_keys; i++) {
             if (policy->keys[i]->key == NULL)
                 return 0;
-	    if (policy->keys[i]->mki_size > SRTP_MAX_MKI_LEN)
-		return 0;
+            if (policy->keys[i]->mki_size > SRTP_MAX_MKI_LEN)
+                return 0;
         }
     }
 
     return 1;
 }
 
-srtp_session_keys_t*
+srtp_session_keys_t *
 srtp_get_session_keys_with_mki_index(srtp_stream_ctx_t *stream,
                                      unsigned int use_mki,
-                                     unsigned int mki_index) {
+                                     unsigned int mki_index)
+{
     if (use_mki) {
         if (mki_index < stream->num_master_keys) {
             return &stream->session_keys[mki_index];
@@ -824,9 +855,9 @@ srtp_get_session_keys_with_mki_index(srtp_stream_ctx_t *stream,
     return &stream->session_keys[0];
 }
 
-unsigned int
-srtp_inject_mki(uint8_t *mki_tag_location, srtp_session_keys_t* session_keys,
-                unsigned int use_mki)
+unsigned int srtp_inject_mki(uint8_t *mki_tag_location,
+                             srtp_session_keys_t *session_keys,
+                             unsigned int use_mki)
 {
     unsigned int mki_size = 0;
 
@@ -846,12 +877,13 @@ srtp_err_status_t
 srtp_stream_init_all_master_keys(srtp_stream_ctx_t *srtp,
                                  unsigned char *key,
                                  srtp_master_key_t **keys,
-                                 const unsigned int max_master_keys) {
+                                 const unsigned int max_master_keys)
+{
     int i = 0;
     srtp_err_status_t status = srtp_err_status_ok;
     srtp_master_key_t single_master_key;
 
-    if ( key != NULL ) {
+    if (key != NULL) {
         srtp->num_master_keys = 1;
         single_master_key.key = key;
         single_master_key.mki_id = NULL;
@@ -860,7 +892,8 @@ srtp_stream_init_all_master_keys(srtp_stream_ctx_t *srtp,
     } else {
         srtp->num_master_keys = max_master_keys;
 
-        for (i = 0; i < srtp->num_master_keys && i < SRTP_MAX_NUM_MASTER_KEYS; i++) {
+        for (i = 0; i < srtp->num_master_keys && i < SRTP_MAX_NUM_MASTER_KEYS;
+             i++) {
             status = srtp_stream_init_keys(srtp, keys[i], i);
 
             if (status) {
@@ -872,485 +905,517 @@ srtp_stream_init_all_master_keys(srtp_stream_ctx_t *srtp,
     return status;
 }
 
-srtp_err_status_t
-srtp_stream_init_keys(srtp_stream_ctx_t *srtp, srtp_master_key_t *master_key,
-                      const unsigned int current_mki_index) {
-  srtp_err_status_t stat;
-  srtp_kdf_t kdf;
-  uint8_t tmp_key[MAX_SRTP_KEY_LEN];
-  int kdf_keylen = 30, rtp_keylen, rtcp_keylen;
-  int rtp_base_key_len, rtp_salt_len;
-  int rtcp_base_key_len, rtcp_salt_len;
-  srtp_session_keys_t *session_keys = NULL;
-  unsigned char *key = master_key->key;
-
-  /* If RTP or RTCP have a key length > AES-128, assume matching kdf. */
-  /* TODO: kdf algorithm, master key length, and master salt length should
-   * be part of srtp_policy_t. */
-  session_keys = &srtp->session_keys[current_mki_index];
-
-   /* initialize key limit to maximum value */
-#ifdef NO_64BIT_MATH
+srtp_err_status_t srtp_stream_init_keys(srtp_stream_ctx_t *srtp,
+                                        srtp_master_key_t *master_key,
+                                        const unsigned int current_mki_index)
 {
-   uint64_t temp;
-   temp = make64(UINT_MAX,UINT_MAX);
-   srtp_key_limit_set(session_keys->limit, temp);
-}
-#else
-   srtp_key_limit_set(session_keys->limit, 0xffffffffffffLL);
-#endif
+    srtp_err_status_t stat;
+    srtp_kdf_t kdf;
+    uint8_t tmp_key[MAX_SRTP_KEY_LEN];
+    int kdf_keylen = 30, rtp_keylen, rtcp_keylen;
+    int rtp_base_key_len, rtp_salt_len;
+    int rtcp_base_key_len, rtcp_salt_len;
+    srtp_session_keys_t *session_keys = NULL;
+    unsigned char *key = master_key->key;
 
+    /* If RTP or RTCP have a key length > AES-128, assume matching kdf. */
+    /* TODO: kdf algorithm, master key length, and master salt length should
+     * be part of srtp_policy_t.
+    */
+    session_keys = &srtp->session_keys[current_mki_index];
 
-  if ( master_key->mki_size != 0 ) {
-      session_keys->mki_id = srtp_crypto_alloc(master_key->mki_size);
-
-      if (session_keys->mki_id == NULL) {
-        return srtp_err_status_init_fail;
-      }
-      memset(session_keys->mki_id, 0x0, master_key->mki_size);
-      memcpy(session_keys->mki_id, master_key->mki_id, master_key->mki_size);
-  } else {
-      session_keys->mki_id = NULL;
-  }
-
-  session_keys->mki_size = master_key->mki_size;
-
-  rtp_keylen = srtp_cipher_get_key_length(session_keys->rtp_cipher);
-  rtcp_keylen = srtp_cipher_get_key_length(session_keys->rtcp_cipher);
-  rtp_base_key_len = base_key_length(session_keys->rtp_cipher->type, rtp_keylen);
-  rtp_salt_len = rtp_keylen - rtp_base_key_len;
-
-  if (rtp_keylen > kdf_keylen) {
-    kdf_keylen = 46;  /* AES-CTR mode is always used for KDF */
-  }
-
-  if (rtcp_keylen > kdf_keylen) {
-    kdf_keylen = 46;  /* AES-CTR mode is always used for KDF */
-  }
-
-  debug_print(mod_srtp, "srtp key len: %d", rtp_keylen);
-  debug_print(mod_srtp, "srtcp key len: %d", rtcp_keylen);
-  debug_print(mod_srtp, "base key len: %d", rtp_base_key_len);
-  debug_print(mod_srtp, "kdf key len: %d", kdf_keylen);
-  debug_print(mod_srtp, "rtp salt len: %d", rtp_salt_len);
-
-  /* 
-   * Make sure the key given to us is 'zero' appended.  GCM
-   * mode uses a shorter master SALT (96 bits), but still relies on 
-   * the legacy CTR mode KDF, which uses a 112 bit master SALT.
-   */
-  memset(tmp_key, 0x0, MAX_SRTP_KEY_LEN);
-  memcpy(tmp_key, key, (rtp_base_key_len + rtp_salt_len));
-
-  /* initialize KDF state     */
-#if defined(OPENSSL) && defined(OPENSSL_KDF)
-  stat = srtp_kdf_init(&kdf, (const uint8_t *)tmp_key, rtp_base_key_len, rtp_salt_len); 
-#else
-  stat = srtp_kdf_init(&kdf, (const uint8_t *)tmp_key, kdf_keylen);
-#endif
-  if (stat) {
-    /* zeroize temp buffer */
-    octet_string_set_to_zero(tmp_key, MAX_SRTP_KEY_LEN);
-    return srtp_err_status_init_fail;
-  }
-  
-  /* generate encryption key  */
-  stat = srtp_kdf_generate(&kdf, label_rtp_encryption, 
-			   tmp_key, rtp_base_key_len);
-  if (stat) {
-    /* zeroize temp buffer */
-    octet_string_set_to_zero(tmp_key, MAX_SRTP_KEY_LEN);
-    return srtp_err_status_init_fail;
-  }
-  debug_print(mod_srtp, "cipher key: %s", 
-	      srtp_octet_string_hex_string(tmp_key, rtp_base_key_len));
-
-  /* 
-   * if the cipher in the srtp context uses a salt, then we need
-   * to generate the salt value
-   */
-  if (rtp_salt_len > 0) {
-    debug_print(mod_srtp, "found rtp_salt_len > 0, generating salt", NULL);
-
-    /* generate encryption salt, put after encryption key */
-    stat = srtp_kdf_generate(&kdf, label_rtp_salt, 
-			     tmp_key + rtp_base_key_len, rtp_salt_len);
-    if (stat) {
-      /* zeroize temp buffer */
-      octet_string_set_to_zero(tmp_key, MAX_SRTP_KEY_LEN);
-      return srtp_err_status_init_fail;
+/* initialize key limit to maximum value */
+#ifdef NO_64BIT_MATH
+    {
+        uint64_t temp;
+        temp = make64(UINT_MAX, UINT_MAX);
+        srtp_key_limit_set(session_keys->limit, temp);
     }
-    memcpy(session_keys->salt, tmp_key + rtp_base_key_len, SRTP_AEAD_SALT_LEN);
-  }
-  if (rtp_salt_len > 0) {
-    debug_print(mod_srtp, "cipher salt: %s",
-		srtp_octet_string_hex_string(tmp_key + rtp_base_key_len, rtp_salt_len));
-  }
-
-  /* initialize cipher */
-  stat = srtp_cipher_init(session_keys->rtp_cipher, tmp_key);
-  if (stat) {
-    /* zeroize temp buffer */
-    octet_string_set_to_zero(tmp_key, MAX_SRTP_KEY_LEN);
-    return srtp_err_status_init_fail;
-  }
-
-  if (session_keys->rtp_xtn_hdr_cipher) {
-    /* generate extensions header encryption key  */
-    int rtp_xtn_hdr_keylen;
-    int rtp_xtn_hdr_base_key_len;
-    int rtp_xtn_hdr_salt_len;
-    srtp_kdf_t tmp_kdf;
-    srtp_kdf_t *xtn_hdr_kdf;
-
-    if (session_keys->rtp_xtn_hdr_cipher->type != session_keys->rtp_cipher->type) {
-      /* With GCM ciphers, the header extensions are still encrypted using the corresponding ICM cipher. */
-      /* See https://tools.ietf.org/html/rfc7714#section-8.3 */
-      uint8_t tmp_xtn_hdr_key[MAX_SRTP_KEY_LEN];
-      rtp_xtn_hdr_keylen = srtp_cipher_get_key_length(session_keys->rtp_xtn_hdr_cipher);
-      rtp_xtn_hdr_base_key_len = base_key_length(session_keys->rtp_xtn_hdr_cipher->type,
-                                                 rtp_xtn_hdr_keylen);
-      rtp_xtn_hdr_salt_len = rtp_xtn_hdr_keylen - rtp_xtn_hdr_base_key_len;
-      if (rtp_xtn_hdr_salt_len > rtp_salt_len) {
-        switch (session_keys->rtp_cipher->type->id) {
-        case SRTP_AES_GCM_128:
-        case SRTP_AES_GCM_256:
-          /* The shorter GCM salt is padded to the required ICM salt length. */
-          rtp_xtn_hdr_salt_len = rtp_salt_len;
-          break;
-        default:
-          /* zeroize temp buffer */
-          octet_string_set_to_zero(tmp_key, MAX_SRTP_KEY_LEN);
-          return srtp_err_status_bad_param;
-        }
-      }
-      memset(tmp_xtn_hdr_key, 0x0, MAX_SRTP_KEY_LEN);
-      memcpy(tmp_xtn_hdr_key, key, (rtp_xtn_hdr_base_key_len + rtp_xtn_hdr_salt_len));
-      xtn_hdr_kdf = &tmp_kdf;
-
-      /* initialize KDF state     */
-#if defined(OPENSSL) && defined(OPENSSL_KDF)
-      stat = srtp_kdf_init(xtn_hdr_kdf, (const uint8_t *)tmp_xtn_hdr_key, rtp_xtn_hdr_base_key_len, rtp_xtn_hdr_salt_len);
 #else
-      stat = srtp_kdf_init(xtn_hdr_kdf, (const uint8_t *)tmp_xtn_hdr_key, kdf_keylen);
+    srtp_key_limit_set(session_keys->limit, 0xffffffffffffLL);
 #endif
-      octet_string_set_to_zero(tmp_xtn_hdr_key, MAX_SRTP_KEY_LEN);
-      if (stat) {
+
+    if (master_key->mki_size != 0) {
+        session_keys->mki_id = srtp_crypto_alloc(master_key->mki_size);
+
+        if (session_keys->mki_id == NULL) {
+            return srtp_err_status_init_fail;
+        }
+        memset(session_keys->mki_id, 0x0, master_key->mki_size);
+        memcpy(session_keys->mki_id, master_key->mki_id, master_key->mki_size);
+    } else {
+        session_keys->mki_id = NULL;
+    }
+
+    session_keys->mki_size = master_key->mki_size;
+
+    rtp_keylen = srtp_cipher_get_key_length(session_keys->rtp_cipher);
+    rtcp_keylen = srtp_cipher_get_key_length(session_keys->rtcp_cipher);
+    rtp_base_key_len =
+        base_key_length(session_keys->rtp_cipher->type, rtp_keylen);
+    rtp_salt_len = rtp_keylen - rtp_base_key_len;
+
+    if (rtp_keylen > kdf_keylen) {
+        kdf_keylen = 46; /* AES-CTR mode is always used for KDF */
+    }
+
+    if (rtcp_keylen > kdf_keylen) {
+        kdf_keylen = 46; /* AES-CTR mode is always used for KDF */
+    }
+
+    debug_print(mod_srtp, "srtp key len: %d", rtp_keylen);
+    debug_print(mod_srtp, "srtcp key len: %d", rtcp_keylen);
+    debug_print(mod_srtp, "base key len: %d", rtp_base_key_len);
+    debug_print(mod_srtp, "kdf key len: %d", kdf_keylen);
+    debug_print(mod_srtp, "rtp salt len: %d", rtp_salt_len);
+
+    /*
+     * Make sure the key given to us is 'zero' appended.  GCM
+     * mode uses a shorter master SALT (96 bits), but still relies on
+     * the legacy CTR mode KDF, which uses a 112 bit master SALT.
+     */
+    memset(tmp_key, 0x0, MAX_SRTP_KEY_LEN);
+    memcpy(tmp_key, key, (rtp_base_key_len + rtp_salt_len));
+
+/* initialize KDF state     */
+#if defined(OPENSSL) && defined(OPENSSL_KDF)
+    stat = srtp_kdf_init(&kdf, (const uint8_t *)tmp_key, rtp_base_key_len,
+                         rtp_salt_len);
+#else
+    stat = srtp_kdf_init(&kdf, (const uint8_t *)tmp_key, kdf_keylen);
+#endif
+    if (stat) {
         /* zeroize temp buffer */
         octet_string_set_to_zero(tmp_key, MAX_SRTP_KEY_LEN);
         return srtp_err_status_init_fail;
-      }
-    } else {
-      /* Reuse main KDF. */
-      rtp_xtn_hdr_keylen = rtp_keylen;
-      rtp_xtn_hdr_base_key_len = rtp_base_key_len;
-      rtp_xtn_hdr_salt_len = rtp_salt_len;
-      xtn_hdr_kdf = &kdf;
     }
 
-    stat = srtp_kdf_generate(xtn_hdr_kdf, label_rtp_header_encryption,
-           tmp_key, rtp_xtn_hdr_base_key_len);
+    /* generate encryption key  */
+    stat = srtp_kdf_generate(&kdf, label_rtp_encryption, tmp_key,
+                             rtp_base_key_len);
     if (stat) {
-      /* zeroize temp buffer */
-      octet_string_set_to_zero(tmp_key, MAX_SRTP_KEY_LEN);
-      return srtp_err_status_init_fail;
+        /* zeroize temp buffer */
+        octet_string_set_to_zero(tmp_key, MAX_SRTP_KEY_LEN);
+        return srtp_err_status_init_fail;
     }
-    debug_print(mod_srtp, "extensions cipher key: %s",
-          srtp_octet_string_hex_string(tmp_key, rtp_xtn_hdr_base_key_len));
+    debug_print(mod_srtp, "cipher key: %s",
+                srtp_octet_string_hex_string(tmp_key, rtp_base_key_len));
 
     /*
      * if the cipher in the srtp context uses a salt, then we need
      * to generate the salt value
      */
-    if (rtp_xtn_hdr_salt_len > 0) {
-      debug_print(mod_srtp, "found rtp_xtn_hdr_salt_len > 0, generating salt", NULL);
+    if (rtp_salt_len > 0) {
+        debug_print(mod_srtp, "found rtp_salt_len > 0, generating salt", NULL);
 
-      /* generate encryption salt, put after encryption key */
-      stat = srtp_kdf_generate(xtn_hdr_kdf, label_rtp_header_salt,
-             tmp_key + rtp_xtn_hdr_base_key_len, rtp_xtn_hdr_salt_len);
-      if (stat) {
+        /* generate encryption salt, put after encryption key */
+        stat = srtp_kdf_generate(&kdf, label_rtp_salt,
+                                 tmp_key + rtp_base_key_len, rtp_salt_len);
+        if (stat) {
+            /* zeroize temp buffer */
+            octet_string_set_to_zero(tmp_key, MAX_SRTP_KEY_LEN);
+            return srtp_err_status_init_fail;
+        }
+        memcpy(session_keys->salt, tmp_key + rtp_base_key_len,
+               SRTP_AEAD_SALT_LEN);
+    }
+    if (rtp_salt_len > 0) {
+        debug_print(mod_srtp, "cipher salt: %s",
+                    srtp_octet_string_hex_string(tmp_key + rtp_base_key_len,
+                                                 rtp_salt_len));
+    }
+
+    /* initialize cipher */
+    stat = srtp_cipher_init(session_keys->rtp_cipher, tmp_key);
+    if (stat) {
         /* zeroize temp buffer */
         octet_string_set_to_zero(tmp_key, MAX_SRTP_KEY_LEN);
         return srtp_err_status_init_fail;
-      }
-    }
-    if (rtp_xtn_hdr_salt_len > 0) {
-      debug_print(mod_srtp, "extensions cipher salt: %s",
-      srtp_octet_string_hex_string(tmp_key + rtp_xtn_hdr_base_key_len, rtp_xtn_hdr_salt_len));
     }
 
-    /* initialize extensions header cipher */
-    stat = srtp_cipher_init(session_keys->rtp_xtn_hdr_cipher, tmp_key);
+    if (session_keys->rtp_xtn_hdr_cipher) {
+        /* generate extensions header encryption key  */
+        int rtp_xtn_hdr_keylen;
+        int rtp_xtn_hdr_base_key_len;
+        int rtp_xtn_hdr_salt_len;
+        srtp_kdf_t tmp_kdf;
+        srtp_kdf_t *xtn_hdr_kdf;
+
+        if (session_keys->rtp_xtn_hdr_cipher->type !=
+            session_keys->rtp_cipher->type) {
+            /*
+             * With GCM ciphers, the header extensions are still encrypted using
+             * the corresponding ICM cipher.
+             * See https://tools.ietf.org/html/rfc7714#section-8.3
+             */
+            uint8_t tmp_xtn_hdr_key[MAX_SRTP_KEY_LEN];
+            rtp_xtn_hdr_keylen =
+                srtp_cipher_get_key_length(session_keys->rtp_xtn_hdr_cipher);
+            rtp_xtn_hdr_base_key_len = base_key_length(
+                session_keys->rtp_xtn_hdr_cipher->type, rtp_xtn_hdr_keylen);
+            rtp_xtn_hdr_salt_len =
+                rtp_xtn_hdr_keylen - rtp_xtn_hdr_base_key_len;
+            if (rtp_xtn_hdr_salt_len > rtp_salt_len) {
+                switch (session_keys->rtp_cipher->type->id) {
+                case SRTP_AES_GCM_128:
+                case SRTP_AES_GCM_256:
+                    /*
+                     * The shorter GCM salt is padded to the required ICM salt
+                     * length.
+                     */
+                    rtp_xtn_hdr_salt_len = rtp_salt_len;
+                    break;
+                default:
+                    /* zeroize temp buffer */
+                    octet_string_set_to_zero(tmp_key, MAX_SRTP_KEY_LEN);
+                    return srtp_err_status_bad_param;
+                }
+            }
+            memset(tmp_xtn_hdr_key, 0x0, MAX_SRTP_KEY_LEN);
+            memcpy(tmp_xtn_hdr_key, key,
+                   (rtp_xtn_hdr_base_key_len + rtp_xtn_hdr_salt_len));
+            xtn_hdr_kdf = &tmp_kdf;
+
+/* initialize KDF state */
+#if defined(OPENSSL) && defined(OPENSSL_KDF)
+            stat =
+                srtp_kdf_init(xtn_hdr_kdf, (const uint8_t *)tmp_xtn_hdr_key,
+                              rtp_xtn_hdr_base_key_len, rtp_xtn_hdr_salt_len);
+#else
+            stat = srtp_kdf_init(xtn_hdr_kdf, (const uint8_t *)tmp_xtn_hdr_key,
+                                 kdf_keylen);
+#endif
+            octet_string_set_to_zero(tmp_xtn_hdr_key, MAX_SRTP_KEY_LEN);
+            if (stat) {
+                /* zeroize temp buffer */
+                octet_string_set_to_zero(tmp_key, MAX_SRTP_KEY_LEN);
+                return srtp_err_status_init_fail;
+            }
+        } else {
+            /* Reuse main KDF. */
+            rtp_xtn_hdr_keylen = rtp_keylen;
+            rtp_xtn_hdr_base_key_len = rtp_base_key_len;
+            rtp_xtn_hdr_salt_len = rtp_salt_len;
+            xtn_hdr_kdf = &kdf;
+        }
+
+        stat = srtp_kdf_generate(xtn_hdr_kdf, label_rtp_header_encryption,
+                                 tmp_key, rtp_xtn_hdr_base_key_len);
+        if (stat) {
+            /* zeroize temp buffer */
+            octet_string_set_to_zero(tmp_key, MAX_SRTP_KEY_LEN);
+            return srtp_err_status_init_fail;
+        }
+        debug_print(
+            mod_srtp, "extensions cipher key: %s",
+            srtp_octet_string_hex_string(tmp_key, rtp_xtn_hdr_base_key_len));
+
+        /*
+         * if the cipher in the srtp context uses a salt, then we need
+         * to generate the salt value
+         */
+        if (rtp_xtn_hdr_salt_len > 0) {
+            debug_print(mod_srtp,
+                        "found rtp_xtn_hdr_salt_len > 0, generating salt",
+                        NULL);
+
+            /* generate encryption salt, put after encryption key */
+            stat = srtp_kdf_generate(xtn_hdr_kdf, label_rtp_header_salt,
+                                     tmp_key + rtp_xtn_hdr_base_key_len,
+                                     rtp_xtn_hdr_salt_len);
+            if (stat) {
+                /* zeroize temp buffer */
+                octet_string_set_to_zero(tmp_key, MAX_SRTP_KEY_LEN);
+                return srtp_err_status_init_fail;
+            }
+        }
+        if (rtp_xtn_hdr_salt_len > 0) {
+            debug_print(
+                mod_srtp, "extensions cipher salt: %s",
+                srtp_octet_string_hex_string(tmp_key + rtp_xtn_hdr_base_key_len,
+                                             rtp_xtn_hdr_salt_len));
+        }
+
+        /* initialize extensions header cipher */
+        stat = srtp_cipher_init(session_keys->rtp_xtn_hdr_cipher, tmp_key);
+        if (stat) {
+            /* zeroize temp buffer */
+            octet_string_set_to_zero(tmp_key, MAX_SRTP_KEY_LEN);
+            return srtp_err_status_init_fail;
+        }
+
+        if (xtn_hdr_kdf != &kdf) {
+            /* release memory for custom header extension encryption kdf */
+            stat = srtp_kdf_clear(xtn_hdr_kdf);
+            if (stat) {
+                /* zeroize temp buffer */
+                octet_string_set_to_zero(tmp_key, MAX_SRTP_KEY_LEN);
+                return srtp_err_status_init_fail;
+            }
+        }
+    }
+
+    /* generate authentication key */
+    stat = srtp_kdf_generate(&kdf, label_rtp_msg_auth, tmp_key,
+                             srtp_auth_get_key_length(session_keys->rtp_auth));
     if (stat) {
-      /* zeroize temp buffer */
-      octet_string_set_to_zero(tmp_key, MAX_SRTP_KEY_LEN);
-      return srtp_err_status_init_fail;
-    }
-
-    if (xtn_hdr_kdf != &kdf) {
-      /* release memory for custom header extension encryption kdf */
-      stat = srtp_kdf_clear(xtn_hdr_kdf);
-      if (stat) {
         /* zeroize temp buffer */
         octet_string_set_to_zero(tmp_key, MAX_SRTP_KEY_LEN);
         return srtp_err_status_init_fail;
-      }
     }
-  }
+    debug_print(mod_srtp, "auth key:   %s",
+                srtp_octet_string_hex_string(
+                    tmp_key, srtp_auth_get_key_length(session_keys->rtp_auth)));
 
-  /* generate authentication key */
-  stat = srtp_kdf_generate(&kdf, label_rtp_msg_auth,
-			   tmp_key, srtp_auth_get_key_length(session_keys->rtp_auth));
-  if (stat) {
-    /* zeroize temp buffer */
-    octet_string_set_to_zero(tmp_key, MAX_SRTP_KEY_LEN);
-    return srtp_err_status_init_fail;
-  }
-  debug_print(mod_srtp, "auth key:   %s",
-	      srtp_octet_string_hex_string(tmp_key, 
-				      srtp_auth_get_key_length(session_keys->rtp_auth))); 
-
-  /* initialize auth function */
-  stat = srtp_auth_init(session_keys->rtp_auth, tmp_key);
-  if (stat) {
-    /* zeroize temp buffer */
-    octet_string_set_to_zero(tmp_key, MAX_SRTP_KEY_LEN);
-    return srtp_err_status_init_fail;
-  }
-
-  /*
-   * ...now initialize SRTCP keys
-   */
-
-  rtcp_base_key_len = base_key_length(session_keys->rtcp_cipher->type, rtcp_keylen);
-  rtcp_salt_len = rtcp_keylen - rtcp_base_key_len;
-  debug_print(mod_srtp, "rtcp salt len: %d", rtcp_salt_len);
-  
-  /* generate encryption key  */
-  stat = srtp_kdf_generate(&kdf, label_rtcp_encryption, 
-			   tmp_key, rtcp_base_key_len);
-  if (stat) {
-    /* zeroize temp buffer */
-    octet_string_set_to_zero(tmp_key, MAX_SRTP_KEY_LEN);
-    return srtp_err_status_init_fail;
-  }
-
-  /* 
-   * if the cipher in the srtp context uses a salt, then we need
-   * to generate the salt value
-   */
-  if (rtcp_salt_len > 0) {
-    debug_print(mod_srtp, "found rtcp_salt_len > 0, generating rtcp salt",
-		NULL);
-
-    /* generate encryption salt, put after encryption key */
-    stat = srtp_kdf_generate(&kdf, label_rtcp_salt, 
-			     tmp_key + rtcp_base_key_len, rtcp_salt_len);
+    /* initialize auth function */
+    stat = srtp_auth_init(session_keys->rtp_auth, tmp_key);
     if (stat) {
-      /* zeroize temp buffer */
-      octet_string_set_to_zero(tmp_key, MAX_SRTP_KEY_LEN);
-      return srtp_err_status_init_fail;
+        /* zeroize temp buffer */
+        octet_string_set_to_zero(tmp_key, MAX_SRTP_KEY_LEN);
+        return srtp_err_status_init_fail;
     }
-    memcpy(session_keys->c_salt, tmp_key + rtcp_base_key_len, SRTP_AEAD_SALT_LEN);
-  }
-  debug_print(mod_srtp, "rtcp cipher key: %s", 
-	      srtp_octet_string_hex_string(tmp_key, rtcp_base_key_len));  
-  if (rtcp_salt_len > 0) {
-    debug_print(mod_srtp, "rtcp cipher salt: %s",
-		srtp_octet_string_hex_string(tmp_key + rtcp_base_key_len, rtcp_salt_len));
-  }
 
-  /* initialize cipher */
-  stat = srtp_cipher_init(session_keys->rtcp_cipher, tmp_key);
-  if (stat) {
-    /* zeroize temp buffer */
+    /*
+     * ...now initialize SRTCP keys
+     */
+
+    rtcp_base_key_len =
+        base_key_length(session_keys->rtcp_cipher->type, rtcp_keylen);
+    rtcp_salt_len = rtcp_keylen - rtcp_base_key_len;
+    debug_print(mod_srtp, "rtcp salt len: %d", rtcp_salt_len);
+
+    /* generate encryption key  */
+    stat = srtp_kdf_generate(&kdf, label_rtcp_encryption, tmp_key,
+                             rtcp_base_key_len);
+    if (stat) {
+        /* zeroize temp buffer */
+        octet_string_set_to_zero(tmp_key, MAX_SRTP_KEY_LEN);
+        return srtp_err_status_init_fail;
+    }
+
+    /*
+     * if the cipher in the srtp context uses a salt, then we need
+     * to generate the salt value
+     */
+    if (rtcp_salt_len > 0) {
+        debug_print(mod_srtp, "found rtcp_salt_len > 0, generating rtcp salt",
+                    NULL);
+
+        /* generate encryption salt, put after encryption key */
+        stat = srtp_kdf_generate(&kdf, label_rtcp_salt,
+                                 tmp_key + rtcp_base_key_len, rtcp_salt_len);
+        if (stat) {
+            /* zeroize temp buffer */
+            octet_string_set_to_zero(tmp_key, MAX_SRTP_KEY_LEN);
+            return srtp_err_status_init_fail;
+        }
+        memcpy(session_keys->c_salt, tmp_key + rtcp_base_key_len,
+               SRTP_AEAD_SALT_LEN);
+    }
+    debug_print(mod_srtp, "rtcp cipher key: %s",
+                srtp_octet_string_hex_string(tmp_key, rtcp_base_key_len));
+    if (rtcp_salt_len > 0) {
+        debug_print(mod_srtp, "rtcp cipher salt: %s",
+                    srtp_octet_string_hex_string(tmp_key + rtcp_base_key_len,
+                                                 rtcp_salt_len));
+    }
+
+    /* initialize cipher */
+    stat = srtp_cipher_init(session_keys->rtcp_cipher, tmp_key);
+    if (stat) {
+        /* zeroize temp buffer */
+        octet_string_set_to_zero(tmp_key, MAX_SRTP_KEY_LEN);
+        return srtp_err_status_init_fail;
+    }
+
+    /* generate authentication key */
+    stat = srtp_kdf_generate(&kdf, label_rtcp_msg_auth, tmp_key,
+                             srtp_auth_get_key_length(session_keys->rtcp_auth));
+    if (stat) {
+        /* zeroize temp buffer */
+        octet_string_set_to_zero(tmp_key, MAX_SRTP_KEY_LEN);
+        return srtp_err_status_init_fail;
+    }
+
+    debug_print(
+        mod_srtp, "rtcp auth key:   %s",
+        srtp_octet_string_hex_string(
+            tmp_key, srtp_auth_get_key_length(session_keys->rtcp_auth)));
+
+    /* initialize auth function */
+    stat = srtp_auth_init(session_keys->rtcp_auth, tmp_key);
+    if (stat) {
+        /* zeroize temp buffer */
+        octet_string_set_to_zero(tmp_key, MAX_SRTP_KEY_LEN);
+        return srtp_err_status_init_fail;
+    }
+
+    /* clear memory then return */
+    stat = srtp_kdf_clear(&kdf);
     octet_string_set_to_zero(tmp_key, MAX_SRTP_KEY_LEN);
-    return srtp_err_status_init_fail;
-  }
+    if (stat)
+        return srtp_err_status_init_fail;
 
-  /* generate authentication key */
-  stat = srtp_kdf_generate(&kdf, label_rtcp_msg_auth,
-			   tmp_key, srtp_auth_get_key_length(session_keys->rtcp_auth));
-  if (stat) {
-    /* zeroize temp buffer */
-    octet_string_set_to_zero(tmp_key, MAX_SRTP_KEY_LEN);
-    return srtp_err_status_init_fail;
-  }
-
-  debug_print(mod_srtp, "rtcp auth key:   %s",
-	      srtp_octet_string_hex_string(tmp_key, 
-		     srtp_auth_get_key_length(session_keys->rtcp_auth))); 
-
-  /* initialize auth function */
-  stat = srtp_auth_init(session_keys->rtcp_auth, tmp_key);
-  if (stat) {
-    /* zeroize temp buffer */
-    octet_string_set_to_zero(tmp_key, MAX_SRTP_KEY_LEN);
-    return srtp_err_status_init_fail;
-  }
-
-  /* clear memory then return */
-  stat = srtp_kdf_clear(&kdf);
-  octet_string_set_to_zero(tmp_key, MAX_SRTP_KEY_LEN);
-  if (stat)
-    return srtp_err_status_init_fail;
-
-  return srtp_err_status_ok;
+    return srtp_err_status_ok;
 }
 
-srtp_err_status_t
-srtp_stream_init(srtp_stream_ctx_t *srtp, 
-		  const srtp_policy_t *p) {
-  srtp_err_status_t err;
+srtp_err_status_t srtp_stream_init(srtp_stream_ctx_t *srtp,
+                                   const srtp_policy_t *p)
+{
+    srtp_err_status_t err;
 
-   debug_print(mod_srtp, "initializing stream (SSRC: 0x%08x)", 
-	       p->ssrc.value);
+    debug_print(mod_srtp, "initializing stream (SSRC: 0x%08x)", p->ssrc.value);
 
-   /* initialize replay database */
-   /* window size MUST be at least 64.  MAY be larger.  Values more than
-    * 2^15 aren't meaningful due to how extended sequence numbers are
-    * calculated.   Let a window size of 0 imply the default value. */
+    /* initialize replay database */
+    /*
+     * window size MUST be at least 64.  MAY be larger.  Values more than
+     * 2^15 aren't meaningful due to how extended sequence numbers are
+     * calculated.
+     * Let a window size of 0 imply the default value.
+     */
 
-   if (p->window_size != 0 && (p->window_size < 64 || p->window_size >= 0x8000))
-     return srtp_err_status_bad_param;
+    if (p->window_size != 0 &&
+        (p->window_size < 64 || p->window_size >= 0x8000))
+        return srtp_err_status_bad_param;
 
-   if (p->window_size != 0)
-     err = srtp_rdbx_init(&srtp->rtp_rdbx, p->window_size);
-   else
-     err = srtp_rdbx_init(&srtp->rtp_rdbx, 128);
-   if (err) return err;
+    if (p->window_size != 0)
+        err = srtp_rdbx_init(&srtp->rtp_rdbx, p->window_size);
+    else
+        err = srtp_rdbx_init(&srtp->rtp_rdbx, 128);
+    if (err)
+        return err;
 
-   /* set the SSRC value */
-   srtp->ssrc = htonl(p->ssrc.value);
+    /* set the SSRC value */
+    srtp->ssrc = htonl(p->ssrc.value);
 
-   /* reset pending ROC */
-   srtp->pending_roc = 0;
+    /* reset pending ROC */
+    srtp->pending_roc = 0;
 
-   /* set the security service flags */
-   srtp->rtp_services  = p->rtp.sec_serv;
-   srtp->rtcp_services = p->rtcp.sec_serv;
+    /* set the security service flags */
+    srtp->rtp_services = p->rtp.sec_serv;
+    srtp->rtcp_services = p->rtcp.sec_serv;
 
-   /*
-    * set direction to unknown - this flag gets checked in srtp_protect(),
-    * srtp_unprotect(), srtp_protect_rtcp(), and srtp_unprotect_rtcp(), and 
-    * gets set appropriately if it is set to unknown.
-    */
-   srtp->direction = dir_unknown;
+    /*
+     * set direction to unknown - this flag gets checked in srtp_protect(),
+     * srtp_unprotect(), srtp_protect_rtcp(), and srtp_unprotect_rtcp(), and
+     * gets set appropriately if it is set to unknown.
+     */
+    srtp->direction = dir_unknown;
 
-   /* initialize SRTCP replay database */
-   srtp_rdb_init(&srtp->rtcp_rdb);
+    /* initialize SRTCP replay database */
+    srtp_rdb_init(&srtp->rtcp_rdb);
 
-   /* initialize allow_repeat_tx */
-   /* guard against uninitialized memory: allow only 0 or 1 here */
-   if (p->allow_repeat_tx != 0 && p->allow_repeat_tx != 1) {
-     srtp_rdbx_dealloc(&srtp->rtp_rdbx);
-     return srtp_err_status_bad_param;
-   }
-   srtp->allow_repeat_tx = p->allow_repeat_tx;
+    /* initialize allow_repeat_tx */
+    /* guard against uninitialized memory: allow only 0 or 1 here */
+    if (p->allow_repeat_tx != 0 && p->allow_repeat_tx != 1) {
+        srtp_rdbx_dealloc(&srtp->rtp_rdbx);
+        return srtp_err_status_bad_param;
+    }
+    srtp->allow_repeat_tx = p->allow_repeat_tx;
 
-   /* DAM - no RTCP key limit at present */
+    /* DAM - no RTCP key limit at present */
 
-   /* initialize keys */
-   err = srtp_stream_init_all_master_keys(srtp, p->key, p->keys, p->num_master_keys);
-   if (err) {
-     srtp_rdbx_dealloc(&srtp->rtp_rdbx);
-     return err;
-   }
+    /* initialize keys */
+    err = srtp_stream_init_all_master_keys(srtp, p->key, p->keys,
+                                           p->num_master_keys);
+    if (err) {
+        srtp_rdbx_dealloc(&srtp->rtp_rdbx);
+        return err;
+    }
 
-   /* 
-    * if EKT is in use, then initialize the EKT data associated with
-    * the stream
-    */
-   err = srtp_ekt_stream_init_from_policy(srtp->ekt, p->ekt);
-   if (err) {
-     srtp_rdbx_dealloc(&srtp->rtp_rdbx);
-     return err;
-   }
+    /*
+     * if EKT is in use, then initialize the EKT data associated with
+     * the stream
+     */
+    err = srtp_ekt_stream_init_from_policy(srtp->ekt, p->ekt);
+    if (err) {
+        srtp_rdbx_dealloc(&srtp->rtp_rdbx);
+        return err;
+    }
 
-   return srtp_err_status_ok;  
- }
+    return srtp_err_status_ok;
+}
 
+/*
+ * srtp_event_reporter is an event handler function that merely
+ * reports the events that are reported by the callbacks
+ */
 
- /*
-  * srtp_event_reporter is an event handler function that merely
-  * reports the events that are reported by the callbacks
-  */
+void srtp_event_reporter(srtp_event_data_t *data)
+{
+    srtp_err_report(srtp_err_level_warning, "srtp: in stream 0x%x: ",
+                    data->ssrc);
 
- void
- srtp_event_reporter(srtp_event_data_t *data) {
+    switch (data->event) {
+    case event_ssrc_collision:
+        srtp_err_report(srtp_err_level_warning, "\tSSRC collision\n");
+        break;
+    case event_key_soft_limit:
+        srtp_err_report(srtp_err_level_warning,
+                        "\tkey usage soft limit reached\n");
+        break;
+    case event_key_hard_limit:
+        srtp_err_report(srtp_err_level_warning,
+                        "\tkey usage hard limit reached\n");
+        break;
+    case event_packet_index_limit:
+        srtp_err_report(srtp_err_level_warning,
+                        "\tpacket index limit reached\n");
+        break;
+    default:
+        srtp_err_report(srtp_err_level_warning,
+                        "\tunknown event reported to handler\n");
+    }
+}
 
-   srtp_err_report(srtp_err_level_warning, "srtp: in stream 0x%x: ", 
-                   data->ssrc);
+/*
+ * srtp_event_handler is a global variable holding a pointer to the
+ * event handler function; this function is called for any unexpected
+ * event that needs to be handled out of the SRTP data path.  see
+ * srtp_event_t in srtp.h for more info
+ *
+ * it is okay to set srtp_event_handler to NULL, but we set
+ * it to the srtp_event_reporter.
+ */
 
-   switch(data->event) {
-   case event_ssrc_collision:
-     srtp_err_report(srtp_err_level_warning, "\tSSRC collision\n");
-     break;
-   case event_key_soft_limit:
-     srtp_err_report(srtp_err_level_warning, "\tkey usage soft limit reached\n");
-     break;
-   case event_key_hard_limit:
-     srtp_err_report(srtp_err_level_warning, "\tkey usage hard limit reached\n");
-     break;
-   case event_packet_index_limit:
-     srtp_err_report(srtp_err_level_warning, "\tpacket index limit reached\n");
-     break;
-   default:
-     srtp_err_report(srtp_err_level_warning, "\tunknown event reported to handler\n");
-   }
- }
+static srtp_event_handler_func_t *srtp_event_handler = srtp_event_reporter;
 
- /*
-  * srtp_event_handler is a global variable holding a pointer to the
-  * event handler function; this function is called for any unexpected
-  * event that needs to be handled out of the SRTP data path.  see
-  * srtp_event_t in srtp.h for more info
-  *
-  * it is okay to set srtp_event_handler to NULL, but we set 
-  * it to the srtp_event_reporter.
-  */
+srtp_err_status_t srtp_install_event_handler(srtp_event_handler_func_t func)
+{
+    /*
+     * note that we accept NULL arguments intentionally - calling this
+     * function with a NULL arguments removes an event handler that's
+     * been previously installed
+     */
 
- static srtp_event_handler_func_t *srtp_event_handler = srtp_event_reporter;
-
- srtp_err_status_t
- srtp_install_event_handler(srtp_event_handler_func_t func) {
-
-   /* 
-    * note that we accept NULL arguments intentionally - calling this
-    * function with a NULL arguments removes an event handler that's
-    * been previously installed
-    */
-
-   /* set global event handling function */
-   srtp_event_handler = func;
-   return srtp_err_status_ok;
- }
-
+    /* set global event handling function */
+    srtp_event_handler = func;
+    return srtp_err_status_ok;
+}
 
 /*
  * Check if the given extension header id is / should be encrypted.
  * Returns 1 if yes, otherwise 0.
  */
-static int
-srtp_protect_extension_header(srtp_stream_ctx_t *stream, int id) {
-  int* enc_xtn_hdr = stream->enc_xtn_hdr;
-  int count = stream->enc_xtn_hdr_count;
+static int srtp_protect_extension_header(srtp_stream_ctx_t *stream, int id)
+{
+    int *enc_xtn_hdr = stream->enc_xtn_hdr;
+    int count = stream->enc_xtn_hdr_count;
 
-  if (!enc_xtn_hdr || count <= 0) {
-    return 0;
-  }
-
-  while (count > 0) {
-    if (*enc_xtn_hdr == id) {
-      return 1;
+    if (!enc_xtn_hdr || count <= 0) {
+        return 0;
     }
 
-    enc_xtn_hdr++;
-    count--;
-  }
-  return 0;
-}
+    while (count > 0) {
+        if (*enc_xtn_hdr == id) {
+            return 1;
+        }
 
+        enc_xtn_hdr++;
+        count--;
+    }
+    return 0;
+}
 
 /*
  * extensions header encryption RFC 6904
@@ -1358,90 +1423,91 @@ srtp_protect_extension_header(srtp_stream_ctx_t *stream, int id) {
 static srtp_err_status_t
 srtp_process_header_encryption(srtp_stream_ctx_t *stream,
                                srtp_hdr_xtnd_t *xtn_hdr,
-                               srtp_session_keys_t *session_keys) {
-  srtp_err_status_t status;
-  uint8_t keystream[257];  /* Maximum 2 bytes header + 255 bytes data. */
-  int keystream_pos;
-  uint8_t* xtn_hdr_data = ((uint8_t *)xtn_hdr) + octets_in_rtp_extn_hdr;
-  uint8_t* xtn_hdr_end = xtn_hdr_data + (ntohs(xtn_hdr->length) * sizeof(uint32_t));
+                               srtp_session_keys_t *session_keys)
+{
+    srtp_err_status_t status;
+    uint8_t keystream[257]; /* Maximum 2 bytes header + 255 bytes data. */
+    int keystream_pos;
+    uint8_t *xtn_hdr_data = ((uint8_t *)xtn_hdr) + octets_in_rtp_extn_hdr;
+    uint8_t *xtn_hdr_end =
+        xtn_hdr_data + (ntohs(xtn_hdr->length) * sizeof(uint32_t));
 
-  if (ntohs(xtn_hdr->profile_specific) == 0xbede) {
-    /* RFC 5285, section 4.2. One-Byte Header */
-    while (xtn_hdr_data < xtn_hdr_end) {
-      uint8_t xid = (*xtn_hdr_data & 0xf0) >> 4;
-      unsigned int xlen = (*xtn_hdr_data & 0x0f) + 1;
-      uint32_t xlen_with_header = 1+xlen;
-      xtn_hdr_data++;
+    if (ntohs(xtn_hdr->profile_specific) == 0xbede) {
+        /* RFC 5285, section 4.2. One-Byte Header */
+        while (xtn_hdr_data < xtn_hdr_end) {
+            uint8_t xid = (*xtn_hdr_data & 0xf0) >> 4;
+            unsigned int xlen = (*xtn_hdr_data & 0x0f) + 1;
+            uint32_t xlen_with_header = 1 + xlen;
+            xtn_hdr_data++;
 
-      if (xtn_hdr_data + xlen > xtn_hdr_end)
-        return srtp_err_status_parse_err;
+            if (xtn_hdr_data + xlen > xtn_hdr_end)
+                return srtp_err_status_parse_err;
 
-      if (xid == 15) {
-        /* found header 15, stop further processing. */
-        break;
-      }
+            if (xid == 15) {
+                /* found header 15, stop further processing. */
+                break;
+            }
 
-      status = srtp_cipher_output(session_keys->rtp_xtn_hdr_cipher,
-                                  keystream, &xlen_with_header);
-      if (status)
-        return srtp_err_status_cipher_fail;
+            status = srtp_cipher_output(session_keys->rtp_xtn_hdr_cipher,
+                                        keystream, &xlen_with_header);
+            if (status)
+                return srtp_err_status_cipher_fail;
 
-      if (srtp_protect_extension_header(stream, xid)) {
-        keystream_pos = 1;
-        while (xlen > 0) {
-          *xtn_hdr_data ^= keystream[keystream_pos++];
-          xtn_hdr_data++;
-          xlen--;
+            if (srtp_protect_extension_header(stream, xid)) {
+                keystream_pos = 1;
+                while (xlen > 0) {
+                    *xtn_hdr_data ^= keystream[keystream_pos++];
+                    xtn_hdr_data++;
+                    xlen--;
+                }
+            } else {
+                xtn_hdr_data += xlen;
+            }
+
+            /* skip padding bytes. */
+            while (xtn_hdr_data < xtn_hdr_end && *xtn_hdr_data == 0) {
+                xtn_hdr_data++;
+            }
         }
-      } else {
-        xtn_hdr_data += xlen;
-      }
+    } else if ((ntohs(xtn_hdr->profile_specific) & 0x1fff) == 0x100) {
+        /* RFC 5285, section 4.3. Two-Byte Header */
+        while (xtn_hdr_data + 1 < xtn_hdr_end) {
+            uint8_t xid = *xtn_hdr_data;
+            unsigned int xlen = *(xtn_hdr_data + 1);
+            uint32_t xlen_with_header = 2 + xlen;
+            xtn_hdr_data += 2;
 
-      /* skip padding bytes. */
-      while (xtn_hdr_data < xtn_hdr_end && *xtn_hdr_data == 0) {
-        xtn_hdr_data++;
-      }
-    }
-  } else if ((ntohs(xtn_hdr->profile_specific) & 0x1fff) == 0x100) {
-    /* RFC 5285, section 4.3. Two-Byte Header */
-    while (xtn_hdr_data + 1 < xtn_hdr_end) {
-      uint8_t xid = *xtn_hdr_data;
-      unsigned int xlen = *(xtn_hdr_data+1);
-      uint32_t xlen_with_header = 2+xlen;
-      xtn_hdr_data += 2;
+            if (xtn_hdr_data + xlen > xtn_hdr_end)
+                return srtp_err_status_parse_err;
 
-      if (xtn_hdr_data + xlen > xtn_hdr_end)
-        return srtp_err_status_parse_err;
+            status = srtp_cipher_output(session_keys->rtp_xtn_hdr_cipher,
+                                        keystream, &xlen_with_header);
+            if (status)
+                return srtp_err_status_cipher_fail;
 
-      status = srtp_cipher_output(session_keys->rtp_xtn_hdr_cipher,
-                                  keystream, &xlen_with_header);
-      if (status)
-        return srtp_err_status_cipher_fail;
+            if (xlen > 0 && srtp_protect_extension_header(stream, xid)) {
+                keystream_pos = 2;
+                while (xlen > 0) {
+                    *xtn_hdr_data ^= keystream[keystream_pos++];
+                    xtn_hdr_data++;
+                    xlen--;
+                }
+            } else {
+                xtn_hdr_data += xlen;
+            }
 
-      if (xlen > 0 && srtp_protect_extension_header(stream, xid)) {
-        keystream_pos = 2;
-        while (xlen > 0) {
-          *xtn_hdr_data ^= keystream[keystream_pos++];
-          xtn_hdr_data++;
-          xlen--;
+            /* skip padding bytes. */
+            while (xtn_hdr_data < xtn_hdr_end && *xtn_hdr_data == 0) {
+                xtn_hdr_data++;
+            }
         }
-      } else {
-        xtn_hdr_data += xlen;
-      }
-
-      /* skip padding bytes. */
-      while (xtn_hdr_data < xtn_hdr_end && *xtn_hdr_data == 0) {
-        xtn_hdr_data++;
-      }
+    } else {
+        /* unsupported extension header format. */
+        return srtp_err_status_parse_err;
     }
-  } else {
-    /* unsupported extension header format. */
-    return srtp_err_status_parse_err;
-  }
 
-  return srtp_err_status_ok;
+    return srtp_err_status_ok;
 }
-
 
 /*
  * AEAD uses a new IV formation method.  This function implements
@@ -1464,7 +1530,7 @@ srtp_process_header_encryption(srtp_stream_ctx_t *stream,
  *            +--+--+--+--+--+--+--+--+--+--+--+--+*
  *
  * Input:  *session_keys - pointer to SRTP stream context session keys,
- *                         used to retrieve the SALT 
+ *                         used to retrieve the SALT
  *         *iv     - Pointer to receive the calculated IV
  *         *seq    - The ROC and SEQ value to use for the
  *                   IV calculation.
@@ -1472,19 +1538,20 @@ srtp_process_header_encryption(srtp_stream_ctx_t *stream,
  *
  */
 
-static void srtp_calc_aead_iv(srtp_session_keys_t *session_keys, v128_t *iv,
-                              srtp_xtd_seq_num_t *seq, srtp_hdr_t *hdr)
+static void srtp_calc_aead_iv(srtp_session_keys_t *session_keys,
+                              v128_t *iv,
+                              srtp_xtd_seq_num_t *seq,
+                              srtp_hdr_t *hdr)
 {
-    v128_t	in;
-    v128_t	salt;
+    v128_t in;
+    v128_t salt;
 
 #ifdef NO_64BIT_MATH
-    uint32_t local_roc = ((high32(*seq) << 16) |
-                         (low32(*seq) >> 16));
-    uint16_t local_seq = (uint16_t) (low32(*seq));
+    uint32_t local_roc = ((high32(*seq) << 16) | (low32(*seq) >> 16));
+    uint16_t local_seq = (uint16_t)(low32(*seq));
 #else
     uint32_t local_roc = (uint32_t)(*seq >> 16);
-    uint16_t local_seq = (uint16_t) *seq;
+    uint16_t local_seq = (uint16_t)*seq;
 #endif
 
     memset(&in, 0, sizeof(v128_t));
@@ -1512,149 +1579,145 @@ static void srtp_calc_aead_iv(srtp_session_keys_t *session_keys, v128_t *iv,
     v128_xor(iv, &in, &salt);
 }
 
+srtp_session_keys_t *srtp_get_session_keys(srtp_stream_ctx_t *stream,
+                                           uint8_t *hdr,
+                                           const unsigned int *pkt_octet_len,
+                                           unsigned int *mki_size)
+{
+    unsigned int base_mki_start_location = *pkt_octet_len;
+    unsigned int mki_start_location = 0;
+    unsigned int tag_len = 0;
+    unsigned int i = 0;
 
-srtp_session_keys_t* 
-srtp_get_session_keys(srtp_stream_ctx_t *stream, uint8_t* hdr,
-                      const unsigned int* pkt_octet_len,
-                      unsigned int* mki_size) {
-  unsigned int base_mki_start_location = *pkt_octet_len;
-  unsigned int mki_start_location = 0;
-  unsigned int tag_len = 0;
-  unsigned int i = 0;
+    // Determine the authentication tag size
+    if (stream->session_keys[0].rtp_cipher->algorithm == SRTP_AES_GCM_128 ||
+        stream->session_keys[0].rtp_cipher->algorithm == SRTP_AES_GCM_256) {
+        tag_len = 0;
+    } else {
+        tag_len = srtp_auth_get_tag_length(stream->session_keys[0].rtp_auth);
+    }
 
-  // Determine the authentication tag size
-  if (stream->session_keys[0].rtp_cipher->algorithm == SRTP_AES_GCM_128 ||
-      stream->session_keys[0].rtp_cipher->algorithm == SRTP_AES_GCM_256) {
-      tag_len = 0;
-  } else {
-      tag_len = srtp_auth_get_tag_length(stream->session_keys[0].rtp_auth);
-  }
+    if (tag_len > base_mki_start_location) {
+        *mki_size = 0;
+        return NULL;
+    }
 
-  if (tag_len > base_mki_start_location) {
-     *mki_size = 0;
-     return NULL;
-  }
+    base_mki_start_location -= tag_len;
 
-  base_mki_start_location -= tag_len;
+    for (i = 0; i < stream->num_master_keys; i++) {
+        if (stream->session_keys[i].mki_size != 0) {
+            *mki_size = stream->session_keys[i].mki_size;
+            mki_start_location = base_mki_start_location - *mki_size;
 
-  for (i = 0; i < stream->num_master_keys; i++) {
-      if (stream->session_keys[i].mki_size != 0) {
-          *mki_size = stream->session_keys[i].mki_size;
-          mki_start_location = base_mki_start_location - *mki_size;
+            if (mki_start_location >= *mki_size &&
+                memcmp(hdr + mki_start_location, stream->session_keys[i].mki_id,
+                       *mki_size) == 0) {
+                return &stream->session_keys[i];
+            }
+        }
+    }
 
-          if ( mki_start_location >= *mki_size &&
-              memcmp(hdr + mki_start_location, stream->session_keys[i].mki_id, *mki_size) == 0 ) {
-              return &stream->session_keys[i];
-	  }
-      }
-  }
-
-  *mki_size = 0;
-  return NULL;
+    *mki_size = 0;
+    return NULL;
 }
 
-static srtp_err_status_t
-srtp_estimate_index(srtp_rdbx_t *rdbx,
-                    uint32_t roc,
-                    srtp_xtd_seq_num_t *est,
-                    srtp_sequence_number_t seq,
-                    int *delta)
+static srtp_err_status_t srtp_estimate_index(srtp_rdbx_t *rdbx,
+                                             uint32_t roc,
+                                             srtp_xtd_seq_num_t *est,
+                                             srtp_sequence_number_t seq,
+                                             int *delta)
 {
 #ifdef NO_64BIT_MATH
-  uint32_t internal_pkt_idx_reduced;
-  uint32_t external_pkt_idx_reduced;
-  uint32_t internal_roc;
-  uint32_t roc_difference;
+    uint32_t internal_pkt_idx_reduced;
+    uint32_t external_pkt_idx_reduced;
+    uint32_t internal_roc;
+    uint32_t roc_difference;
 #endif
 
 #ifdef NO_64BIT_MATH
-  *est = (srtp_xtd_seq_num_t)make64(roc >> 16, (roc << 16) | seq);
-  *delta = low32(est) - rdbx->index;
+    *est = (srtp_xtd_seq_num_t)make64(roc >> 16, (roc << 16) | seq);
+    *delta = low32(est) - rdbx->index;
 #else
-  *est = (srtp_xtd_seq_num_t)(((uint64_t)roc) << 16) | seq;
-  *delta = (int)(*est - rdbx->index);
+    *est = (srtp_xtd_seq_num_t)(((uint64_t)roc) << 16) | seq;
+    *delta = (int)(*est - rdbx->index);
 #endif
 
-  if (*est > rdbx->index) {
+    if (*est > rdbx->index) {
 #ifdef NO_64BIT_MATH
-    internal_roc = (uint32_t)(rdbx->index >> 16);
-    roc_difference = roc - internal_roc;
-    if (roc_difference > 1) {
-      *delta = 0;
-      return srtp_err_status_pkt_idx_adv;
-    }
+        internal_roc = (uint32_t)(rdbx->index >> 16);
+        roc_difference = roc - internal_roc;
+        if (roc_difference > 1) {
+            *delta = 0;
+            return srtp_err_status_pkt_idx_adv;
+        }
 
-    internal_pkt_idx_reduced = (uint32_t)(rdbx->index & 0xFFFF);
-    external_pkt_idx_reduced = (uint32_t)((roc_difference << 16) | seq);
+        internal_pkt_idx_reduced = (uint32_t)(rdbx->index & 0xFFFF);
+        external_pkt_idx_reduced = (uint32_t)((roc_difference << 16) | seq);
 
-    if (external_pkt_idx_reduced - internal_pkt_idx_reduced >
-                                                    seq_num_median) {
-      *delta = 0;
-      return srtp_err_status_pkt_idx_adv;
-    }
+        if (external_pkt_idx_reduced - internal_pkt_idx_reduced >
+            seq_num_median) {
+            *delta = 0;
+            return srtp_err_status_pkt_idx_adv;
+        }
 #else
-    if (*est - rdbx->index > seq_num_median) {
-      *delta = 0;
-      return srtp_err_status_pkt_idx_adv;
-    }
+        if (*est - rdbx->index > seq_num_median) {
+            *delta = 0;
+            return srtp_err_status_pkt_idx_adv;
+        }
 #endif
-  } else if (*est < rdbx->index) {
+    } else if (*est < rdbx->index) {
 #ifdef NO_64BIT_MATH
 
-    internal_roc = (uint32_t)(rdbx->index >> 16);
-    roc_difference = internal_roc - roc;
-    if (roc_difference > 1) {
-      *delta = 0;
-      return srtp_err_status_pkt_idx_adv;
-    }
+        internal_roc = (uint32_t)(rdbx->index >> 16);
+        roc_difference = internal_roc - roc;
+        if (roc_difference > 1) {
+            *delta = 0;
+            return srtp_err_status_pkt_idx_adv;
+        }
 
-    internal_pkt_idx_reduced =
-                (uint32_t)((roc_difference << 16) | rdbx->index & 0xFFFF);
-    external_pkt_idx_reduced = (uint32_t)(seq);
+        internal_pkt_idx_reduced =
+            (uint32_t)((roc_difference << 16) | rdbx->index & 0xFFFF);
+        external_pkt_idx_reduced = (uint32_t)(seq);
 
-    if (internal_pkt_idx_reduced - external_pkt_idx_reduced >
-                                                    seq_num_median) {
-      *delta = 0;
-      return srtp_err_status_pkt_idx_old;
-    }
+        if (internal_pkt_idx_reduced - external_pkt_idx_reduced >
+            seq_num_median) {
+            *delta = 0;
+            return srtp_err_status_pkt_idx_old;
+        }
 #else
-    if (rdbx->index - *est > seq_num_median) {
-      *delta = 0;
-      return srtp_err_status_pkt_idx_old;
-    }
+        if (rdbx->index - *est > seq_num_median) {
+            *delta = 0;
+            return srtp_err_status_pkt_idx_old;
+        }
 #endif
-  }
+    }
 
-  return srtp_err_status_ok;
+    return srtp_err_status_ok;
 }
 
-static srtp_err_status_t
-srtp_get_est_pkt_index(srtp_hdr_t *hdr,
-                       srtp_stream_ctx_t *stream,
-                       srtp_xtd_seq_num_t *est,
-                       int *delta)
+static srtp_err_status_t srtp_get_est_pkt_index(srtp_hdr_t *hdr,
+                                                srtp_stream_ctx_t *stream,
+                                                srtp_xtd_seq_num_t *est,
+                                                int *delta)
 {
-  srtp_err_status_t result = srtp_err_status_ok;
+    srtp_err_status_t result = srtp_err_status_ok;
 
-  if (stream->pending_roc) {
-    result = srtp_estimate_index(&stream->rtp_rdbx,
-                                 stream->pending_roc,
-                                 est,
-                                 ntohs(hdr->seq),
-                                 delta);
-  } else {
-    /* estimate packet index from seq. num. in header */
-    *delta = srtp_rdbx_estimate_index(&stream->rtp_rdbx,
-                                      est,
-                                      ntohs(hdr->seq));
-  }
+    if (stream->pending_roc) {
+        result = srtp_estimate_index(&stream->rtp_rdbx, stream->pending_roc,
+                                     est, ntohs(hdr->seq), delta);
+    } else {
+        /* estimate packet index from seq. num. in header */
+        *delta =
+            srtp_rdbx_estimate_index(&stream->rtp_rdbx, est, ntohs(hdr->seq));
+    }
 
 #ifdef NO_64BIT_MATH
-  debug_print2(mod_srtp, "estimated u_packet index: %08x%08x", high32(*est), low32(*est));
+    debug_print2(mod_srtp, "estimated u_packet index: %08x%08x", high32(*est),
+                 low32(*est));
 #else
-  debug_print(mod_srtp, "estimated u_packet index: %016llx", *est);
+    debug_print(mod_srtp, "estimated u_packet index: %016llx", *est);
 #endif
-  return result;
+    return result;
 }
 
 /*
@@ -1662,16 +1725,18 @@ srtp_get_est_pkt_index(srtp_hdr_t *hdr,
  * which currently supports AES-GCM encryption.  All packets are
  * encrypted and authenticated.
  */
-static srtp_err_status_t
-srtp_protect_aead (srtp_ctx_t *ctx, srtp_stream_ctx_t *stream,
-                   void *rtp_hdr, unsigned int *pkt_octet_len,
-                   srtp_session_keys_t *session_keys, unsigned int use_mki)
+static srtp_err_status_t srtp_protect_aead(srtp_ctx_t *ctx,
+                                           srtp_stream_ctx_t *stream,
+                                           void *rtp_hdr,
+                                           unsigned int *pkt_octet_len,
+                                           srtp_session_keys_t *session_keys,
+                                           unsigned int use_mki)
 {
-    srtp_hdr_t *hdr = (srtp_hdr_t*)rtp_hdr;
-    uint32_t *enc_start;        /* pointer to start of encrypted portion  */
-    int enc_octet_len = 0; /* number of octets in encrypted portion  */
-    srtp_xtd_seq_num_t est;          /* estimated xtd_seq_num_t of *hdr        */
-    int delta;                  /* delta of local pkt idx and that in hdr */
+    srtp_hdr_t *hdr = (srtp_hdr_t *)rtp_hdr;
+    uint32_t *enc_start;    /* pointer to start of encrypted portion  */
+    int enc_octet_len = 0;  /* number of octets in encrypted portion  */
+    srtp_xtd_seq_num_t est; /* estimated xtd_seq_num_t of *hdr        */
+    int delta;              /* delta of local pkt idx and that in hdr */
     srtp_err_status_t status;
     uint32_t tag_len;
     v128_t iv;
@@ -1708,17 +1773,18 @@ srtp_protect_aead (srtp_ctx_t *ctx, srtp_stream_ctx_t *stream,
      * extension, if present; otherwise, it starts after the last csrc,
      * if any are present
      */
-     enc_start = (uint32_t*)hdr + uint32s_in_rtp_header + hdr->cc;
-     if (hdr->x == 1) {
-         xtn_hdr = (srtp_hdr_xtnd_t*)enc_start;
-         enc_start += (ntohs(xtn_hdr->length) + 1);
-     }
-     /* note: the passed size is without the auth tag */
-     if (!((uint8_t*)enc_start <= (uint8_t*)hdr + *pkt_octet_len))
-         return srtp_err_status_parse_err;
-     enc_octet_len = (int)(*pkt_octet_len -
-                                    ((uint8_t*)enc_start - (uint8_t*)hdr));
-     if (enc_octet_len < 0) return srtp_err_status_parse_err;
+    enc_start = (uint32_t *)hdr + uint32s_in_rtp_header + hdr->cc;
+    if (hdr->x == 1) {
+        xtn_hdr = (srtp_hdr_xtnd_t *)enc_start;
+        enc_start += (ntohs(xtn_hdr->length) + 1);
+    }
+    /* note: the passed size is without the auth tag */
+    if (!((uint8_t *)enc_start <= (uint8_t *)hdr + *pkt_octet_len))
+        return srtp_err_status_parse_err;
+    enc_octet_len =
+        (int)(*pkt_octet_len - ((uint8_t *)enc_start - (uint8_t *)hdr));
+    if (enc_octet_len < 0)
+        return srtp_err_status_parse_err;
 
     /*
      * estimate the packet index using the start of the replay window
@@ -1727,16 +1793,16 @@ srtp_protect_aead (srtp_ctx_t *ctx, srtp_stream_ctx_t *stream,
     delta = srtp_rdbx_estimate_index(&stream->rtp_rdbx, &est, ntohs(hdr->seq));
     status = srtp_rdbx_check(&stream->rtp_rdbx, delta);
     if (status) {
-	if (status != srtp_err_status_replay_fail || !stream->allow_repeat_tx) {
-	    return status;  /* we've been asked to reuse an index */
-	}
+        if (status != srtp_err_status_replay_fail || !stream->allow_repeat_tx) {
+            return status; /* we've been asked to reuse an index */
+        }
     } else {
-	srtp_rdbx_add_index(&stream->rtp_rdbx, delta);
+        srtp_rdbx_add_index(&stream->rtp_rdbx, delta);
     }
 
 #ifdef NO_64BIT_MATH
-    debug_print2(mod_srtp, "estimated packet index: %08x%08x",
-                 high32(est), low32(est));
+    debug_print2(mod_srtp, "estimated packet index: %08x%08x", high32(est),
+                 low32(est));
 #else
     debug_print(mod_srtp, "estimated packet index: %016llx", est);
 #endif
@@ -1745,50 +1811,50 @@ srtp_protect_aead (srtp_ctx_t *ctx, srtp_stream_ctx_t *stream,
      * AEAD uses a new IV formation method
      */
     srtp_calc_aead_iv(session_keys, &iv, &est, hdr);
-    /* shift est, put into network byte order */
+/* shift est, put into network byte order */
 #ifdef NO_64BIT_MATH
-    est = be64_to_cpu(make64((high32(est) << 16) |
-                             (low32(est) >> 16),
-                             low32(est) << 16));
+    est = be64_to_cpu(
+        make64((high32(est) << 16) | (low32(est) >> 16), low32(est) << 16));
 #else
     est = be64_to_cpu(est << 16);
 #endif
 
-    status = srtp_cipher_set_iv(session_keys->rtp_cipher,
-                                (uint8_t*)&iv, srtp_direction_encrypt);
+    status = srtp_cipher_set_iv(session_keys->rtp_cipher, (uint8_t *)&iv,
+                                srtp_direction_encrypt);
     if (!status && session_keys->rtp_xtn_hdr_cipher) {
-      iv.v32[0] = 0;
-      iv.v32[1] = hdr->ssrc;
-      iv.v64[1] = est;
-      status = srtp_cipher_set_iv(session_keys->rtp_xtn_hdr_cipher,
-                                  (uint8_t*)&iv, srtp_direction_encrypt);
+        iv.v32[0] = 0;
+        iv.v32[1] = hdr->ssrc;
+        iv.v64[1] = est;
+        status = srtp_cipher_set_iv(session_keys->rtp_xtn_hdr_cipher,
+                                    (uint8_t *)&iv, srtp_direction_encrypt);
     }
     if (status) {
         return srtp_err_status_cipher_fail;
     }
 
     if (xtn_hdr && session_keys->rtp_xtn_hdr_cipher) {
-      /*
-       * extensions header encryption RFC 6904
-       */
-	status = srtp_process_header_encryption(stream, xtn_hdr, session_keys);
-      if (status) {
-        return status;
-      }
+        /*
+         * extensions header encryption RFC 6904
+         */
+        status = srtp_process_header_encryption(stream, xtn_hdr, session_keys);
+        if (status) {
+            return status;
+        }
     }
 
     /*
-     * Set the AAD over the RTP header 
+     * Set the AAD over the RTP header
      */
     aad_len = (uint8_t *)enc_start - (uint8_t *)hdr;
-    status = srtp_cipher_set_aad(session_keys->rtp_cipher, (uint8_t*)hdr, aad_len);
+    status =
+        srtp_cipher_set_aad(session_keys->rtp_cipher, (uint8_t *)hdr, aad_len);
     if (status) {
-        return ( srtp_err_status_cipher_fail);
+        return (srtp_err_status_cipher_fail);
     }
 
     /* Encrypt the payload  */
-    status = srtp_cipher_encrypt(session_keys->rtp_cipher,
-                            (uint8_t*)enc_start, (unsigned int *)&enc_octet_len);
+    status = srtp_cipher_encrypt(session_keys->rtp_cipher, (uint8_t *)enc_start,
+                                 (unsigned int *)&enc_octet_len);
     if (status) {
         return srtp_err_status_cipher_fail;
     }
@@ -1796,10 +1862,11 @@ srtp_protect_aead (srtp_ctx_t *ctx, srtp_stream_ctx_t *stream,
      * If we're doing GCM, we need to get the tag
      * and append that to the output
      */
-    status = srtp_cipher_get_tag(session_keys->rtp_cipher, 
-                            (uint8_t*)enc_start+enc_octet_len, &tag_len);
+    status =
+        srtp_cipher_get_tag(session_keys->rtp_cipher,
+                            (uint8_t *)enc_start + enc_octet_len, &tag_len);
     if (status) {
-	return ( srtp_err_status_cipher_fail);
+        return (srtp_err_status_cipher_fail);
     }
 
     mki_location = (uint8_t *)hdr + *pkt_octet_len + tag_len;
@@ -1814,7 +1881,6 @@ srtp_protect_aead (srtp_ctx_t *ctx, srtp_stream_ctx_t *stream,
     return srtp_err_status_ok;
 }
 
-
 /*
  * This function handles incoming SRTP packets while in AEAD mode,
  * which currently supports AES-GCM encryption.  All packets are
@@ -1822,13 +1888,17 @@ srtp_protect_aead (srtp_ctx_t *ctx, srtp_stream_ctx_t *stream,
  * of the packet stream and is automatically checked by GCM
  * when decrypting the payload.
  */
-static srtp_err_status_t
-srtp_unprotect_aead (srtp_ctx_t *ctx, srtp_stream_ctx_t *stream, int delta, 
-                     srtp_xtd_seq_num_t est, void *srtp_hdr, unsigned int *pkt_octet_len,
-                     srtp_session_keys_t *session_keys, unsigned int mki_size)
+static srtp_err_status_t srtp_unprotect_aead(srtp_ctx_t *ctx,
+                                             srtp_stream_ctx_t *stream,
+                                             int delta,
+                                             srtp_xtd_seq_num_t est,
+                                             void *srtp_hdr,
+                                             unsigned int *pkt_octet_len,
+                                             srtp_session_keys_t *session_keys,
+                                             unsigned int mki_size)
 {
-    srtp_hdr_t *hdr = (srtp_hdr_t*)srtp_hdr;
-    uint32_t *enc_start;        /* pointer to start of encrypted portion  */
+    srtp_hdr_t *hdr = (srtp_hdr_t *)srtp_hdr;
+    uint32_t *enc_start;            /* pointer to start of encrypted portion  */
     unsigned int enc_octet_len = 0; /* number of octets in encrypted portion */
     v128_t iv;
     srtp_err_status_t status;
@@ -1839,7 +1909,8 @@ srtp_unprotect_aead (srtp_ctx_t *ctx, srtp_stream_ctx_t *stream, int delta,
     debug_print(mod_srtp, "function srtp_unprotect_aead", NULL);
 
 #ifdef NO_64BIT_MATH
-    debug_print2(mod_srtp, "estimated u_packet index: %08x%08x", high32(est), low32(est));
+    debug_print2(mod_srtp, "estimated u_packet index: %08x%08x", high32(est),
+                 low32(est));
 #else
     debug_print(mod_srtp, "estimated u_packet index: %016llx", est);
 #endif
@@ -1848,21 +1919,22 @@ srtp_unprotect_aead (srtp_ctx_t *ctx, srtp_stream_ctx_t *stream, int delta,
     tag_len = srtp_auth_get_tag_length(session_keys->rtp_auth);
 
     /*
-     * AEAD uses a new IV formation method 
+     * AEAD uses a new IV formation method
      */
     srtp_calc_aead_iv(session_keys, &iv, &est, hdr);
-    status = srtp_cipher_set_iv(session_keys->rtp_cipher,
-                                (uint8_t*)&iv, srtp_direction_decrypt);
+    status = srtp_cipher_set_iv(session_keys->rtp_cipher, (uint8_t *)&iv,
+                                srtp_direction_decrypt);
     if (!status && session_keys->rtp_xtn_hdr_cipher) {
-      iv.v32[0] = 0;
-      iv.v32[1] = hdr->ssrc;
+        iv.v32[0] = 0;
+        iv.v32[1] = hdr->ssrc;
 #ifdef NO_64BIT_MATH
-      iv.v64[1] = be64_to_cpu(make64((high32(est) << 16) | (low32(est) >> 16),
-                  low32(est) << 16));
+        iv.v64[1] = be64_to_cpu(
+            make64((high32(est) << 16) | (low32(est) >> 16), low32(est) << 16));
 #else
-      iv.v64[1] = be64_to_cpu(est << 16);
+        iv.v64[1] = be64_to_cpu(est << 16);
 #endif
-      status = srtp_cipher_set_iv(session_keys->rtp_xtn_hdr_cipher, (uint8_t*)&iv, srtp_direction_encrypt);
+        status = srtp_cipher_set_iv(session_keys->rtp_xtn_hdr_cipher,
+                                    (uint8_t *)&iv, srtp_direction_encrypt);
     }
     if (status) {
         return srtp_err_status_cipher_fail;
@@ -1874,25 +1946,26 @@ srtp_unprotect_aead (srtp_ctx_t *ctx, srtp_stream_ctx_t *stream, int delta,
      * extension, if present; otherwise, it starts after the last csrc,
      * if any are present
      */
-    enc_start = (uint32_t*)hdr + uint32s_in_rtp_header + hdr->cc;
+    enc_start = (uint32_t *)hdr + uint32s_in_rtp_header + hdr->cc;
     if (hdr->x == 1) {
-        xtn_hdr = (srtp_hdr_xtnd_t*)enc_start;
+        xtn_hdr = (srtp_hdr_xtnd_t *)enc_start;
         enc_start += (ntohs(xtn_hdr->length) + 1);
     }
-    if (!((uint8_t*)enc_start <= (uint8_t*)hdr + (*pkt_octet_len - tag_len - mki_size)))
+    if (!((uint8_t *)enc_start <=
+          (uint8_t *)hdr + (*pkt_octet_len - tag_len - mki_size)))
         return srtp_err_status_parse_err;
     /*
-     * We pass the tag down to the cipher when doing GCM mode 
+     * We pass the tag down to the cipher when doing GCM mode
      */
     enc_octet_len = (unsigned int)(*pkt_octet_len - mki_size -
-                                   ((uint8_t*)enc_start - (uint8_t*)hdr));
+                                   ((uint8_t *)enc_start - (uint8_t *)hdr));
 
     /*
      * Sanity check the encrypted payload length against
      * the tag size.  It must always be at least as large
      * as the tag length.
      */
-    if (enc_octet_len < (unsigned int) tag_len) {
+    if (enc_octet_len < (unsigned int)tag_len) {
         return srtp_err_status_cipher_fail;
     }
 
@@ -1918,27 +1991,28 @@ srtp_unprotect_aead (srtp_ctx_t *ctx, srtp_stream_ctx_t *stream, int delta,
      * Set the AAD for AES-GCM, which is the RTP header
      */
     aad_len = (uint8_t *)enc_start - (uint8_t *)hdr;
-    status = srtp_cipher_set_aad(session_keys->rtp_cipher, (uint8_t*)hdr, aad_len);
+    status =
+        srtp_cipher_set_aad(session_keys->rtp_cipher, (uint8_t *)hdr, aad_len);
     if (status) {
-        return ( srtp_err_status_cipher_fail);
+        return (srtp_err_status_cipher_fail);
     }
 
     /* Decrypt the ciphertext.  This also checks the auth tag based
      * on the AAD we just specified above */
-    status = srtp_cipher_decrypt(session_keys->rtp_cipher,
-                                 (uint8_t*)enc_start, &enc_octet_len);
+    status = srtp_cipher_decrypt(session_keys->rtp_cipher, (uint8_t *)enc_start,
+                                 &enc_octet_len);
     if (status) {
         return status;
     }
 
     if (xtn_hdr && session_keys->rtp_xtn_hdr_cipher) {
-      /*
-       * extensions header encryption RFC 6904
-       */
-      status = srtp_process_header_encryption(stream, xtn_hdr, session_keys);
-      if (status) {
-        return status;
-      }
+        /*
+         * extensions header encryption RFC 6904
+         */
+        status = srtp_process_header_encryption(stream, xtn_hdr, session_keys);
+        if (status) {
+            return status;
+        }
     }
 
     /*
@@ -1974,7 +2048,8 @@ srtp_unprotect_aead (srtp_ctx_t *ctx, srtp_stream_ctx_t *stream, int delta,
          * stream, and some implementations will want to not return
          * failure here
          */
-        status = srtp_stream_clone(ctx->stream_template, hdr->ssrc, &new_stream);
+        status =
+            srtp_stream_clone(ctx->stream_template, hdr->ssrc, &new_stream);
         if (status) {
             return status;
         }
@@ -2002,724 +2077,725 @@ srtp_unprotect_aead (srtp_ctx_t *ctx, srtp_stream_ctx_t *stream, int delta,
     return srtp_err_status_ok;
 }
 
-
- srtp_err_status_t
- srtp_protect(srtp_ctx_t *ctx, void *rtp_hdr, int *pkt_octet_len) {
-   return srtp_protect_mki(ctx, rtp_hdr, pkt_octet_len, 0, 0);
- }
-
 srtp_err_status_t
-srtp_protect_mki(srtp_ctx_t *ctx, void *rtp_hdr, int *pkt_octet_len,
-                 unsigned int use_mki, unsigned int mki_index ) {
-   srtp_hdr_t *hdr = (srtp_hdr_t *)rtp_hdr;
-   uint32_t *enc_start;        /* pointer to start of encrypted portion  */
-   uint32_t *auth_start;       /* pointer to start of auth. portion      */
-   int enc_octet_len = 0; /* number of octets in encrypted portion  */
-   srtp_xtd_seq_num_t est;          /* estimated xtd_seq_num_t of *hdr        */
-   int delta;                  /* delta of local pkt idx and that in hdr */
-   uint8_t *auth_tag = NULL;   /* location of auth_tag within packet     */
-   srtp_err_status_t status;   
-   int tag_len;
-   srtp_stream_ctx_t *stream;
-   uint32_t prefix_len;
-   srtp_hdr_xtnd_t *xtn_hdr = NULL;
-   unsigned int mki_size = 0;
-   srtp_session_keys_t *session_keys = NULL;
-   uint8_t* mki_location = NULL;
-   int advance_packet_index = 0;
-
-   debug_print(mod_srtp, "function srtp_protect", NULL);
-
-  /* we assume the hdr is 32-bit aligned to start */
-
-  /* Verify RTP header */
-  status = srtp_validate_rtp_header(rtp_hdr, pkt_octet_len);
-  if (status)
-    return status;
-
-   /* check the packet length - it must at least contain a full header */
-   if (*pkt_octet_len < octets_in_rtp_header)
-     return srtp_err_status_bad_param;
-
-   /*
-    * look up ssrc in srtp_stream list, and process the packet with
-    * the appropriate stream.  if we haven't seen this stream before,
-    * there's a template key for this srtp_session, and the cipher
-    * supports key-sharing, then we assume that a new stream using
-    * that key has just started up
-    */
-   stream = srtp_get_stream(ctx, hdr->ssrc);
-   if (stream == NULL) {
-     if (ctx->stream_template != NULL) {
-       srtp_stream_ctx_t *new_stream;
-
-       /* allocate and initialize a new stream */
-       status = srtp_stream_clone(ctx->stream_template, 
-				  hdr->ssrc, &new_stream); 
-       if (status)
-	 return status;
-
-       /* add new stream to the head of the stream_list */
-       new_stream->next = ctx->stream_list;
-       ctx->stream_list = new_stream;
-
-       /* set direction to outbound */
-       new_stream->direction = dir_srtp_sender;
-
-       /* set stream (the pointer used in this function) */
-       stream = new_stream;
-     } else {
-       /* no template stream, so we return an error */
-       return srtp_err_status_no_ctx;
-     } 
-   }
-
-   /* 
-    * verify that stream is for sending traffic - this check will
-    * detect SSRC collisions, since a stream that appears in both
-    * srtp_protect() and srtp_unprotect() will fail this test in one of
-    * those functions.
-    */
-
-  if (stream->direction != dir_srtp_sender) {
-     if (stream->direction == dir_unknown) {
-       stream->direction = dir_srtp_sender;
-     } else {
-       srtp_handle_event(ctx, stream, event_ssrc_collision);
-     }
-  }
-
-  session_keys = srtp_get_session_keys_with_mki_index(stream, use_mki, mki_index);
-
-   /*
-    * Check if this is an AEAD stream (GCM mode).  If so, then dispatch
-    * the request to our AEAD handler.
-    */
-  if (session_keys->rtp_cipher->algorithm == SRTP_AES_GCM_128 ||
-      session_keys->rtp_cipher->algorithm == SRTP_AES_GCM_256) {
-      return srtp_protect_aead(ctx, stream, rtp_hdr,
-                               (unsigned int*)pkt_octet_len, session_keys,
-                               use_mki);
-  }
-
-  /* 
-   * update the key usage limit, and check it to make sure that we
-   * didn't just hit either the soft limit or the hard limit, and call
-   * the event handler if we hit either.
-   */
-  switch(srtp_key_limit_update(session_keys->limit)) {
-  case srtp_key_event_normal:
-    break;
-  case srtp_key_event_soft_limit: 
-    srtp_handle_event(ctx, stream, event_key_soft_limit);
-    break; 
-  case srtp_key_event_hard_limit:
-    srtp_handle_event(ctx, stream, event_key_hard_limit);
-	return srtp_err_status_key_expired;
-  default:
-    break;
-  }
-
-   /* get tag length from stream */
-   tag_len = srtp_auth_get_tag_length(session_keys->rtp_auth); 
-
-   /*
-    * find starting point for encryption and length of data to be
-    * encrypted - the encrypted portion starts after the rtp header
-    * extension, if present; otherwise, it starts after the last csrc,
-    * if any are present
-    *
-    * if we're not providing confidentiality, set enc_start to NULL
-    */
-   if (stream->rtp_services & sec_serv_conf) {
-     enc_start = (uint32_t *)hdr + uint32s_in_rtp_header + hdr->cc;  
-     if (hdr->x == 1) {
-       xtn_hdr = (srtp_hdr_xtnd_t *)enc_start;
-       enc_start += (ntohs(xtn_hdr->length) + 1);
-     }
-     /* note: the passed size is without the auth tag */
-     if (!((uint8_t*)enc_start <= (uint8_t*)hdr + *pkt_octet_len))
-       return srtp_err_status_parse_err;
-     enc_octet_len = (int)(*pkt_octet_len -
-                                    ((uint8_t*)enc_start - (uint8_t*)hdr));
-     if (enc_octet_len < 0) return srtp_err_status_parse_err;
-   } else {
-     enc_start = NULL;
-   }
-
-   mki_location = (uint8_t *)hdr + *pkt_octet_len;
-   mki_size = srtp_inject_mki(mki_location, session_keys, use_mki);
-
-   /* 
-    * if we're providing authentication, set the auth_start and auth_tag
-    * pointers to the proper locations; otherwise, set auth_start to NULL
-    * to indicate that no authentication is needed
-    */
-   if (stream->rtp_services & sec_serv_auth) {
-     auth_start = (uint32_t *)hdr;
-     auth_tag = (uint8_t *)hdr + *pkt_octet_len + mki_size;
-   } else {
-     auth_start = NULL;
-     auth_tag = NULL;
-   }
-
-  /*
-   * estimate the packet index using the start of the replay window
-   * and the sequence number from the header
-   */
-  status = srtp_get_est_pkt_index(hdr,
-                                  stream,
-                                  &est,
-                                  &delta);
-
-  if (status && (status != srtp_err_status_pkt_idx_adv))
-    return status;
-
-  if (status == srtp_err_status_pkt_idx_adv)
-    advance_packet_index = 1;
-
-  if (advance_packet_index) {
-    srtp_rdbx_set_roc_seq(&stream->rtp_rdbx,
-                          (uint32_t)(est >> 16),
-                          (uint16_t)(est & 0xFFFF));
-    stream->pending_roc = 0;
-    srtp_rdbx_add_index(&stream->rtp_rdbx, 0);
-  } else {
-    status = srtp_rdbx_check(&stream->rtp_rdbx, delta);
-    if (status) {
-      if (status != srtp_err_status_replay_fail || !stream->allow_repeat_tx)
-        return status; /* we've been asked to reuse an index */
-    }
-    srtp_rdbx_add_index(&stream->rtp_rdbx, delta);
-  }
-
-#ifdef NO_64BIT_MATH
-   debug_print2(mod_srtp, "estimated packet index: %08x%08x", 
-		high32(est),low32(est));
-#else
-   debug_print(mod_srtp, "estimated packet index: %016llx", est);
-#endif
-
-   /* 
-    * if we're using rindael counter mode, set nonce and seq 
-    */
-   if (session_keys->rtp_cipher->type->id == SRTP_AES_ICM_128 ||
-       session_keys->rtp_cipher->type->id == SRTP_AES_ICM_192 ||
-       session_keys->rtp_cipher->type->id == SRTP_AES_ICM_256) {
-     v128_t iv;
-
-     iv.v32[0] = 0;
-     iv.v32[1] = hdr->ssrc;
-#ifdef NO_64BIT_MATH
-     iv.v64[1] = be64_to_cpu(make64((high32(est) << 16) | (low32(est) >> 16),
-								 low32(est) << 16));
-#else
-     iv.v64[1] = be64_to_cpu(est << 16);
-#endif
-     status = srtp_cipher_set_iv(session_keys->rtp_cipher, (uint8_t*)&iv, srtp_direction_encrypt);
-     if (!status && session_keys->rtp_xtn_hdr_cipher) {
-       status = srtp_cipher_set_iv(session_keys->rtp_xtn_hdr_cipher, (uint8_t*)&iv, srtp_direction_encrypt);
-     }
-   } else {  
-     v128_t iv;
-
-     /* otherwise, set the index to est */  
-#ifdef NO_64BIT_MATH
-     iv.v32[0] = 0;
-     iv.v32[1] = 0;
-#else
-     iv.v64[0] = 0;
-#endif
-     iv.v64[1] = be64_to_cpu(est);
-     status = srtp_cipher_set_iv(session_keys->rtp_cipher, (uint8_t*)&iv, srtp_direction_encrypt);
-     if (!status && session_keys->rtp_xtn_hdr_cipher) {
-       status = srtp_cipher_set_iv(session_keys->rtp_xtn_hdr_cipher, (uint8_t*)&iv, srtp_direction_encrypt);
-     }
-   }
-   if (status)
-     return srtp_err_status_cipher_fail;
-
-   /* shift est, put into network byte order */
-#ifdef NO_64BIT_MATH
-   est = be64_to_cpu(make64((high32(est) << 16) |
-						 (low32(est) >> 16),
-						 low32(est) << 16));
-#else
-   est = be64_to_cpu(est << 16);
-#endif
-   
-   /* 
-    * if we're authenticating using a universal hash, put the keystream
-    * prefix into the authentication tag
-    */
-   if (auth_start) {
-     
-    prefix_len = srtp_auth_get_prefix_length(session_keys->rtp_auth);    
-    if (prefix_len) {
-      status = srtp_cipher_output(session_keys->rtp_cipher, auth_tag, &prefix_len);
-      if (status)
-	return srtp_err_status_cipher_fail;
-      debug_print(mod_srtp, "keystream prefix: %s", 
-		  srtp_octet_string_hex_string(auth_tag, prefix_len));
-    }
-  }
-
-  if (xtn_hdr && session_keys->rtp_xtn_hdr_cipher) {
-    /*
-     * extensions header encryption RFC 6904
-     */
-      status = srtp_process_header_encryption(stream, xtn_hdr, session_keys);
-    if (status) {
-      return status;
-    }
-  }
-
-  /* if we're encrypting, exor keystream into the message */
-  if (enc_start) {
-    status = srtp_cipher_encrypt(session_keys->rtp_cipher, 
-			        (uint8_t *)enc_start, (unsigned int *)&enc_octet_len);
-    if (status)
-      return srtp_err_status_cipher_fail;
-  }
-
-  /*
-   *  if we're authenticating, run authentication function and put result
-   *  into the auth_tag 
-   */
-  if (auth_start) {        
-
-    /* initialize auth func context */
-    status = srtp_auth_start(session_keys->rtp_auth);
-    if (status) return status;
-
-    /* run auth func over packet */
-    status = srtp_auth_update(session_keys->rtp_auth,
-			 (uint8_t *)auth_start, *pkt_octet_len);
-    if (status) return status;
-    
-    /* run auth func over ROC, put result into auth_tag */
-    debug_print(mod_srtp, "estimated packet index: %016llx", est);
-    status = srtp_auth_compute(session_keys->rtp_auth, (uint8_t *)&est, 4, auth_tag);
-    debug_print(mod_srtp, "srtp auth tag:    %s", 
-		srtp_octet_string_hex_string(auth_tag, tag_len));
-    if (status)
-      return srtp_err_status_auth_fail;   
-
-  }
-
-  if (auth_tag) {
-
-    /* increase the packet length by the length of the auth tag */
-    *pkt_octet_len += tag_len;
-  }
-
-  if (use_mki) {
-    /* increate the packet length by the mki size */
-    *pkt_octet_len += mki_size;
-  }
-
-  return srtp_err_status_ok;  
+srtp_protect(srtp_ctx_t *ctx, void *rtp_hdr, int *pkt_octet_len)
+{
+    return srtp_protect_mki(ctx, rtp_hdr, pkt_octet_len, 0, 0);
 }
 
+srtp_err_status_t srtp_protect_mki(srtp_ctx_t *ctx,
+                                   void *rtp_hdr,
+                                   int *pkt_octet_len,
+                                   unsigned int use_mki,
+                                   unsigned int mki_index)
+{
+    srtp_hdr_t *hdr = (srtp_hdr_t *)rtp_hdr;
+    uint32_t *enc_start;      /* pointer to start of encrypted portion  */
+    uint32_t *auth_start;     /* pointer to start of auth. portion      */
+    int enc_octet_len = 0;    /* number of octets in encrypted portion  */
+    srtp_xtd_seq_num_t est;   /* estimated xtd_seq_num_t of *hdr        */
+    int delta;                /* delta of local pkt idx and that in hdr */
+    uint8_t *auth_tag = NULL; /* location of auth_tag within packet     */
+    srtp_err_status_t status;
+    int tag_len;
+    srtp_stream_ctx_t *stream;
+    uint32_t prefix_len;
+    srtp_hdr_xtnd_t *xtn_hdr = NULL;
+    unsigned int mki_size = 0;
+    srtp_session_keys_t *session_keys = NULL;
+    uint8_t *mki_location = NULL;
+    int advance_packet_index = 0;
+
+    debug_print(mod_srtp, "function srtp_protect", NULL);
+
+    /* we assume the hdr is 32-bit aligned to start */
+
+    /* Verify RTP header */
+    status = srtp_validate_rtp_header(rtp_hdr, pkt_octet_len);
+    if (status)
+        return status;
+
+    /* check the packet length - it must at least contain a full header */
+    if (*pkt_octet_len < octets_in_rtp_header)
+        return srtp_err_status_bad_param;
+
+    /*
+     * look up ssrc in srtp_stream list, and process the packet with
+     * the appropriate stream.  if we haven't seen this stream before,
+     * there's a template key for this srtp_session, and the cipher
+     * supports key-sharing, then we assume that a new stream using
+     * that key has just started up
+     */
+    stream = srtp_get_stream(ctx, hdr->ssrc);
+    if (stream == NULL) {
+        if (ctx->stream_template != NULL) {
+            srtp_stream_ctx_t *new_stream;
+
+            /* allocate and initialize a new stream */
+            status =
+                srtp_stream_clone(ctx->stream_template, hdr->ssrc, &new_stream);
+            if (status)
+                return status;
+
+            /* add new stream to the head of the stream_list */
+            new_stream->next = ctx->stream_list;
+            ctx->stream_list = new_stream;
+
+            /* set direction to outbound */
+            new_stream->direction = dir_srtp_sender;
+
+            /* set stream (the pointer used in this function) */
+            stream = new_stream;
+        } else {
+            /* no template stream, so we return an error */
+            return srtp_err_status_no_ctx;
+        }
+    }
+
+    /*
+     * verify that stream is for sending traffic - this check will
+     * detect SSRC collisions, since a stream that appears in both
+     * srtp_protect() and srtp_unprotect() will fail this test in one of
+     * those functions.
+     */
+
+    if (stream->direction != dir_srtp_sender) {
+        if (stream->direction == dir_unknown) {
+            stream->direction = dir_srtp_sender;
+        } else {
+            srtp_handle_event(ctx, stream, event_ssrc_collision);
+        }
+    }
+
+    session_keys =
+        srtp_get_session_keys_with_mki_index(stream, use_mki, mki_index);
+
+    /*
+     * Check if this is an AEAD stream (GCM mode).  If so, then dispatch
+     * the request to our AEAD handler.
+     */
+    if (session_keys->rtp_cipher->algorithm == SRTP_AES_GCM_128 ||
+        session_keys->rtp_cipher->algorithm == SRTP_AES_GCM_256) {
+        return srtp_protect_aead(ctx, stream, rtp_hdr,
+                                 (unsigned int *)pkt_octet_len, session_keys,
+                                 use_mki);
+    }
+
+    /*
+     * update the key usage limit, and check it to make sure that we
+     * didn't just hit either the soft limit or the hard limit, and call
+     * the event handler if we hit either.
+     */
+    switch (srtp_key_limit_update(session_keys->limit)) {
+    case srtp_key_event_normal:
+        break;
+    case srtp_key_event_soft_limit:
+        srtp_handle_event(ctx, stream, event_key_soft_limit);
+        break;
+    case srtp_key_event_hard_limit:
+        srtp_handle_event(ctx, stream, event_key_hard_limit);
+        return srtp_err_status_key_expired;
+    default:
+        break;
+    }
+
+    /* get tag length from stream */
+    tag_len = srtp_auth_get_tag_length(session_keys->rtp_auth);
+
+    /*
+     * find starting point for encryption and length of data to be
+     * encrypted - the encrypted portion starts after the rtp header
+     * extension, if present; otherwise, it starts after the last csrc,
+     * if any are present
+     *
+     * if we're not providing confidentiality, set enc_start to NULL
+     */
+    if (stream->rtp_services & sec_serv_conf) {
+        enc_start = (uint32_t *)hdr + uint32s_in_rtp_header + hdr->cc;
+        if (hdr->x == 1) {
+            xtn_hdr = (srtp_hdr_xtnd_t *)enc_start;
+            enc_start += (ntohs(xtn_hdr->length) + 1);
+        }
+        /* note: the passed size is without the auth tag */
+        if (!((uint8_t *)enc_start <= (uint8_t *)hdr + *pkt_octet_len))
+            return srtp_err_status_parse_err;
+        enc_octet_len =
+            (int)(*pkt_octet_len - ((uint8_t *)enc_start - (uint8_t *)hdr));
+        if (enc_octet_len < 0)
+            return srtp_err_status_parse_err;
+    } else {
+        enc_start = NULL;
+    }
+
+    mki_location = (uint8_t *)hdr + *pkt_octet_len;
+    mki_size = srtp_inject_mki(mki_location, session_keys, use_mki);
+
+    /*
+     * if we're providing authentication, set the auth_start and auth_tag
+     * pointers to the proper locations; otherwise, set auth_start to NULL
+     * to indicate that no authentication is needed
+     */
+    if (stream->rtp_services & sec_serv_auth) {
+        auth_start = (uint32_t *)hdr;
+        auth_tag = (uint8_t *)hdr + *pkt_octet_len + mki_size;
+    } else {
+        auth_start = NULL;
+        auth_tag = NULL;
+    }
+
+    /*
+     * estimate the packet index using the start of the replay window
+     * and the sequence number from the header
+     */
+    status = srtp_get_est_pkt_index(hdr, stream, &est, &delta);
+
+    if (status && (status != srtp_err_status_pkt_idx_adv))
+        return status;
+
+    if (status == srtp_err_status_pkt_idx_adv)
+        advance_packet_index = 1;
+
+    if (advance_packet_index) {
+        srtp_rdbx_set_roc_seq(&stream->rtp_rdbx, (uint32_t)(est >> 16),
+                              (uint16_t)(est & 0xFFFF));
+        stream->pending_roc = 0;
+        srtp_rdbx_add_index(&stream->rtp_rdbx, 0);
+    } else {
+        status = srtp_rdbx_check(&stream->rtp_rdbx, delta);
+        if (status) {
+            if (status != srtp_err_status_replay_fail ||
+                !stream->allow_repeat_tx)
+                return status; /* we've been asked to reuse an index */
+        }
+        srtp_rdbx_add_index(&stream->rtp_rdbx, delta);
+    }
+
+#ifdef NO_64BIT_MATH
+    debug_print2(mod_srtp, "estimated packet index: %08x%08x", high32(est),
+                 low32(est));
+#else
+    debug_print(mod_srtp, "estimated packet index: %016llx", est);
+#endif
+
+    /*
+     * if we're using rindael counter mode, set nonce and seq
+     */
+    if (session_keys->rtp_cipher->type->id == SRTP_AES_ICM_128 ||
+        session_keys->rtp_cipher->type->id == SRTP_AES_ICM_192 ||
+        session_keys->rtp_cipher->type->id == SRTP_AES_ICM_256) {
+        v128_t iv;
+
+        iv.v32[0] = 0;
+        iv.v32[1] = hdr->ssrc;
+#ifdef NO_64BIT_MATH
+        iv.v64[1] = be64_to_cpu(
+            make64((high32(est) << 16) | (low32(est) >> 16), low32(est) << 16));
+#else
+        iv.v64[1] = be64_to_cpu(est << 16);
+#endif
+        status = srtp_cipher_set_iv(session_keys->rtp_cipher, (uint8_t *)&iv,
+                                    srtp_direction_encrypt);
+        if (!status && session_keys->rtp_xtn_hdr_cipher) {
+            status = srtp_cipher_set_iv(session_keys->rtp_xtn_hdr_cipher,
+                                        (uint8_t *)&iv, srtp_direction_encrypt);
+        }
+    } else {
+        v128_t iv;
+
+/* otherwise, set the index to est */
+#ifdef NO_64BIT_MATH
+        iv.v32[0] = 0;
+        iv.v32[1] = 0;
+#else
+        iv.v64[0] = 0;
+#endif
+        iv.v64[1] = be64_to_cpu(est);
+        status = srtp_cipher_set_iv(session_keys->rtp_cipher, (uint8_t *)&iv,
+                                    srtp_direction_encrypt);
+        if (!status && session_keys->rtp_xtn_hdr_cipher) {
+            status = srtp_cipher_set_iv(session_keys->rtp_xtn_hdr_cipher,
+                                        (uint8_t *)&iv, srtp_direction_encrypt);
+        }
+    }
+    if (status)
+        return srtp_err_status_cipher_fail;
+
+/* shift est, put into network byte order */
+#ifdef NO_64BIT_MATH
+    est = be64_to_cpu(
+        make64((high32(est) << 16) | (low32(est) >> 16), low32(est) << 16));
+#else
+    est = be64_to_cpu(est << 16);
+#endif
+
+    /*
+     * if we're authenticating using a universal hash, put the keystream
+     * prefix into the authentication tag
+     */
+    if (auth_start) {
+        prefix_len = srtp_auth_get_prefix_length(session_keys->rtp_auth);
+        if (prefix_len) {
+            status = srtp_cipher_output(session_keys->rtp_cipher, auth_tag,
+                                        &prefix_len);
+            if (status)
+                return srtp_err_status_cipher_fail;
+            debug_print(mod_srtp, "keystream prefix: %s",
+                        srtp_octet_string_hex_string(auth_tag, prefix_len));
+        }
+    }
+
+    if (xtn_hdr && session_keys->rtp_xtn_hdr_cipher) {
+        /*
+         * extensions header encryption RFC 6904
+         */
+        status = srtp_process_header_encryption(stream, xtn_hdr, session_keys);
+        if (status) {
+            return status;
+        }
+    }
+
+    /* if we're encrypting, exor keystream into the message */
+    if (enc_start) {
+        status =
+            srtp_cipher_encrypt(session_keys->rtp_cipher, (uint8_t *)enc_start,
+                                (unsigned int *)&enc_octet_len);
+        if (status)
+            return srtp_err_status_cipher_fail;
+    }
+
+    /*
+     *  if we're authenticating, run authentication function and put result
+     *  into the auth_tag
+     */
+    if (auth_start) {
+        /* initialize auth func context */
+        status = srtp_auth_start(session_keys->rtp_auth);
+        if (status)
+            return status;
+
+        /* run auth func over packet */
+        status = srtp_auth_update(session_keys->rtp_auth, (uint8_t *)auth_start,
+                                  *pkt_octet_len);
+        if (status)
+            return status;
+
+        /* run auth func over ROC, put result into auth_tag */
+        debug_print(mod_srtp, "estimated packet index: %016llx", est);
+        status = srtp_auth_compute(session_keys->rtp_auth, (uint8_t *)&est, 4,
+                                   auth_tag);
+        debug_print(mod_srtp, "srtp auth tag:    %s",
+                    srtp_octet_string_hex_string(auth_tag, tag_len));
+        if (status)
+            return srtp_err_status_auth_fail;
+    }
+
+    if (auth_tag) {
+        /* increase the packet length by the length of the auth tag */
+        *pkt_octet_len += tag_len;
+    }
+
+    if (use_mki) {
+        /* increate the packet length by the mki size */
+        *pkt_octet_len += mki_size;
+    }
+
+    return srtp_err_status_ok;
+}
 
 srtp_err_status_t
-srtp_unprotect(srtp_ctx_t *ctx, void *srtp_hdr, int *pkt_octet_len) {
+srtp_unprotect(srtp_ctx_t *ctx, void *srtp_hdr, int *pkt_octet_len)
+{
     return srtp_unprotect_mki(ctx, srtp_hdr, pkt_octet_len, 0);
 }
 
-srtp_err_status_t
-srtp_unprotect_mki(srtp_ctx_t *ctx, void *srtp_hdr, int *pkt_octet_len,
-                   unsigned int use_mki) {
-  srtp_hdr_t *hdr = (srtp_hdr_t *)srtp_hdr;
-  uint32_t *enc_start;      /* pointer to start of encrypted portion  */
-  uint32_t *auth_start;     /* pointer to start of auth. portion      */
-  unsigned int enc_octet_len = 0;/* number of octets in encrypted portion */
-  uint8_t *auth_tag = NULL; /* location of auth_tag within packet     */
-  srtp_xtd_seq_num_t est;        /* estimated xtd_seq_num_t of *hdr        */
-  int delta;                /* delta of local pkt idx and that in hdr */
-  v128_t iv;
-  srtp_err_status_t status;
-  srtp_stream_ctx_t *stream;
-  uint8_t tmp_tag[SRTP_MAX_TAG_LEN];
-  uint32_t tag_len, prefix_len;
-  srtp_hdr_xtnd_t *xtn_hdr = NULL;
-  unsigned int mki_size = 0;
-  srtp_session_keys_t *session_keys = NULL;
-  int advance_packet_index = 0;
-  uint32_t roc_to_set = 0;
-  uint16_t seq_to_set = 0;
+srtp_err_status_t srtp_unprotect_mki(srtp_ctx_t *ctx,
+                                     void *srtp_hdr,
+                                     int *pkt_octet_len,
+                                     unsigned int use_mki)
+{
+    srtp_hdr_t *hdr = (srtp_hdr_t *)srtp_hdr;
+    uint32_t *enc_start;            /* pointer to start of encrypted portion  */
+    uint32_t *auth_start;           /* pointer to start of auth. portion      */
+    unsigned int enc_octet_len = 0; /* number of octets in encrypted portion */
+    uint8_t *auth_tag = NULL;       /* location of auth_tag within packet     */
+    srtp_xtd_seq_num_t est;         /* estimated xtd_seq_num_t of *hdr        */
+    int delta;                      /* delta of local pkt idx and that in hdr */
+    v128_t iv;
+    srtp_err_status_t status;
+    srtp_stream_ctx_t *stream;
+    uint8_t tmp_tag[SRTP_MAX_TAG_LEN];
+    uint32_t tag_len, prefix_len;
+    srtp_hdr_xtnd_t *xtn_hdr = NULL;
+    unsigned int mki_size = 0;
+    srtp_session_keys_t *session_keys = NULL;
+    int advance_packet_index = 0;
+    uint32_t roc_to_set = 0;
+    uint16_t seq_to_set = 0;
 
-  debug_print(mod_srtp, "function srtp_unprotect", NULL);
+    debug_print(mod_srtp, "function srtp_unprotect", NULL);
 
-  /* we assume the hdr is 32-bit aligned to start */
+    /* we assume the hdr is 32-bit aligned to start */
 
-  /* Verify RTP header */
-  status = srtp_validate_rtp_header(srtp_hdr, pkt_octet_len);
-  if (status)
-    return status;
-
-  /* check the packet length - it must at least contain a full header */
-  if (*pkt_octet_len < octets_in_rtp_header)
-    return srtp_err_status_bad_param;
-
-  /*
-   * look up ssrc in srtp_stream list, and process the packet with 
-   * the appropriate stream.  if we haven't seen this stream before,
-   * there's only one key for this srtp_session, and the cipher
-   * supports key-sharing, then we assume that a new stream using
-   * that key has just started up
-   */
-  stream = srtp_get_stream(ctx, hdr->ssrc);
-  if (stream == NULL) {
-    if (ctx->stream_template != NULL) {
-      stream = ctx->stream_template;
-      debug_print(mod_srtp, "using provisional stream (SSRC: 0x%08x)",
-		  ntohl(hdr->ssrc));
-      
-      /* 
-       * set estimated packet index to sequence number from header,
-       * and set delta equal to the same value
-       */
-#ifdef NO_64BIT_MATH
-      est = (srtp_xtd_seq_num_t) make64(0,ntohs(hdr->seq));
-      delta = low32(est);
-#else
-      est = (srtp_xtd_seq_num_t) ntohs(hdr->seq);
-      delta = (int)est;
-#endif
-    } else {
-      
-      /*
-       * no stream corresponding to SSRC found, and we don't do
-       * key-sharing, so return an error
-       */
-      return srtp_err_status_no_ctx;
-    }
-  } else {
-    status = srtp_get_est_pkt_index(hdr,
-                                    stream,
-                                    &est,
-                                    &delta);
-
-    if (status && (status != srtp_err_status_pkt_idx_adv))
-      return status;
-
-    if (status == srtp_err_status_pkt_idx_adv) {
-      advance_packet_index = 1;
-      roc_to_set = (uint32_t)(est >> 16);
-      seq_to_set = (uint16_t)(est & 0xFFFF);
-    }
-
-    /* check replay database */
-    if (!advance_packet_index) {
-      status = srtp_rdbx_check(&stream->rtp_rdbx, delta);
-      if (status)
+    /* Verify RTP header */
+    status = srtp_validate_rtp_header(srtp_hdr, pkt_octet_len);
+    if (status)
         return status;
-    }
-  }
 
-#ifdef NO_64BIT_MATH
-  debug_print2(mod_srtp, "estimated u_packet index: %08x%08x", high32(est),low32(est));
-#else
-  debug_print(mod_srtp, "estimated u_packet index: %016llx", est);
-#endif
+    /* check the packet length - it must at least contain a full header */
+    if (*pkt_octet_len < octets_in_rtp_header)
+        return srtp_err_status_bad_param;
 
-  /*
-   * Determine if MKI is being used and what session keys should be used
-   */
-  if (use_mki) {
-      session_keys = srtp_get_session_keys(stream, (uint8_t *)hdr,
-                                           (const unsigned int*)pkt_octet_len,
-                                           &mki_size);
-
-      if (session_keys == NULL) 
-         return srtp_err_status_bad_mki;
-  } else {
-      session_keys = &stream->session_keys[0];
-  }
-
-  /*
-   * Check if this is an AEAD stream (GCM mode).  If so, then dispatch
-   * the request to our AEAD handler.
-   */
-  if (session_keys->rtp_cipher->algorithm == SRTP_AES_GCM_128 ||
-      session_keys->rtp_cipher->algorithm == SRTP_AES_GCM_256) {
-      return srtp_unprotect_aead(ctx, stream, delta, est, srtp_hdr,
-                                 (unsigned int*)pkt_octet_len, session_keys,
-                                 mki_size);
-  }
-
-  /* get tag length from stream */
-  tag_len = srtp_auth_get_tag_length(session_keys->rtp_auth); 
-
-  /* 
-   * set the cipher's IV properly, depending on whatever cipher we
-   * happen to be using
-   */
-  if (session_keys->rtp_cipher->type->id == SRTP_AES_ICM_128 ||
-      session_keys->rtp_cipher->type->id == SRTP_AES_ICM_192 ||
-      session_keys->rtp_cipher->type->id == SRTP_AES_ICM_256) {
-    /* aes counter mode */
-    iv.v32[0] = 0;
-    iv.v32[1] = hdr->ssrc;  /* still in network order */
-#ifdef NO_64BIT_MATH
-    iv.v64[1] = be64_to_cpu(make64((high32(est) << 16) | (low32(est) >> 16),
-			         low32(est) << 16));
-#else
-    iv.v64[1] = be64_to_cpu(est << 16);
-#endif
-    status = srtp_cipher_set_iv(session_keys->rtp_cipher,
-                                (uint8_t*)&iv, srtp_direction_decrypt);
-    if (!status && session_keys->rtp_xtn_hdr_cipher) {
-      status = srtp_cipher_set_iv(session_keys->rtp_xtn_hdr_cipher,
-                                  (uint8_t*)&iv, srtp_direction_decrypt);
-    }
-  } else {  
-    
-    /* no particular format - set the iv to the pakcet index */  
-#ifdef NO_64BIT_MATH
-    iv.v32[0] = 0;
-    iv.v32[1] = 0;
-#else
-    iv.v64[0] = 0;
-#endif
-    iv.v64[1] = be64_to_cpu(est);
-    status = srtp_cipher_set_iv(session_keys->rtp_cipher, (uint8_t*)&iv, srtp_direction_decrypt);
-    if (!status && session_keys->rtp_xtn_hdr_cipher) {
-      status = srtp_cipher_set_iv(session_keys->rtp_xtn_hdr_cipher, (uint8_t*)&iv, srtp_direction_decrypt);
-    }
-  }
-  if (status)
-    return srtp_err_status_cipher_fail;
-
-  /* shift est, put into network byte order */
-#ifdef NO_64BIT_MATH
-  est = be64_to_cpu(make64((high32(est) << 16) |
-					    (low32(est) >> 16),
-					    low32(est) << 16));
-#else
-  est = be64_to_cpu(est << 16);
-#endif
-
-  /*
-   * find starting point for decryption and length of data to be
-   * decrypted - the encrypted portion starts after the rtp header
-   * extension, if present; otherwise, it starts after the last csrc,
-   * if any are present
-   *
-   * if we're not providing confidentiality, set enc_start to NULL
-   */
-  if (stream->rtp_services & sec_serv_conf) {
-    enc_start = (uint32_t *)hdr + uint32s_in_rtp_header + hdr->cc;  
-    if (hdr->x == 1) {
-      xtn_hdr = (srtp_hdr_xtnd_t *)enc_start;
-      enc_start += (ntohs(xtn_hdr->length) + 1);
-    }  
-    if (!((uint8_t*)enc_start <= (uint8_t*)hdr + (*pkt_octet_len - tag_len - mki_size)))
-      return srtp_err_status_parse_err;
-    enc_octet_len = (uint32_t)(*pkt_octet_len - tag_len - mki_size -
-                               ((uint8_t*)enc_start - (uint8_t*)hdr));
-  } else {
-    enc_start = NULL;
-  }
-
-  /* 
-   * if we're providing authentication, set the auth_start and auth_tag
-   * pointers to the proper locations; otherwise, set auth_start to NULL
-   * to indicate that no authentication is needed
-   */
-  if (stream->rtp_services & sec_serv_auth) {
-    auth_start = (uint32_t *)hdr;
-    auth_tag = (uint8_t *)hdr + *pkt_octet_len - tag_len;
-  } else {
-    auth_start = NULL;
-    auth_tag = NULL;
-  } 
-
-  /*
-   * if we expect message authentication, run the authentication
-   * function and compare the result with the value of the auth_tag
-   */
-  if (auth_start) {        
-
-    /* 
-     * if we're using a universal hash, then we need to compute the
-     * keystream prefix for encrypting the universal hash output
-     *
-     * if the keystream prefix length is zero, then we know that
-     * the authenticator isn't using a universal hash function
-     */  
-    if (session_keys->rtp_auth->prefix_len != 0) {
-      
-      prefix_len = srtp_auth_get_prefix_length(session_keys->rtp_auth);    
-      status = srtp_cipher_output(session_keys->rtp_cipher, tmp_tag, &prefix_len);
-      debug_print(mod_srtp, "keystream prefix: %s", 
-		  srtp_octet_string_hex_string(tmp_tag, prefix_len));
-      if (status)
-	return srtp_err_status_cipher_fail;
-    } 
-
-    /* initialize auth func context */
-    status = srtp_auth_start(session_keys->rtp_auth);
-    if (status) return status;
- 
-    /* now compute auth function over packet */
-    status = srtp_auth_update(session_keys->rtp_auth, (uint8_t *)auth_start,
-			 *pkt_octet_len - tag_len - mki_size);
-
-    /* run auth func over ROC, then write tmp tag */
-    status = srtp_auth_compute(session_keys->rtp_auth, (uint8_t *)&est, 4, tmp_tag);
-
-    debug_print(mod_srtp, "computed auth tag:    %s", 
-		srtp_octet_string_hex_string(tmp_tag, tag_len));
-    debug_print(mod_srtp, "packet auth tag:      %s", 
-		srtp_octet_string_hex_string(auth_tag, tag_len));
-    if (status)
-      return srtp_err_status_auth_fail;   
-
-    if (octet_string_is_eq(tmp_tag, auth_tag, tag_len))
-      return srtp_err_status_auth_fail;
-  }
-
-  /* 
-   * update the key usage limit, and check it to make sure that we
-   * didn't just hit either the soft limit or the hard limit, and call
-   * the event handler if we hit either.
-   */
-  switch(srtp_key_limit_update(session_keys->limit)) {
-  case srtp_key_event_normal:
-    break;
-  case srtp_key_event_soft_limit: 
-    srtp_handle_event(ctx, stream, event_key_soft_limit);
-    break; 
-  case srtp_key_event_hard_limit:
-    srtp_handle_event(ctx, stream, event_key_hard_limit);
-    return srtp_err_status_key_expired;
-  default:
-    break;
-  }
-
-  if (xtn_hdr && session_keys->rtp_xtn_hdr_cipher) {
     /*
-     * extensions header encryption RFC 6904
+     * look up ssrc in srtp_stream list, and process the packet with
+     * the appropriate stream.  if we haven't seen this stream before,
+     * there's only one key for this srtp_session, and the cipher
+     * supports key-sharing, then we assume that a new stream using
+     * that key has just started up
      */
-      status = srtp_process_header_encryption(stream, xtn_hdr, session_keys);
-    if (status) {
-      return status;
-    }
-  }
+    stream = srtp_get_stream(ctx, hdr->ssrc);
+    if (stream == NULL) {
+        if (ctx->stream_template != NULL) {
+            stream = ctx->stream_template;
+            debug_print(mod_srtp, "using provisional stream (SSRC: 0x%08x)",
+                        ntohl(hdr->ssrc));
 
-  /* if we're decrypting, add keystream into ciphertext */
-  if (enc_start) {
-    status = srtp_cipher_decrypt(session_keys->rtp_cipher,
-                                 (uint8_t *)enc_start, &enc_octet_len);
-    if (status)
-      return srtp_err_status_cipher_fail;
-  }
-
-  /* 
-   * verify that stream is for received traffic - this check will
-   * detect SSRC collisions, since a stream that appears in both
-   * srtp_protect() and srtp_unprotect() will fail this test in one of
-   * those functions.
-   *
-   * we do this check *after* the authentication check, so that the
-   * latter check will catch any attempts to fool us into thinking
-   * that we've got a collision
-   */
-  if (stream->direction != dir_srtp_receiver) {
-    if (stream->direction == dir_unknown) {
-      stream->direction = dir_srtp_receiver;
+/*
+ * set estimated packet index to sequence number from header,
+ * and set delta equal to the same value
+ */
+#ifdef NO_64BIT_MATH
+            est = (srtp_xtd_seq_num_t)make64(0, ntohs(hdr->seq));
+            delta = low32(est);
+#else
+            est = (srtp_xtd_seq_num_t)ntohs(hdr->seq);
+            delta = (int)est;
+#endif
+        } else {
+            /*
+             * no stream corresponding to SSRC found, and we don't do
+             * key-sharing, so return an error
+             */
+            return srtp_err_status_no_ctx;
+        }
     } else {
-      srtp_handle_event(ctx, stream, event_ssrc_collision);
+        status = srtp_get_est_pkt_index(hdr, stream, &est, &delta);
+
+        if (status && (status != srtp_err_status_pkt_idx_adv))
+            return status;
+
+        if (status == srtp_err_status_pkt_idx_adv) {
+            advance_packet_index = 1;
+            roc_to_set = (uint32_t)(est >> 16);
+            seq_to_set = (uint16_t)(est & 0xFFFF);
+        }
+
+        /* check replay database */
+        if (!advance_packet_index) {
+            status = srtp_rdbx_check(&stream->rtp_rdbx, delta);
+            if (status)
+                return status;
+        }
     }
-  }
 
-  /* 
-   * if the stream is a 'provisional' one, in which the template context
-   * is used, then we need to allocate a new stream at this point, since
-   * the authentication passed
-   */
-  if (stream == ctx->stream_template) {  
-    srtp_stream_ctx_t *new_stream;
+#ifdef NO_64BIT_MATH
+    debug_print2(mod_srtp, "estimated u_packet index: %08x%08x", high32(est),
+                 low32(est));
+#else
+    debug_print(mod_srtp, "estimated u_packet index: %016llx", est);
+#endif
 
-    /* 
-     * allocate and initialize a new stream 
-     * 
-     * note that we indicate failure if we can't allocate the new
-     * stream, and some implementations will want to not return
-     * failure here
+    /* Determine if MKI is being used and what session keys should be used */
+    if (use_mki) {
+        session_keys = srtp_get_session_keys(
+            stream, (uint8_t *)hdr, (const unsigned int *)pkt_octet_len,
+            &mki_size);
+
+        if (session_keys == NULL)
+            return srtp_err_status_bad_mki;
+    } else {
+        session_keys = &stream->session_keys[0];
+    }
+
+    /*
+     * Check if this is an AEAD stream (GCM mode).  If so, then dispatch
+     * the request to our AEAD handler.
      */
-    status = srtp_stream_clone(ctx->stream_template, hdr->ssrc, &new_stream); 
+    if (session_keys->rtp_cipher->algorithm == SRTP_AES_GCM_128 ||
+        session_keys->rtp_cipher->algorithm == SRTP_AES_GCM_256) {
+        return srtp_unprotect_aead(ctx, stream, delta, est, srtp_hdr,
+                                   (unsigned int *)pkt_octet_len, session_keys,
+                                   mki_size);
+    }
+
+    /* get tag length from stream */
+    tag_len = srtp_auth_get_tag_length(session_keys->rtp_auth);
+
+    /*
+     * set the cipher's IV properly, depending on whatever cipher we
+     * happen to be using
+     */
+    if (session_keys->rtp_cipher->type->id == SRTP_AES_ICM_128 ||
+        session_keys->rtp_cipher->type->id == SRTP_AES_ICM_192 ||
+        session_keys->rtp_cipher->type->id == SRTP_AES_ICM_256) {
+        /* aes counter mode */
+        iv.v32[0] = 0;
+        iv.v32[1] = hdr->ssrc; /* still in network order */
+#ifdef NO_64BIT_MATH
+        iv.v64[1] = be64_to_cpu(
+            make64((high32(est) << 16) | (low32(est) >> 16), low32(est) << 16));
+#else
+        iv.v64[1] = be64_to_cpu(est << 16);
+#endif
+        status = srtp_cipher_set_iv(session_keys->rtp_cipher, (uint8_t *)&iv,
+                                    srtp_direction_decrypt);
+        if (!status && session_keys->rtp_xtn_hdr_cipher) {
+            status = srtp_cipher_set_iv(session_keys->rtp_xtn_hdr_cipher,
+                                        (uint8_t *)&iv, srtp_direction_decrypt);
+        }
+    } else {
+/* no particular format - set the iv to the pakcet index */
+#ifdef NO_64BIT_MATH
+        iv.v32[0] = 0;
+        iv.v32[1] = 0;
+#else
+        iv.v64[0] = 0;
+#endif
+        iv.v64[1] = be64_to_cpu(est);
+        status = srtp_cipher_set_iv(session_keys->rtp_cipher, (uint8_t *)&iv,
+                                    srtp_direction_decrypt);
+        if (!status && session_keys->rtp_xtn_hdr_cipher) {
+            status = srtp_cipher_set_iv(session_keys->rtp_xtn_hdr_cipher,
+                                        (uint8_t *)&iv, srtp_direction_decrypt);
+        }
+    }
     if (status)
-      return status;
-    
-    /* add new stream to the head of the stream_list */
-    new_stream->next = ctx->stream_list;
-    ctx->stream_list = new_stream;
-    
-    /* set stream (the pointer used in this function) */
-    stream = new_stream;
-  }
+        return srtp_err_status_cipher_fail;
 
-  /* 
-   * the message authentication function passed, so add the packet
-   * index into the replay database 
-   */
-  if (advance_packet_index) {
-    srtp_rdbx_set_roc_seq(&stream->rtp_rdbx,
-                           roc_to_set,
-                           seq_to_set);
-    stream->pending_roc = 0;
-    srtp_rdbx_add_index(&stream->rtp_rdbx, 0);
-  } else {
-    srtp_rdbx_add_index(&stream->rtp_rdbx, delta);
-  }
+/* shift est, put into network byte order */
+#ifdef NO_64BIT_MATH
+    est = be64_to_cpu(
+        make64((high32(est) << 16) | (low32(est) >> 16), low32(est) << 16));
+#else
+    est = be64_to_cpu(est << 16);
+#endif
 
-  /* decrease the packet length by the length of the auth tag */
-  *pkt_octet_len -= tag_len;
+    /*
+     * find starting point for decryption and length of data to be
+     * decrypted - the encrypted portion starts after the rtp header
+     * extension, if present; otherwise, it starts after the last csrc,
+     * if any are present
+     *
+     * if we're not providing confidentiality, set enc_start to NULL
+     */
+    if (stream->rtp_services & sec_serv_conf) {
+        enc_start = (uint32_t *)hdr + uint32s_in_rtp_header + hdr->cc;
+        if (hdr->x == 1) {
+            xtn_hdr = (srtp_hdr_xtnd_t *)enc_start;
+            enc_start += (ntohs(xtn_hdr->length) + 1);
+        }
+        if (!((uint8_t *)enc_start <=
+              (uint8_t *)hdr + (*pkt_octet_len - tag_len - mki_size)))
+            return srtp_err_status_parse_err;
+        enc_octet_len = (uint32_t)(*pkt_octet_len - tag_len - mki_size -
+                                   ((uint8_t *)enc_start - (uint8_t *)hdr));
+    } else {
+        enc_start = NULL;
+    }
 
-  /* decrease the packet length by the mki size */
-  *pkt_octet_len -= mki_size;
+    /*
+     * if we're providing authentication, set the auth_start and auth_tag
+     * pointers to the proper locations; otherwise, set auth_start to NULL
+     * to indicate that no authentication is needed
+     */
+    if (stream->rtp_services & sec_serv_auth) {
+        auth_start = (uint32_t *)hdr;
+        auth_tag = (uint8_t *)hdr + *pkt_octet_len - tag_len;
+    } else {
+        auth_start = NULL;
+        auth_tag = NULL;
+    }
 
-  return srtp_err_status_ok;  
+    /*
+     * if we expect message authentication, run the authentication
+     * function and compare the result with the value of the auth_tag
+     */
+    if (auth_start) {
+        /*
+         * if we're using a universal hash, then we need to compute the
+         * keystream prefix for encrypting the universal hash output
+         *
+         * if the keystream prefix length is zero, then we know that
+         * the authenticator isn't using a universal hash function
+         */
+        if (session_keys->rtp_auth->prefix_len != 0) {
+            prefix_len = srtp_auth_get_prefix_length(session_keys->rtp_auth);
+            status = srtp_cipher_output(session_keys->rtp_cipher, tmp_tag,
+                                        &prefix_len);
+            debug_print(mod_srtp, "keystream prefix: %s",
+                        srtp_octet_string_hex_string(tmp_tag, prefix_len));
+            if (status)
+                return srtp_err_status_cipher_fail;
+        }
+
+        /* initialize auth func context */
+        status = srtp_auth_start(session_keys->rtp_auth);
+        if (status)
+            return status;
+
+        /* now compute auth function over packet */
+        status = srtp_auth_update(session_keys->rtp_auth, (uint8_t *)auth_start,
+                                  *pkt_octet_len - tag_len - mki_size);
+
+        /* run auth func over ROC, then write tmp tag */
+        status = srtp_auth_compute(session_keys->rtp_auth, (uint8_t *)&est, 4,
+                                   tmp_tag);
+
+        debug_print(mod_srtp, "computed auth tag:    %s",
+                    srtp_octet_string_hex_string(tmp_tag, tag_len));
+        debug_print(mod_srtp, "packet auth tag:      %s",
+                    srtp_octet_string_hex_string(auth_tag, tag_len));
+        if (status)
+            return srtp_err_status_auth_fail;
+
+        if (octet_string_is_eq(tmp_tag, auth_tag, tag_len))
+            return srtp_err_status_auth_fail;
+    }
+
+    /*
+     * update the key usage limit, and check it to make sure that we
+     * didn't just hit either the soft limit or the hard limit, and call
+     * the event handler if we hit either.
+     */
+    switch (srtp_key_limit_update(session_keys->limit)) {
+    case srtp_key_event_normal:
+        break;
+    case srtp_key_event_soft_limit:
+        srtp_handle_event(ctx, stream, event_key_soft_limit);
+        break;
+    case srtp_key_event_hard_limit:
+        srtp_handle_event(ctx, stream, event_key_hard_limit);
+        return srtp_err_status_key_expired;
+    default:
+        break;
+    }
+
+    if (xtn_hdr && session_keys->rtp_xtn_hdr_cipher) {
+        /* extensions header encryption RFC 6904 */
+        status = srtp_process_header_encryption(stream, xtn_hdr, session_keys);
+        if (status) {
+            return status;
+        }
+    }
+
+    /* if we're decrypting, add keystream into ciphertext */
+    if (enc_start) {
+        status = srtp_cipher_decrypt(session_keys->rtp_cipher,
+                                     (uint8_t *)enc_start, &enc_octet_len);
+        if (status)
+            return srtp_err_status_cipher_fail;
+    }
+
+    /*
+     * verify that stream is for received traffic - this check will
+     * detect SSRC collisions, since a stream that appears in both
+     * srtp_protect() and srtp_unprotect() will fail this test in one of
+     * those functions.
+     *
+     * we do this check *after* the authentication check, so that the
+     * latter check will catch any attempts to fool us into thinking
+     * that we've got a collision
+     */
+    if (stream->direction != dir_srtp_receiver) {
+        if (stream->direction == dir_unknown) {
+            stream->direction = dir_srtp_receiver;
+        } else {
+            srtp_handle_event(ctx, stream, event_ssrc_collision);
+        }
+    }
+
+    /*
+     * if the stream is a 'provisional' one, in which the template context
+     * is used, then we need to allocate a new stream at this point, since
+     * the authentication passed
+     */
+    if (stream == ctx->stream_template) {
+        srtp_stream_ctx_t *new_stream;
+
+        /*
+         * allocate and initialize a new stream
+         *
+         * note that we indicate failure if we can't allocate the new
+         * stream, and some implementations will want to not return
+         * failure here
+         */
+        status =
+            srtp_stream_clone(ctx->stream_template, hdr->ssrc, &new_stream);
+        if (status)
+            return status;
+
+        /* add new stream to the head of the stream_list */
+        new_stream->next = ctx->stream_list;
+        ctx->stream_list = new_stream;
+
+        /* set stream (the pointer used in this function) */
+        stream = new_stream;
+    }
+
+    /*
+     * the message authentication function passed, so add the packet
+     * index into the replay database
+     */
+    if (advance_packet_index) {
+        srtp_rdbx_set_roc_seq(&stream->rtp_rdbx, roc_to_set, seq_to_set);
+        stream->pending_roc = 0;
+        srtp_rdbx_add_index(&stream->rtp_rdbx, 0);
+    } else {
+        srtp_rdbx_add_index(&stream->rtp_rdbx, delta);
+    }
+
+    /* decrease the packet length by the length of the auth tag */
+    *pkt_octet_len -= tag_len;
+
+    /* decrease the packet length by the mki size */
+    *pkt_octet_len -= mki_size;
+
+    return srtp_err_status_ok;
 }
 
-srtp_err_status_t
-srtp_init() {
-  srtp_err_status_t status;
+srtp_err_status_t srtp_init()
+{
+    srtp_err_status_t status;
 
-  /* initialize crypto kernel */
-  status = srtp_crypto_kernel_init();
-  if (status) 
-    return status;
+    /* initialize crypto kernel */
+    status = srtp_crypto_kernel_init();
+    if (status)
+        return status;
 
-  /* load srtp debug module into the kernel */
-  status = srtp_crypto_kernel_load_debug_module(&mod_srtp);
-  if (status)
-    return status;
+    /* load srtp debug module into the kernel */
+    status = srtp_crypto_kernel_load_debug_module(&mod_srtp);
+    if (status)
+        return status;
 
-  return srtp_err_status_ok;
+    return srtp_err_status_ok;
 }
 
-srtp_err_status_t
-srtp_shutdown() {
-  srtp_err_status_t status;
+srtp_err_status_t srtp_shutdown()
+{
+    srtp_err_status_t status;
 
-  /* shut down crypto kernel */
-  status = srtp_crypto_kernel_shutdown();
-  if (status) 
-    return status;
+    /* shut down crypto kernel */
+    status = srtp_crypto_kernel_shutdown();
+    if (status)
+        return status;
 
-  /* shutting down crypto kernel frees the srtp debug module as well */
+    /* shutting down crypto kernel frees the srtp debug module as well */
 
-  return srtp_err_status_ok;
+    return srtp_err_status_ok;
 }
 
-
-/* 
+/*
  * The following code is under consideration for removal.  See
- * SRTP_MAX_TRAILER_LEN 
+ * SRTP_MAX_TRAILER_LEN
  */
 #if 0
 
@@ -2740,377 +2816,373 @@ srtp_get_trailer_length(const srtp_stream_t s) {
  * srtp_get_stream(ssrc) returns a pointer to the stream corresponding
  * to ssrc, or NULL if no stream exists for that ssrc
  *
- * this is an internal function 
+ * this is an internal function
  */
 
-srtp_stream_ctx_t *
-srtp_get_stream(srtp_t srtp, uint32_t ssrc) {
-  srtp_stream_ctx_t *stream;
+srtp_stream_ctx_t *srtp_get_stream(srtp_t srtp, uint32_t ssrc)
+{
+    srtp_stream_ctx_t *stream;
 
-  /* walk down list until ssrc is found */
-  stream = srtp->stream_list;
-  while (stream != NULL) {
-    if (stream->ssrc == ssrc)
-      return stream;
-    stream = stream->next;
-  }
-  
-  /* we haven't found our ssrc, so return a null */
-  return NULL;
+    /* walk down list until ssrc is found */
+    stream = srtp->stream_list;
+    while (stream != NULL) {
+        if (stream->ssrc == ssrc)
+            return stream;
+        stream = stream->next;
+    }
+
+    /* we haven't found our ssrc, so return a null */
+    return NULL;
 }
 
-srtp_err_status_t
-srtp_dealloc(srtp_t session) {
-  srtp_stream_ctx_t *stream;
-  srtp_err_status_t status;
+srtp_err_status_t srtp_dealloc(srtp_t session)
+{
+    srtp_stream_ctx_t *stream;
+    srtp_err_status_t status;
 
-  /*
-   * we take a conservative deallocation strategy - if we encounter an
-   * error deallocating a stream, then we stop trying to deallocate
-   * memory and just return an error
-   */
+    /*
+     * we take a conservative deallocation strategy - if we encounter an
+     * error deallocating a stream, then we stop trying to deallocate
+     * memory and just return an error
+     */
 
-  /* walk list of streams, deallocating as we go */
-  stream = session->stream_list;
-  while (stream != NULL) {
-    srtp_stream_t next = stream->next;
+    /* walk list of streams, deallocating as we go */
+    stream = session->stream_list;
+    while (stream != NULL) {
+        srtp_stream_t next = stream->next;
+        status = srtp_stream_dealloc(stream, session->stream_template);
+        if (status)
+            return status;
+        stream = next;
+    }
+
+    /* deallocate stream template, if there is one */
+    if (session->stream_template != NULL) {
+        status = srtp_stream_dealloc(session->stream_template, NULL);
+        if (status)
+            return status;
+    }
+
+    /* deallocate session context */
+    srtp_crypto_free(session);
+
+    return srtp_err_status_ok;
+}
+
+srtp_err_status_t srtp_add_stream(srtp_t session, const srtp_policy_t *policy)
+{
+    srtp_err_status_t status;
+    srtp_stream_t tmp;
+
+    /* sanity check arguments */
+    if ((session == NULL) || (policy == NULL) ||
+        (!srtp_validate_policy_master_keys(policy)))
+        return srtp_err_status_bad_param;
+
+    /* allocate stream  */
+    status = srtp_stream_alloc(&tmp, policy);
+    if (status) {
+        return status;
+    }
+
+    /* initialize stream  */
+    status = srtp_stream_init(tmp, policy);
+    if (status) {
+        srtp_crypto_free(tmp);
+        return status;
+    }
+
+    /*
+     * set the head of the stream list or the template to point to the
+     * stream that we've just alloced and init'ed, depending on whether
+     * or not it has a wildcard SSRC value or not
+     *
+     * if the template stream has already been set, then the policy is
+     * inconsistent, so we return a bad_param error code
+     */
+    switch (policy->ssrc.type) {
+    case (ssrc_any_outbound):
+        if (session->stream_template) {
+            return srtp_err_status_bad_param;
+        }
+        session->stream_template = tmp;
+        session->stream_template->direction = dir_srtp_sender;
+        break;
+    case (ssrc_any_inbound):
+        if (session->stream_template) {
+            return srtp_err_status_bad_param;
+        }
+        session->stream_template = tmp;
+        session->stream_template->direction = dir_srtp_receiver;
+        break;
+    case (ssrc_specific):
+        tmp->next = session->stream_list;
+        session->stream_list = tmp;
+        break;
+    case (ssrc_undefined):
+    default:
+        srtp_crypto_free(tmp);
+        return srtp_err_status_bad_param;
+    }
+
+    return srtp_err_status_ok;
+}
+
+srtp_err_status_t srtp_create(srtp_t *session, /* handle for session     */
+                              const srtp_policy_t *policy)
+{ /* SRTP policy (list)     */
+    srtp_err_status_t stat;
+    srtp_ctx_t *ctx;
+
+    /* sanity check arguments */
+    if (session == NULL)
+        return srtp_err_status_bad_param;
+
+    /* allocate srtp context and set ctx_ptr */
+    ctx = (srtp_ctx_t *)srtp_crypto_alloc(sizeof(srtp_ctx_t));
+    if (ctx == NULL)
+        return srtp_err_status_alloc_fail;
+    *session = ctx;
+
+    /*
+     * loop over elements in the policy list, allocating and
+     * initializing a stream for each element
+     */
+    ctx->stream_template = NULL;
+    ctx->stream_list = NULL;
+    ctx->user_data = NULL;
+    while (policy != NULL) {
+        stat = srtp_add_stream(ctx, policy);
+        if (stat) {
+            /* clean up everything */
+            srtp_dealloc(*session);
+            *session = NULL;
+            return stat;
+        }
+
+        /* set policy to next item in list  */
+        policy = policy->next;
+    }
+
+    return srtp_err_status_ok;
+}
+
+srtp_err_status_t srtp_remove_stream(srtp_t session, uint32_t ssrc)
+{
+    srtp_stream_ctx_t *stream, *last_stream;
+    srtp_err_status_t status;
+
+    /* sanity check arguments */
+    if (session == NULL)
+        return srtp_err_status_bad_param;
+
+    /* find stream in list; complain if not found */
+    last_stream = stream = session->stream_list;
+    while ((stream != NULL) && (ssrc != stream->ssrc)) {
+        last_stream = stream;
+        stream = stream->next;
+    }
+    if (stream == NULL)
+        return srtp_err_status_no_ctx;
+
+    /* remove stream from the list */
+    if (last_stream == stream)
+        /* stream was first in list */
+        session->stream_list = stream->next;
+    else
+        last_stream->next = stream->next;
+
+    /* deallocate the stream */
     status = srtp_stream_dealloc(stream, session->stream_template);
     if (status)
-      return status;
-    stream = next;
-  }
-  
-  /* deallocate stream template, if there is one */
-  if (session->stream_template != NULL) {
-    status = srtp_stream_dealloc(session->stream_template, NULL);
-    if (status)
-      return status;
-  }
+        return status;
 
-  /* deallocate session context */
-  srtp_crypto_free(session);
-
-  return srtp_err_status_ok;
+    return srtp_err_status_ok;
 }
 
+srtp_err_status_t srtp_update(srtp_t session, const srtp_policy_t *policy)
+{
+    srtp_err_status_t stat;
 
-srtp_err_status_t
-srtp_add_stream(srtp_t session, 
-		const srtp_policy_t *policy)  {
-  srtp_err_status_t status;
-  srtp_stream_t tmp;
-
-  /* sanity check arguments */
-  if ((session == NULL) || (policy == NULL) || (!srtp_validate_policy_master_keys(policy)))
-    return srtp_err_status_bad_param;
-
-  /* allocate stream  */
-  status = srtp_stream_alloc(&tmp, policy);
-  if (status) {
-    return status;
-  }
-  
-  /* initialize stream  */
-  status = srtp_stream_init(tmp, policy);
-  if (status) {
-    srtp_crypto_free(tmp);
-    return status;
-  }
-  
-  /* 
-   * set the head of the stream list or the template to point to the
-   * stream that we've just alloced and init'ed, depending on whether
-   * or not it has a wildcard SSRC value or not
-   *
-   * if the template stream has already been set, then the policy is
-   * inconsistent, so we return a bad_param error code
-   */
-  switch (policy->ssrc.type) {
-  case (ssrc_any_outbound):
-    if (session->stream_template) {
-      return srtp_err_status_bad_param;
-    }
-    session->stream_template = tmp;
-    session->stream_template->direction = dir_srtp_sender;
-    break;
-  case (ssrc_any_inbound):
-    if (session->stream_template) {
-      return srtp_err_status_bad_param;
-    }
-    session->stream_template = tmp;
-    session->stream_template->direction = dir_srtp_receiver;
-    break;
-  case (ssrc_specific):
-    tmp->next = session->stream_list;
-    session->stream_list = tmp;
-    break;
-  case (ssrc_undefined):
-  default:
-    srtp_crypto_free(tmp);
-    return srtp_err_status_bad_param;
-  }
-    
-  return srtp_err_status_ok;
-}
-
-
-srtp_err_status_t
-srtp_create(srtp_t *session,               /* handle for session     */ 
-	    const srtp_policy_t *policy) { /* SRTP policy (list)     */
-  srtp_err_status_t stat;
-  srtp_ctx_t *ctx;
-
-  /* sanity check arguments */
-  if (session == NULL)
-    return srtp_err_status_bad_param;
-
-  /* allocate srtp context and set ctx_ptr */
-  ctx = (srtp_ctx_t *) srtp_crypto_alloc(sizeof(srtp_ctx_t));
-  if (ctx == NULL)
-    return srtp_err_status_alloc_fail;
-  *session = ctx;
-
-  /* 
-   * loop over elements in the policy list, allocating and
-   * initializing a stream for each element
-   */
-  ctx->stream_template = NULL;
-  ctx->stream_list = NULL;
-  ctx->user_data = NULL;
-  while (policy != NULL) {    
-
-    stat = srtp_add_stream(ctx, policy);
-    if (stat) {
-      /* clean up everything */
-      srtp_dealloc(*session);
-      *session = NULL;
-      return stat;
-    }    
-
-    /* set policy to next item in list  */
-    policy = policy->next;
-  }
-
-  return srtp_err_status_ok;
-}
-
-
-srtp_err_status_t
-srtp_remove_stream(srtp_t session, uint32_t ssrc) {
-  srtp_stream_ctx_t *stream, *last_stream;
-  srtp_err_status_t status;
-
-  /* sanity check arguments */
-  if (session == NULL)
-    return srtp_err_status_bad_param;
-  
-  /* find stream in list; complain if not found */
-  last_stream = stream = session->stream_list;
-  while ((stream != NULL) && (ssrc != stream->ssrc)) {
-    last_stream = stream;
-    stream = stream->next;
-  }
-  if (stream == NULL)
-    return srtp_err_status_no_ctx;
-
-  /* remove stream from the list */
-  if (last_stream == stream)
-    /* stream was first in list */
-    session->stream_list = stream->next;
-  else
-    last_stream->next = stream->next;
-
-  /* deallocate the stream */
-  status = srtp_stream_dealloc(stream, session->stream_template);
-  if (status)
-    return status;
-
-  return srtp_err_status_ok;
-}
-
-
-srtp_err_status_t
-srtp_update(srtp_t session, const srtp_policy_t *policy) {
-  srtp_err_status_t stat;
-
-  /* sanity check arguments */
-  if ((session == NULL) || (policy == NULL) || (!srtp_validate_policy_master_keys(policy))) {
-    return srtp_err_status_bad_param;
-  }
-
-  while (policy != NULL) {
-    stat = srtp_update_stream(session, policy);
-    if (stat) {
-      return stat;
+    /* sanity check arguments */
+    if ((session == NULL) || (policy == NULL) ||
+        (!srtp_validate_policy_master_keys(policy))) {
+        return srtp_err_status_bad_param;
     }
 
-    /* set policy to next item in list  */
-    policy = policy->next;
-  }
-  return srtp_err_status_ok;
+    while (policy != NULL) {
+        stat = srtp_update_stream(session, policy);
+        if (stat) {
+            return stat;
+        }
+
+        /* set policy to next item in list  */
+        policy = policy->next;
+    }
+    return srtp_err_status_ok;
 }
 
+static srtp_err_status_t update_template_streams(srtp_t session,
+                                                 const srtp_policy_t *policy)
+{
+    srtp_err_status_t status;
+    srtp_stream_t new_stream_template;
+    srtp_stream_t new_stream_list = NULL;
 
-static srtp_err_status_t
-update_template_streams(srtp_t session, const srtp_policy_t *policy) {
-  srtp_err_status_t status;
-  srtp_stream_t new_stream_template;
-  srtp_stream_t new_stream_list = NULL;
+    if (session->stream_template == NULL) {
+        return srtp_err_status_bad_param;
+    }
 
-  if (session->stream_template == NULL) {
-    return srtp_err_status_bad_param;
-  }
+    /* allocate new template stream  */
+    status = srtp_stream_alloc(&new_stream_template, policy);
+    if (status) {
+        return status;
+    }
 
-  /* allocate new template stream  */
-  status = srtp_stream_alloc(&new_stream_template, policy);
-  if (status) {
+    /* initialize new template stream  */
+    status = srtp_stream_init(new_stream_template, policy);
+    if (status) {
+        srtp_crypto_free(new_stream_template);
+        return status;
+    }
+
+    /* for all old templated streams */
+    for (;;) {
+        srtp_stream_t stream;
+        uint32_t ssrc;
+        srtp_xtd_seq_num_t old_index;
+        srtp_rdb_t old_rtcp_rdb;
+
+        stream = session->stream_list;
+        while ((stream != NULL) &&
+               (stream->session_keys[0].rtp_auth !=
+                session->stream_template->session_keys[0].rtp_auth)) {
+            stream = stream->next;
+        }
+        if (stream == NULL) {
+            /* no more templated streams */
+            break;
+        }
+
+        /* save old extendard seq */
+        ssrc = stream->ssrc;
+        old_index = stream->rtp_rdbx.index;
+        old_rtcp_rdb = stream->rtcp_rdb;
+
+        /* remove stream */
+        status = srtp_remove_stream(session, ssrc);
+        if (status) {
+            /* free new allocations */
+            while (new_stream_list != NULL) {
+                srtp_stream_t next = new_stream_list->next;
+                srtp_stream_dealloc(new_stream_list, new_stream_template);
+                new_stream_list = next;
+            }
+            srtp_stream_dealloc(new_stream_template, NULL);
+            return status;
+        }
+
+        /* allocate and initialize a new stream */
+        status = srtp_stream_clone(new_stream_template, ssrc, &stream);
+        if (status) {
+            /* free new allocations */
+            while (new_stream_list != NULL) {
+                srtp_stream_t next = new_stream_list->next;
+                srtp_stream_dealloc(new_stream_list, new_stream_template);
+                new_stream_list = next;
+            }
+            srtp_stream_dealloc(new_stream_template, NULL);
+            return status;
+        }
+
+        /* add new stream to the head of the new_stream_list */
+        stream->next = new_stream_list;
+        new_stream_list = stream;
+
+        /* restore old extended seq */
+        stream->rtp_rdbx.index = old_index;
+        stream->rtcp_rdb = old_rtcp_rdb;
+    }
+    /* dealloc old template */
+    srtp_stream_dealloc(session->stream_template, NULL);
+    /* set new template */
+    session->stream_template = new_stream_template;
+    /* add new list */
+    if (new_stream_list) {
+        srtp_stream_t tail = new_stream_list;
+        while (tail->next) {
+            tail = tail->next;
+        }
+        tail->next = session->stream_list;
+        session->stream_list = new_stream_list;
+    }
     return status;
-  }
+}
 
-  /* initialize new template stream  */
-  status = srtp_stream_init(new_stream_template, policy);
-  if (status) {
-    srtp_crypto_free(new_stream_template);
-    return status;
-  }
-
-  /* for all old templated streams */
-  for (;;) {
-    srtp_stream_t stream;
-    uint32_t ssrc;
+static srtp_err_status_t update_stream(srtp_t session,
+                                       const srtp_policy_t *policy)
+{
+    srtp_err_status_t status;
     srtp_xtd_seq_num_t old_index;
     srtp_rdb_t old_rtcp_rdb;
+    srtp_stream_t stream;
 
-    stream = session->stream_list;
-    while ((stream != NULL) &&
-           (stream->session_keys[0].rtp_auth !=
-            session->stream_template->session_keys[0].rtp_auth)) {
-      stream = stream->next;
-    }
+    stream = srtp_get_stream(session, htonl(policy->ssrc.value));
     if (stream == NULL) {
-      /* no more templated streams */
-      break;
+        return srtp_err_status_bad_param;
     }
 
     /* save old extendard seq */
-    ssrc = stream->ssrc;
     old_index = stream->rtp_rdbx.index;
     old_rtcp_rdb = stream->rtcp_rdb;
 
-    /* remove stream */
-    status = srtp_remove_stream(session, ssrc);
+    status = srtp_remove_stream(session, htonl(policy->ssrc.value));
     if (status) {
-      /* free new allocations */
-      while (new_stream_list != NULL) {
-        srtp_stream_t next = new_stream_list->next;
-        srtp_stream_dealloc(new_stream_list, new_stream_template);
-        new_stream_list = next;
-      }
-      srtp_stream_dealloc(new_stream_template, NULL);
-      return status;
+        return status;
     }
 
-    /* allocate and initialize a new stream */
-    status = srtp_stream_clone(new_stream_template, ssrc, &stream);
+    status = srtp_add_stream(session, policy);
     if (status) {
-      /* free new allocations */
-      while (new_stream_list != NULL) {
-        srtp_stream_t next = new_stream_list->next;
-        srtp_stream_dealloc(new_stream_list, new_stream_template);
-        new_stream_list = next;
-      }
-      srtp_stream_dealloc(new_stream_template, NULL);
-      return status;
+        return status;
     }
 
-    /* add new stream to the head of the new_stream_list */
-    stream->next = new_stream_list;
-    new_stream_list = stream;
+    stream = srtp_get_stream(session, htonl(policy->ssrc.value));
+    if (stream == NULL) {
+        return srtp_err_status_fail;
+    }
 
     /* restore old extended seq */
     stream->rtp_rdbx.index = old_index;
     stream->rtcp_rdb = old_rtcp_rdb;
-  }
-  /* dealloc old template */
-  srtp_stream_dealloc(session->stream_template, NULL);
-  /* set new template */
-  session->stream_template = new_stream_template;
-  /* add new list */
-  if (new_stream_list) {
-    srtp_stream_t tail = new_stream_list;
-    while (tail->next) {
-      tail = tail->next;
+
+    return srtp_err_status_ok;
+}
+
+srtp_err_status_t srtp_update_stream(srtp_t session,
+                                     const srtp_policy_t *policy)
+{
+    srtp_err_status_t status;
+
+    /* sanity check arguments */
+    if ((session == NULL) || (policy == NULL) ||
+        (!srtp_validate_policy_master_keys(policy)))
+        return srtp_err_status_bad_param;
+
+    switch (policy->ssrc.type) {
+    case (ssrc_any_outbound):
+    case (ssrc_any_inbound):
+        status = update_template_streams(session, policy);
+        break;
+    case (ssrc_specific):
+        status = update_stream(session, policy);
+        break;
+    case (ssrc_undefined):
+    default:
+        return srtp_err_status_bad_param;
     }
-    tail->next = session->stream_list;
-    session->stream_list = new_stream_list;
-  }
-  return status;
-}
 
-
-static srtp_err_status_t
-update_stream(srtp_t session, const srtp_policy_t *policy) {
-  srtp_err_status_t status;
-  srtp_xtd_seq_num_t old_index;
-  srtp_rdb_t old_rtcp_rdb;
-  srtp_stream_t stream;
-
-  stream = srtp_get_stream(session, htonl(policy->ssrc.value));
-  if (stream == NULL) {
-    return srtp_err_status_bad_param;
-  }
-
-  /* save old extendard seq */
-  old_index = stream->rtp_rdbx.index;
-  old_rtcp_rdb = stream->rtcp_rdb;
-
-  status = srtp_remove_stream(session, htonl(policy->ssrc.value));
-  if (status) {
     return status;
-  }
-
-  status = srtp_add_stream(session, policy);
-  if (status) {
-    return status;
-  }
-
-  stream = srtp_get_stream(session, htonl(policy->ssrc.value));
-  if (stream == NULL) {
-    return srtp_err_status_fail;
-  }
-
-  /* restore old extended seq */
-  stream->rtp_rdbx.index = old_index;
-  stream->rtcp_rdb = old_rtcp_rdb;
-
-  return srtp_err_status_ok;
 }
-
-
-srtp_err_status_t
-srtp_update_stream(srtp_t session, const srtp_policy_t *policy) {
-  srtp_err_status_t status;
-
-  /* sanity check arguments */
-  if ((session == NULL) || (policy == NULL) || (!srtp_validate_policy_master_keys(policy)))
-    return srtp_err_status_bad_param;
-
-  switch (policy->ssrc.type) {
-  case (ssrc_any_outbound):
-  case (ssrc_any_inbound):
-    status = update_template_streams(session, policy);
-    break;
-  case (ssrc_specific):
-    status = update_stream(session, policy);
-    break;
-  case (ssrc_undefined):
-  default:
-    return srtp_err_status_bad_param;
-  }
-
-  return status;
-}
-
 
 /*
  * The default policy - provides a convenient way for callers to use
@@ -3121,283 +3193,264 @@ srtp_update_stream(srtp_t session, const srtp_policy_t *policy) {
  *
  */
 
-/* 
+/*
  * NOTE: cipher_key_len is really key len (128 bits) plus salt len
  *  (112 bits)
  */
 /* There are hard-coded 16's for base_key_len in the key generation code */
 
-void
-srtp_crypto_policy_set_rtp_default(srtp_crypto_policy_t *p) {
-
-  p->cipher_type     = SRTP_AES_ICM_128;
-  p->cipher_key_len  = SRTP_AES_ICM_128_KEY_LEN_WSALT; /* default 128 bits per RFC 3711 */
-  p->auth_type       = SRTP_HMAC_SHA1;             
-  p->auth_key_len    = 20;                /* default 160 bits per RFC 3711 */
-  p->auth_tag_len    = 10;                /* default 80 bits per RFC 3711 */
-  p->sec_serv        = sec_serv_conf_and_auth;
-  
+void srtp_crypto_policy_set_rtp_default(srtp_crypto_policy_t *p)
+{
+    p->cipher_type = SRTP_AES_ICM_128;
+    p->cipher_key_len =
+        SRTP_AES_ICM_128_KEY_LEN_WSALT; /* default 128 bits per RFC 3711 */
+    p->auth_type = SRTP_HMAC_SHA1;
+    p->auth_key_len = 20; /* default 160 bits per RFC 3711 */
+    p->auth_tag_len = 10; /* default 80 bits per RFC 3711 */
+    p->sec_serv = sec_serv_conf_and_auth;
 }
 
-void
-srtp_crypto_policy_set_rtcp_default(srtp_crypto_policy_t *p) {
-
-  p->cipher_type     = SRTP_AES_ICM_128;
-  p->cipher_key_len  = SRTP_AES_ICM_128_KEY_LEN_WSALT; /* default 128 bits per RFC 3711 */
-  p->auth_type       = SRTP_HMAC_SHA1;             
-  p->auth_key_len    = 20;                 /* default 160 bits per RFC 3711 */
-  p->auth_tag_len    = 10;                 /* default 80 bits per RFC 3711 */
-  p->sec_serv        = sec_serv_conf_and_auth;
-  
+void srtp_crypto_policy_set_rtcp_default(srtp_crypto_policy_t *p)
+{
+    p->cipher_type = SRTP_AES_ICM_128;
+    p->cipher_key_len =
+        SRTP_AES_ICM_128_KEY_LEN_WSALT; /* default 128 bits per RFC 3711 */
+    p->auth_type = SRTP_HMAC_SHA1;
+    p->auth_key_len = 20; /* default 160 bits per RFC 3711 */
+    p->auth_tag_len = 10; /* default 80 bits per RFC 3711 */
+    p->sec_serv = sec_serv_conf_and_auth;
 }
 
-void
-srtp_crypto_policy_set_aes_cm_128_hmac_sha1_32(srtp_crypto_policy_t *p) {
+void srtp_crypto_policy_set_aes_cm_128_hmac_sha1_32(srtp_crypto_policy_t *p)
+{
+    /*
+     * corresponds to RFC 4568
+     *
+     * note that this crypto policy is intended for SRTP, but not SRTCP
+     */
 
-  /*
-   * corresponds to RFC 4568
-   *
-   * note that this crypto policy is intended for SRTP, but not SRTCP
-   */
-
-  p->cipher_type     = SRTP_AES_ICM_128;
-  p->cipher_key_len  = SRTP_AES_ICM_128_KEY_LEN_WSALT; /* 128 bit key, 112 bit salt */
-  p->auth_type       = SRTP_HMAC_SHA1;             
-  p->auth_key_len    = 20;                /* 160 bit key               */
-  p->auth_tag_len    = 4;                 /* 32 bit tag                */
-  p->sec_serv        = sec_serv_conf_and_auth;
-  
+    p->cipher_type = SRTP_AES_ICM_128;
+    p->cipher_key_len =
+        SRTP_AES_ICM_128_KEY_LEN_WSALT; /* 128 bit key, 112 bit salt */
+    p->auth_type = SRTP_HMAC_SHA1;
+    p->auth_key_len = 20; /* 160 bit key               */
+    p->auth_tag_len = 4;  /* 32 bit tag                */
+    p->sec_serv = sec_serv_conf_and_auth;
 }
 
+void srtp_crypto_policy_set_aes_cm_128_null_auth(srtp_crypto_policy_t *p)
+{
+    /*
+     * corresponds to RFC 4568
+     *
+     * note that this crypto policy is intended for SRTP, but not SRTCP
+     */
 
-void
-srtp_crypto_policy_set_aes_cm_128_null_auth(srtp_crypto_policy_t *p) {
-
-  /*
-   * corresponds to RFC 4568
-   *
-   * note that this crypto policy is intended for SRTP, but not SRTCP
-   */
-
-  p->cipher_type     = SRTP_AES_ICM_128;
-  p->cipher_key_len  = SRTP_AES_ICM_128_KEY_LEN_WSALT; /* 128 bit key, 112 bit salt */
-  p->auth_type       = SRTP_NULL_AUTH;             
-  p->auth_key_len    = 0; 
-  p->auth_tag_len    = 0; 
-  p->sec_serv        = sec_serv_conf;
-  
+    p->cipher_type = SRTP_AES_ICM_128;
+    p->cipher_key_len =
+        SRTP_AES_ICM_128_KEY_LEN_WSALT; /* 128 bit key, 112 bit salt */
+    p->auth_type = SRTP_NULL_AUTH;
+    p->auth_key_len = 0;
+    p->auth_tag_len = 0;
+    p->sec_serv = sec_serv_conf;
 }
 
+void srtp_crypto_policy_set_null_cipher_hmac_sha1_80(srtp_crypto_policy_t *p)
+{
+    /*
+     * corresponds to RFC 4568
+     */
 
-void
-srtp_crypto_policy_set_null_cipher_hmac_sha1_80(srtp_crypto_policy_t *p) {
-
-  /*
-   * corresponds to RFC 4568
-   */
-
-  p->cipher_type     = SRTP_NULL_CIPHER;           
-  p->cipher_key_len  = 0;
-  p->auth_type       = SRTP_HMAC_SHA1;             
-  p->auth_key_len    = 20; 
-  p->auth_tag_len    = 10; 
-  p->sec_serv        = sec_serv_auth;
-  
+    p->cipher_type = SRTP_NULL_CIPHER;
+    p->cipher_key_len = 0;
+    p->auth_type = SRTP_HMAC_SHA1;
+    p->auth_key_len = 20;
+    p->auth_tag_len = 10;
+    p->sec_serv = sec_serv_auth;
 }
 
-void
-srtp_crypto_policy_set_null_cipher_hmac_null(srtp_crypto_policy_t *p) {
+void srtp_crypto_policy_set_null_cipher_hmac_null(srtp_crypto_policy_t *p)
+{
+    /*
+     * Should only be used for testing
+     */
 
-  /*
-   * Should only be used for testing
-   */
-
-  p->cipher_type     = SRTP_NULL_CIPHER;           
-  p->cipher_key_len  = 0;
-  p->auth_type       = SRTP_NULL_AUTH;             
-  p->auth_key_len    = 0; 
-  p->auth_tag_len    = 0; 
-  p->sec_serv        = sec_serv_none;
-  
+    p->cipher_type = SRTP_NULL_CIPHER;
+    p->cipher_key_len = 0;
+    p->auth_type = SRTP_NULL_AUTH;
+    p->auth_key_len = 0;
+    p->auth_tag_len = 0;
+    p->sec_serv = sec_serv_none;
 }
 
+void srtp_crypto_policy_set_aes_cm_256_hmac_sha1_80(srtp_crypto_policy_t *p)
+{
+    /*
+     * corresponds to RFC 6188
+     */
 
-void
-srtp_crypto_policy_set_aes_cm_256_hmac_sha1_80(srtp_crypto_policy_t *p) {
-
-  /*
-   * corresponds to RFC 6188
-   */
-
-  p->cipher_type     = SRTP_AES_ICM_256;
-  p->cipher_key_len  = SRTP_AES_ICM_256_KEY_LEN_WSALT;
-  p->auth_type       = SRTP_HMAC_SHA1;             
-  p->auth_key_len    = 20;                /* default 160 bits per RFC 3711 */
-  p->auth_tag_len    = 10;                /* default 80 bits per RFC 3711 */
-  p->sec_serv        = sec_serv_conf_and_auth;
+    p->cipher_type = SRTP_AES_ICM_256;
+    p->cipher_key_len = SRTP_AES_ICM_256_KEY_LEN_WSALT;
+    p->auth_type = SRTP_HMAC_SHA1;
+    p->auth_key_len = 20; /* default 160 bits per RFC 3711 */
+    p->auth_tag_len = 10; /* default 80 bits per RFC 3711 */
+    p->sec_serv = sec_serv_conf_and_auth;
 }
 
+void srtp_crypto_policy_set_aes_cm_256_hmac_sha1_32(srtp_crypto_policy_t *p)
+{
+    /*
+     * corresponds to RFC 6188
+     *
+     * note that this crypto policy is intended for SRTP, but not SRTCP
+     */
 
-void
-srtp_crypto_policy_set_aes_cm_256_hmac_sha1_32(srtp_crypto_policy_t *p) {
-
-  /*
-   * corresponds to RFC 6188
-   *
-   * note that this crypto policy is intended for SRTP, but not SRTCP
-   */
-
-  p->cipher_type     = SRTP_AES_ICM_256;
-  p->cipher_key_len  = SRTP_AES_ICM_256_KEY_LEN_WSALT;
-  p->auth_type       = SRTP_HMAC_SHA1;             
-  p->auth_key_len    = 20;                /* default 160 bits per RFC 3711 */
-  p->auth_tag_len    = 4;                 /* default 80 bits per RFC 3711 */
-  p->sec_serv        = sec_serv_conf_and_auth;
+    p->cipher_type = SRTP_AES_ICM_256;
+    p->cipher_key_len = SRTP_AES_ICM_256_KEY_LEN_WSALT;
+    p->auth_type = SRTP_HMAC_SHA1;
+    p->auth_key_len = 20; /* default 160 bits per RFC 3711 */
+    p->auth_tag_len = 4;  /* default 80 bits per RFC 3711 */
+    p->sec_serv = sec_serv_conf_and_auth;
 }
 
 /*
  * AES-256 with no authentication.
  */
-void
-srtp_crypto_policy_set_aes_cm_256_null_auth (srtp_crypto_policy_t *p)
+void srtp_crypto_policy_set_aes_cm_256_null_auth(srtp_crypto_policy_t *p)
 {
-    p->cipher_type     = SRTP_AES_ICM_256;
-    p->cipher_key_len  = SRTP_AES_ICM_256_KEY_LEN_WSALT;
-    p->auth_type       = SRTP_NULL_AUTH;
-    p->auth_key_len    = 0;
-    p->auth_tag_len    = 0;
-    p->sec_serv        = sec_serv_conf;
+    p->cipher_type = SRTP_AES_ICM_256;
+    p->cipher_key_len = SRTP_AES_ICM_256_KEY_LEN_WSALT;
+    p->auth_type = SRTP_NULL_AUTH;
+    p->auth_key_len = 0;
+    p->auth_tag_len = 0;
+    p->sec_serv = sec_serv_conf;
 }
 
 #ifdef OPENSSL
-void
-srtp_crypto_policy_set_aes_cm_192_hmac_sha1_80(srtp_crypto_policy_t *p) {
+void srtp_crypto_policy_set_aes_cm_192_hmac_sha1_80(srtp_crypto_policy_t *p)
+{
+    /*
+     * corresponds to RFC 6188
+     */
 
-  /*
-   * corresponds to RFC 6188
-   */
-
-  p->cipher_type     = SRTP_AES_ICM_192;
-  p->cipher_key_len  = SRTP_AES_ICM_192_KEY_LEN_WSALT;
-  p->auth_type       = SRTP_HMAC_SHA1;
-  p->auth_key_len    = 20;                /* default 160 bits per RFC 3711 */
-  p->auth_tag_len    = 10;                /* default 80 bits per RFC 3711 */
-  p->sec_serv        = sec_serv_conf_and_auth;
+    p->cipher_type = SRTP_AES_ICM_192;
+    p->cipher_key_len = SRTP_AES_ICM_192_KEY_LEN_WSALT;
+    p->auth_type = SRTP_HMAC_SHA1;
+    p->auth_key_len = 20; /* default 160 bits per RFC 3711 */
+    p->auth_tag_len = 10; /* default 80 bits per RFC 3711 */
+    p->sec_serv = sec_serv_conf_and_auth;
 }
 
+void srtp_crypto_policy_set_aes_cm_192_hmac_sha1_32(srtp_crypto_policy_t *p)
+{
+    /*
+     * corresponds to RFC 6188
+     *
+     * note that this crypto policy is intended for SRTP, but not SRTCP
+     */
 
-void
-srtp_crypto_policy_set_aes_cm_192_hmac_sha1_32(srtp_crypto_policy_t *p) {
-
-  /*
-   * corresponds to RFC 6188
-   *
-   * note that this crypto policy is intended for SRTP, but not SRTCP
-   */
-
-  p->cipher_type     = SRTP_AES_ICM_192;
-  p->cipher_key_len  = SRTP_AES_ICM_192_KEY_LEN_WSALT;
-  p->auth_type       = SRTP_HMAC_SHA1;
-  p->auth_key_len    = 20;                /* default 160 bits per RFC 3711 */
-  p->auth_tag_len    = 4;                 /* default 80 bits per RFC 3711 */
-  p->sec_serv        = sec_serv_conf_and_auth;
+    p->cipher_type = SRTP_AES_ICM_192;
+    p->cipher_key_len = SRTP_AES_ICM_192_KEY_LEN_WSALT;
+    p->auth_type = SRTP_HMAC_SHA1;
+    p->auth_key_len = 20; /* default 160 bits per RFC 3711 */
+    p->auth_tag_len = 4;  /* default 80 bits per RFC 3711 */
+    p->sec_serv = sec_serv_conf_and_auth;
 }
 
 /*
  * AES-192 with no authentication.
  */
-void
-srtp_crypto_policy_set_aes_cm_192_null_auth (srtp_crypto_policy_t *p)
+void srtp_crypto_policy_set_aes_cm_192_null_auth(srtp_crypto_policy_t *p)
 {
-    p->cipher_type     = SRTP_AES_ICM_192;
-    p->cipher_key_len  = SRTP_AES_ICM_192_KEY_LEN_WSALT;
-    p->auth_type       = SRTP_NULL_AUTH;
-    p->auth_key_len    = 0;
-    p->auth_tag_len    = 0;
-    p->sec_serv        = sec_serv_conf;
+    p->cipher_type = SRTP_AES_ICM_192;
+    p->cipher_key_len = SRTP_AES_ICM_192_KEY_LEN_WSALT;
+    p->auth_type = SRTP_NULL_AUTH;
+    p->auth_key_len = 0;
+    p->auth_tag_len = 0;
+    p->sec_serv = sec_serv_conf;
 }
 
 /*
- * AES-128 GCM mode with 8 octet auth tag. 
+ * AES-128 GCM mode with 8 octet auth tag.
  */
-void
-srtp_crypto_policy_set_aes_gcm_128_8_auth(srtp_crypto_policy_t *p) {
-  p->cipher_type     = SRTP_AES_GCM_128;
-  p->cipher_key_len  = SRTP_AES_GCM_128_KEY_LEN_WSALT;
-  p->auth_type       = SRTP_NULL_AUTH; /* GCM handles the auth for us */            
-  p->auth_key_len    = 0; 
-  p->auth_tag_len    = 8;   /* 8 octet tag length */
-  p->sec_serv        = sec_serv_conf_and_auth;
+void srtp_crypto_policy_set_aes_gcm_128_8_auth(srtp_crypto_policy_t *p)
+{
+    p->cipher_type = SRTP_AES_GCM_128;
+    p->cipher_key_len = SRTP_AES_GCM_128_KEY_LEN_WSALT;
+    p->auth_type = SRTP_NULL_AUTH; /* GCM handles the auth for us */
+    p->auth_key_len = 0;
+    p->auth_tag_len = 8; /* 8 octet tag length */
+    p->sec_serv = sec_serv_conf_and_auth;
 }
 
 /*
- * AES-256 GCM mode with 8 octet auth tag. 
+ * AES-256 GCM mode with 8 octet auth tag.
  */
-void
-srtp_crypto_policy_set_aes_gcm_256_8_auth(srtp_crypto_policy_t *p) {
-  p->cipher_type     = SRTP_AES_GCM_256;
-  p->cipher_key_len  = SRTP_AES_GCM_256_KEY_LEN_WSALT;
-  p->auth_type       = SRTP_NULL_AUTH; /* GCM handles the auth for us */ 
-  p->auth_key_len    = 0; 
-  p->auth_tag_len    = 8;   /* 8 octet tag length */
-  p->sec_serv        = sec_serv_conf_and_auth;
+void srtp_crypto_policy_set_aes_gcm_256_8_auth(srtp_crypto_policy_t *p)
+{
+    p->cipher_type = SRTP_AES_GCM_256;
+    p->cipher_key_len = SRTP_AES_GCM_256_KEY_LEN_WSALT;
+    p->auth_type = SRTP_NULL_AUTH; /* GCM handles the auth for us */
+    p->auth_key_len = 0;
+    p->auth_tag_len = 8; /* 8 octet tag length */
+    p->sec_serv = sec_serv_conf_and_auth;
 }
 
 /*
- * AES-128 GCM mode with 8 octet auth tag, no RTCP encryption. 
+ * AES-128 GCM mode with 8 octet auth tag, no RTCP encryption.
  */
-void
-srtp_crypto_policy_set_aes_gcm_128_8_only_auth(srtp_crypto_policy_t *p) {
-  p->cipher_type     = SRTP_AES_GCM_128;
-  p->cipher_key_len  = SRTP_AES_GCM_128_KEY_LEN_WSALT;
-  p->auth_type       = SRTP_NULL_AUTH; /* GCM handles the auth for us */ 
-  p->auth_key_len    = 0; 
-  p->auth_tag_len    = 8;   /* 8 octet tag length */
-  p->sec_serv        = sec_serv_auth;  /* This only applies to RTCP */
+void srtp_crypto_policy_set_aes_gcm_128_8_only_auth(srtp_crypto_policy_t *p)
+{
+    p->cipher_type = SRTP_AES_GCM_128;
+    p->cipher_key_len = SRTP_AES_GCM_128_KEY_LEN_WSALT;
+    p->auth_type = SRTP_NULL_AUTH; /* GCM handles the auth for us */
+    p->auth_key_len = 0;
+    p->auth_tag_len = 8;         /* 8 octet tag length */
+    p->sec_serv = sec_serv_auth; /* This only applies to RTCP */
 }
 
 /*
- * AES-256 GCM mode with 8 octet auth tag, no RTCP encryption. 
+ * AES-256 GCM mode with 8 octet auth tag, no RTCP encryption.
  */
-void
-srtp_crypto_policy_set_aes_gcm_256_8_only_auth(srtp_crypto_policy_t *p) {
-  p->cipher_type     = SRTP_AES_GCM_256;
-  p->cipher_key_len  = SRTP_AES_GCM_256_KEY_LEN_WSALT;
-  p->auth_type       = SRTP_NULL_AUTH; /* GCM handles the auth for us */ 
-  p->auth_key_len    = 0; 
-  p->auth_tag_len    = 8;   /* 8 octet tag length */
-  p->sec_serv        = sec_serv_auth;  /* This only applies to RTCP */
+void srtp_crypto_policy_set_aes_gcm_256_8_only_auth(srtp_crypto_policy_t *p)
+{
+    p->cipher_type = SRTP_AES_GCM_256;
+    p->cipher_key_len = SRTP_AES_GCM_256_KEY_LEN_WSALT;
+    p->auth_type = SRTP_NULL_AUTH; /* GCM handles the auth for us */
+    p->auth_key_len = 0;
+    p->auth_tag_len = 8;         /* 8 octet tag length */
+    p->sec_serv = sec_serv_auth; /* This only applies to RTCP */
 }
 
 /*
- * AES-128 GCM mode with 16 octet auth tag. 
+ * AES-128 GCM mode with 16 octet auth tag.
  */
-void
-srtp_crypto_policy_set_aes_gcm_128_16_auth(srtp_crypto_policy_t *p) {
-  p->cipher_type     = SRTP_AES_GCM_128;
-  p->cipher_key_len  = SRTP_AES_GCM_128_KEY_LEN_WSALT;
-  p->auth_type       = SRTP_NULL_AUTH; /* GCM handles the auth for us */            
-  p->auth_key_len    = 0; 
-  p->auth_tag_len    = 16;   /* 16 octet tag length */
-  p->sec_serv        = sec_serv_conf_and_auth;
+void srtp_crypto_policy_set_aes_gcm_128_16_auth(srtp_crypto_policy_t *p)
+{
+    p->cipher_type = SRTP_AES_GCM_128;
+    p->cipher_key_len = SRTP_AES_GCM_128_KEY_LEN_WSALT;
+    p->auth_type = SRTP_NULL_AUTH; /* GCM handles the auth for us */
+    p->auth_key_len = 0;
+    p->auth_tag_len = 16; /* 16 octet tag length */
+    p->sec_serv = sec_serv_conf_and_auth;
 }
 
 /*
- * AES-256 GCM mode with 16 octet auth tag. 
+ * AES-256 GCM mode with 16 octet auth tag.
  */
-void
-srtp_crypto_policy_set_aes_gcm_256_16_auth(srtp_crypto_policy_t *p) {
-  p->cipher_type     = SRTP_AES_GCM_256;
-  p->cipher_key_len  = SRTP_AES_GCM_256_KEY_LEN_WSALT;
-  p->auth_type       = SRTP_NULL_AUTH; /* GCM handles the auth for us */ 
-  p->auth_key_len    = 0; 
-  p->auth_tag_len    = 16;   /* 16 octet tag length */
-  p->sec_serv        = sec_serv_conf_and_auth;
+void srtp_crypto_policy_set_aes_gcm_256_16_auth(srtp_crypto_policy_t *p)
+{
+    p->cipher_type = SRTP_AES_GCM_256;
+    p->cipher_key_len = SRTP_AES_GCM_256_KEY_LEN_WSALT;
+    p->auth_type = SRTP_NULL_AUTH; /* GCM handles the auth for us */
+    p->auth_key_len = 0;
+    p->auth_tag_len = 16; /* 16 octet tag length */
+    p->sec_serv = sec_serv_conf_and_auth;
 }
 
 #endif
 
-/* 
+/*
  * secure rtcp functions
  */
 
@@ -3420,7 +3473,7 @@ srtp_crypto_policy_set_aes_gcm_256_16_auth(srtp_crypto_policy_t *p) {
  *               +--+--+--+--+--+--+--+--+--+--+--+--+*
  *
  * Input:  *session_keys - pointer to SRTP stream context session keys,
- *                        used to retrieve the SALT 
+ *                        used to retrieve the SALT
  *         *iv           - Pointer to recieve the calculated IV
  *         seq_num       - The SEQ value to use for the IV calculation.
  *         *hdr          - The RTP header, used to get the SSRC value
@@ -3430,11 +3483,13 @@ srtp_crypto_policy_set_aes_gcm_256_16_auth(srtp_crypto_policy_t *p) {
  *
  */
 static srtp_err_status_t
-srtp_calc_aead_iv_srtcp(srtp_session_keys_t *session_keys, v128_t *iv,
-                        uint32_t seq_num, srtcp_hdr_t *hdr)
+srtp_calc_aead_iv_srtcp(srtp_session_keys_t *session_keys,
+                        v128_t *iv,
+                        uint32_t seq_num,
+                        srtcp_hdr_t *hdr)
 {
-    v128_t	in;
-    v128_t	salt;
+    v128_t in;
+    v128_t salt;
 
     memset(&in, 0, sizeof(v128_t));
     memset(&salt, 0, sizeof(v128_t));
@@ -3470,18 +3525,21 @@ srtp_calc_aead_iv_srtcp(srtp_session_keys_t *session_keys, v128_t *iv,
 
 /*
  * This code handles AEAD ciphers for outgoing RTCP.  We currently support
- * AES-GCM mode with 128 or 256 bit keys. 
+ * AES-GCM mode with 128 or 256 bit keys.
  */
 static srtp_err_status_t
-srtp_protect_rtcp_aead (srtp_t ctx, srtp_stream_ctx_t *stream, 
-                        void *rtcp_hdr, unsigned int *pkt_octet_len,
-                        srtp_session_keys_t *session_keys, unsigned int use_mki)
+srtp_protect_rtcp_aead(srtp_t ctx,
+                       srtp_stream_ctx_t *stream,
+                       void *rtcp_hdr,
+                       unsigned int *pkt_octet_len,
+                       srtp_session_keys_t *session_keys,
+                       unsigned int use_mki)
 {
-    srtcp_hdr_t *hdr = (srtcp_hdr_t*)rtcp_hdr;
-    uint32_t *enc_start;        /* pointer to start of encrypted portion  */
-    uint32_t *trailer;          /* pointer to start of trailer            */
+    srtcp_hdr_t *hdr = (srtcp_hdr_t *)rtcp_hdr;
+    uint32_t *enc_start;            /* pointer to start of encrypted portion  */
+    uint32_t *trailer;              /* pointer to start of trailer            */
     unsigned int enc_octet_len = 0; /* number of octets in encrypted portion */
-    uint8_t *auth_tag = NULL;   /* location of auth_tag within packet     */
+    uint8_t *auth_tag = NULL;       /* location of auth_tag within packet     */
     srtp_err_status_t status;
     uint32_t tag_len;
     uint32_t seq_num;
@@ -3496,14 +3554,16 @@ srtp_protect_rtcp_aead (srtp_t ctx, srtp_stream_ctx_t *stream,
      * set encryption start and encryption length - if we're not
      * providing confidentiality, set enc_start to NULL
      */
-    enc_start = (uint32_t*)hdr + uint32s_in_rtcp_header;
+    enc_start = (uint32_t *)hdr + uint32s_in_rtcp_header;
     enc_octet_len = *pkt_octet_len - octets_in_rtcp_header;
 
     /* NOTE: hdr->length is not usable - it refers to only the first
-           RTCP report in the compound packet! */
+     * RTCP report in the compound packet!
+     */
     /* NOTE: trailer is 32-bit aligned because RTCP 'packets' are always
-           multiples of 32-bits (RFC 3550 6.1) */
-    trailer = (uint32_t*)((char*)enc_start + enc_octet_len + tag_len);
+     * multiples of 32-bits (RFC 3550 6.1)
+     */
+    trailer = (uint32_t *)((char *)enc_start + enc_octet_len + tag_len);
 
     if (stream->rtcp_services & sec_serv_conf) {
         *trailer = htonl(SRTCP_E_BIT); /* set encrypt bit */
@@ -3514,7 +3574,8 @@ srtp_protect_rtcp_aead (srtp_t ctx, srtp_stream_ctx_t *stream,
         *trailer = 0x00000000; /* set encrypt bit */
     }
 
-    mki_size = srtp_inject_mki((uint8_t *)hdr + *pkt_octet_len + tag_len + sizeof(srtcp_trailer_t),
+    mki_size = srtp_inject_mki((uint8_t *)hdr + *pkt_octet_len + tag_len +
+                                   sizeof(srtcp_trailer_t),
                                session_keys, use_mki);
 
     /*
@@ -3523,7 +3584,7 @@ srtp_protect_rtcp_aead (srtp_t ctx, srtp_stream_ctx_t *stream,
      * (note that srtpc *always* provides authentication, unlike srtp)
      */
     /* Note: This would need to change for optional mikey data */
-    auth_tag = (uint8_t*)hdr + *pkt_octet_len;
+    auth_tag = (uint8_t *)hdr + *pkt_octet_len;
 
     /*
      * check sequence number for overruns, and copy it into the packet
@@ -3544,8 +3605,8 @@ srtp_protect_rtcp_aead (srtp_t ctx, srtp_stream_ctx_t *stream,
     if (status) {
         return srtp_err_status_cipher_fail;
     }
-    status = srtp_cipher_set_iv(session_keys->rtcp_cipher,
-                                (uint8_t*)&iv, srtp_direction_encrypt);
+    status = srtp_cipher_set_iv(session_keys->rtcp_cipher, (uint8_t *)&iv,
+                                srtp_direction_encrypt);
     if (status) {
         return srtp_err_status_cipher_fail;
     }
@@ -3558,10 +3619,10 @@ srtp_protect_rtcp_aead (srtp_t ctx, srtp_stream_ctx_t *stream,
          * If payload encryption is enabled, then the AAD consist of
          * the RTCP header and the seq# at the end of the packet
          */
-        status = srtp_cipher_set_aad(session_keys->rtcp_cipher,
-                                 (uint8_t*)hdr, octets_in_rtcp_header);
+        status = srtp_cipher_set_aad(session_keys->rtcp_cipher, (uint8_t *)hdr,
+                                     octets_in_rtcp_header);
         if (status) {
-            return ( srtp_err_status_cipher_fail);
+            return (srtp_err_status_cipher_fail);
         }
     } else {
         /*
@@ -3569,36 +3630,36 @@ srtp_protect_rtcp_aead (srtp_t ctx, srtp_stream_ctx_t *stream,
          * the entire packet as described in RFC 7714 (Section 9.3. Data
          * Types in Unencrypted SRTCP Compound Packets)
          */
-        status = srtp_cipher_set_aad(session_keys->rtcp_cipher,
-                                 (uint8_t*)hdr, *pkt_octet_len);
+        status = srtp_cipher_set_aad(session_keys->rtcp_cipher, (uint8_t *)hdr,
+                                     *pkt_octet_len);
         if (status) {
-            return ( srtp_err_status_cipher_fail);
+            return (srtp_err_status_cipher_fail);
         }
     }
     /*
      * Process the sequence# as AAD
      */
     tseq = *trailer;
-    status = srtp_cipher_set_aad(session_keys->rtcp_cipher, (uint8_t*)&tseq,
+    status = srtp_cipher_set_aad(session_keys->rtcp_cipher, (uint8_t *)&tseq,
                                  sizeof(srtcp_trailer_t));
     if (status) {
-        return ( srtp_err_status_cipher_fail);
+        return (srtp_err_status_cipher_fail);
     }
 
     /* if we're encrypting, exor keystream into the message */
     if (enc_start) {
         status = srtp_cipher_encrypt(session_keys->rtcp_cipher,
-                                     (uint8_t*)enc_start, &enc_octet_len);
+                                     (uint8_t *)enc_start, &enc_octet_len);
         if (status) {
             return srtp_err_status_cipher_fail;
         }
         /*
          * Get the tag and append that to the output
          */
-        status = srtp_cipher_get_tag(session_keys->rtcp_cipher, (uint8_t*)auth_tag,
-                                     &tag_len);
+        status = srtp_cipher_get_tag(session_keys->rtcp_cipher,
+                                     (uint8_t *)auth_tag, &tag_len);
         if (status) {
-            return ( srtp_err_status_cipher_fail);
+            return (srtp_err_status_cipher_fail);
         }
         enc_octet_len += tag_len;
     } else {
@@ -3614,10 +3675,10 @@ srtp_protect_rtcp_aead (srtp_t ctx, srtp_stream_ctx_t *stream,
         /*
          * Get the tag and append that to the output
          */
-        status = srtp_cipher_get_tag(session_keys->rtcp_cipher, (uint8_t*)auth_tag,
-                                     &tag_len);
+        status = srtp_cipher_get_tag(session_keys->rtcp_cipher,
+                                     (uint8_t *)auth_tag, &tag_len);
         if (status) {
-            return ( srtp_err_status_cipher_fail);
+            return (srtp_err_status_cipher_fail);
         }
         enc_octet_len += tag_len;
     }
@@ -3633,20 +3694,23 @@ srtp_protect_rtcp_aead (srtp_t ctx, srtp_stream_ctx_t *stream,
 
 /*
  * This function handles incoming SRTCP packets while in AEAD mode,
- * which currently supports AES-GCM encryption.  Note, the auth tag is 
+ * which currently supports AES-GCM encryption.  Note, the auth tag is
  * at the end of the packet stream and is automatically checked by GCM
  * when decrypting the payload.
  */
 static srtp_err_status_t
-srtp_unprotect_rtcp_aead (srtp_t ctx, srtp_stream_ctx_t *stream, 
-                          void *srtcp_hdr, unsigned int *pkt_octet_len,
-                          srtp_session_keys_t *session_keys, unsigned int use_mki)
+srtp_unprotect_rtcp_aead(srtp_t ctx,
+                         srtp_stream_ctx_t *stream,
+                         void *srtcp_hdr,
+                         unsigned int *pkt_octet_len,
+                         srtp_session_keys_t *session_keys,
+                         unsigned int use_mki)
 {
-    srtcp_hdr_t *hdr = (srtcp_hdr_t*)srtcp_hdr;
-    uint32_t *enc_start;        /* pointer to start of encrypted portion  */
-    uint32_t *trailer;          /* pointer to start of trailer            */
+    srtcp_hdr_t *hdr = (srtcp_hdr_t *)srtcp_hdr;
+    uint32_t *enc_start;            /* pointer to start of encrypted portion  */
+    uint32_t *trailer;              /* pointer to start of trailer            */
     unsigned int enc_octet_len = 0; /* number of octets in encrypted portion */
-    uint8_t *auth_tag = NULL;   /* location of auth_tag within packet     */
+    uint8_t *auth_tag = NULL;       /* location of auth_tag within packet     */
     srtp_err_status_t status;
     int tag_len;
     unsigned int tmp_len;
@@ -3659,31 +3723,33 @@ srtp_unprotect_rtcp_aead (srtp_t ctx, srtp_stream_ctx_t *stream,
     tag_len = srtp_auth_get_tag_length(session_keys->rtcp_auth);
 
     if (use_mki) {
-      mki_size = session_keys->mki_size;
+        mki_size = session_keys->mki_size;
     }
 
     /*
      * set encryption start, encryption length, and trailer
      */
-    /* index & E (encryption) bit follow normal data.  hdr->len
-           is the number of words (32-bit) in the normal packet minus 1 */
-    /* This should point trailer to the word past the end of the
-           normal data. */
+    /* index & E (encryption) bit follow normal data. hdr->len is the number of
+     * words (32-bit) in the normal packet minus 1
+     */
+    /* This should point trailer to the word past the end of the normal data. */
     /* This would need to be modified for optional mikey data */
     /*
      * NOTE: trailer is 32-bit aligned because RTCP 'packets' are always
-     *	 multiples of 32-bits (RFC 3550 6.1)
+     *   multiples of 32-bits (RFC 3550 6.1)
      */
-    trailer = (uint32_t*)((char*)hdr + *pkt_octet_len - sizeof(srtcp_trailer_t) - mki_size);
+    trailer = (uint32_t *)((char *)hdr + *pkt_octet_len -
+                           sizeof(srtcp_trailer_t) - mki_size);
     /*
-     * We pass the tag down to the cipher when doing GCM mode 
+     * We pass the tag down to the cipher when doing GCM mode
      */
-    enc_octet_len = *pkt_octet_len - (octets_in_rtcp_header + 
+    enc_octet_len = *pkt_octet_len - (octets_in_rtcp_header +
                                       sizeof(srtcp_trailer_t) + mki_size);
-    auth_tag = (uint8_t*)hdr + *pkt_octet_len - tag_len - mki_size - sizeof(srtcp_trailer_t);
+    auth_tag = (uint8_t *)hdr + *pkt_octet_len - tag_len - mki_size -
+               sizeof(srtcp_trailer_t);
 
-    if (*((unsigned char*)trailer) & SRTCP_E_BYTE_BIT) {
-        enc_start = (uint32_t*)hdr + uint32s_in_rtcp_header;
+    if (*((unsigned char *)trailer) & SRTCP_E_BYTE_BIT) {
+        enc_start = (uint32_t *)hdr + uint32s_in_rtcp_header;
     } else {
         enc_octet_len = 0;
         enc_start = NULL; /* this indicates that there's no encryption */
@@ -3707,8 +3773,8 @@ srtp_unprotect_rtcp_aead (srtp_t ctx, srtp_stream_ctx_t *stream,
     if (status) {
         return srtp_err_status_cipher_fail;
     }
-    status = srtp_cipher_set_iv(session_keys->rtcp_cipher,
-                                (uint8_t*)&iv, srtp_direction_decrypt);
+    status = srtp_cipher_set_iv(session_keys->rtcp_cipher, (uint8_t *)&iv,
+                                srtp_direction_decrypt);
     if (status) {
         return srtp_err_status_cipher_fail;
     }
@@ -3721,10 +3787,10 @@ srtp_unprotect_rtcp_aead (srtp_t ctx, srtp_stream_ctx_t *stream,
          * If payload encryption is enabled, then the AAD consist of
          * the RTCP header and the seq# at the end of the packet
          */
-        status = srtp_cipher_set_aad(session_keys->rtcp_cipher,
-                                   (uint8_t*)hdr, octets_in_rtcp_header);
+        status = srtp_cipher_set_aad(session_keys->rtcp_cipher, (uint8_t *)hdr,
+                                     octets_in_rtcp_header);
         if (status) {
-            return ( srtp_err_status_cipher_fail);
+            return (srtp_err_status_cipher_fail);
         }
     } else {
         /*
@@ -3733,10 +3799,10 @@ srtp_unprotect_rtcp_aead (srtp_t ctx, srtp_stream_ctx_t *stream,
          * Types in Unencrypted SRTCP Compound Packets)
          */
         status = srtp_cipher_set_aad(
-          session_keys->rtcp_cipher, (uint8_t*)hdr,
-          (*pkt_octet_len - tag_len - sizeof(srtcp_trailer_t) - mki_size));
+            session_keys->rtcp_cipher, (uint8_t *)hdr,
+            (*pkt_octet_len - tag_len - sizeof(srtcp_trailer_t) - mki_size));
         if (status) {
-            return ( srtp_err_status_cipher_fail);
+            return (srtp_err_status_cipher_fail);
         }
     }
 
@@ -3744,15 +3810,16 @@ srtp_unprotect_rtcp_aead (srtp_t ctx, srtp_stream_ctx_t *stream,
      * Process the sequence# as AAD
      */
     tseq = *trailer;
-    status = srtp_cipher_set_aad(session_keys->rtcp_cipher,
-                                 (uint8_t*)&tseq, sizeof(srtcp_trailer_t));
+    status = srtp_cipher_set_aad(session_keys->rtcp_cipher, (uint8_t *)&tseq,
+                                 sizeof(srtcp_trailer_t));
     if (status) {
-        return ( srtp_err_status_cipher_fail);
+        return (srtp_err_status_cipher_fail);
     }
 
     /* if we're decrypting, exor keystream into the message */
     if (enc_start) {
-        status = srtp_cipher_decrypt(session_keys->rtcp_cipher, (uint8_t*)enc_start, &enc_octet_len);
+        status = srtp_cipher_decrypt(session_keys->rtcp_cipher,
+                                     (uint8_t *)enc_start, &enc_octet_len);
         if (status) {
             return status;
         }
@@ -3761,7 +3828,8 @@ srtp_unprotect_rtcp_aead (srtp_t ctx, srtp_stream_ctx_t *stream,
          * Still need to run the cipher to check the tag
          */
         tmp_len = tag_len;
-        status = srtp_cipher_decrypt(session_keys->rtcp_cipher, (uint8_t*)auth_tag, &tmp_len);
+        status = srtp_cipher_decrypt(session_keys->rtcp_cipher,
+                                     (uint8_t *)auth_tag, &tmp_len);
         if (status) {
             return status;
         }
@@ -3803,7 +3871,8 @@ srtp_unprotect_rtcp_aead (srtp_t ctx, srtp_stream_ctx_t *stream,
          * stream, and some implementations will want to not return
          * failure here
          */
-        status = srtp_stream_clone(ctx->stream_template, hdr->ssrc, &new_stream);
+        status =
+            srtp_stream_clone(ctx->stream_template, hdr->ssrc, &new_stream);
         if (status) {
             return status;
         }
@@ -3822,724 +3891,702 @@ srtp_unprotect_rtcp_aead (srtp_t ctx, srtp_stream_ctx_t *stream,
     return srtp_err_status_ok;
 }
 
-srtp_err_status_t 
-srtp_protect_rtcp(srtp_t ctx, void *rtcp_hdr, int *pkt_octet_len) {
-  return srtp_protect_rtcp_mki(ctx, rtcp_hdr, pkt_octet_len, 0, 0);
+srtp_err_status_t
+srtp_protect_rtcp(srtp_t ctx, void *rtcp_hdr, int *pkt_octet_len)
+{
+    return srtp_protect_rtcp_mki(ctx, rtcp_hdr, pkt_octet_len, 0, 0);
 }
 
-srtp_err_status_t 
-srtp_protect_rtcp_mki(srtp_t ctx, void *rtcp_hdr, int *pkt_octet_len,
-                      unsigned int use_mki, unsigned int mki_index) {
-  srtcp_hdr_t *hdr = (srtcp_hdr_t *)rtcp_hdr;
-  uint32_t *enc_start;      /* pointer to start of encrypted portion  */
-  uint32_t *auth_start;     /* pointer to start of auth. portion      */
-  uint32_t *trailer;        /* pointer to start of trailer            */
-  unsigned int enc_octet_len = 0;/* number of octets in encrypted portion */
-  uint8_t *auth_tag = NULL; /* location of auth_tag within packet     */
-  srtp_err_status_t status;   
-  int tag_len;
-  srtp_stream_ctx_t *stream;
-  uint32_t prefix_len;
-  uint32_t seq_num;
-  unsigned int mki_size = 0;
-  srtp_session_keys_t *session_keys = NULL;
+srtp_err_status_t srtp_protect_rtcp_mki(srtp_t ctx,
+                                        void *rtcp_hdr,
+                                        int *pkt_octet_len,
+                                        unsigned int use_mki,
+                                        unsigned int mki_index)
+{
+    srtcp_hdr_t *hdr = (srtcp_hdr_t *)rtcp_hdr;
+    uint32_t *enc_start;            /* pointer to start of encrypted portion  */
+    uint32_t *auth_start;           /* pointer to start of auth. portion      */
+    uint32_t *trailer;              /* pointer to start of trailer            */
+    unsigned int enc_octet_len = 0; /* number of octets in encrypted portion */
+    uint8_t *auth_tag = NULL;       /* location of auth_tag within packet     */
+    srtp_err_status_t status;
+    int tag_len;
+    srtp_stream_ctx_t *stream;
+    uint32_t prefix_len;
+    uint32_t seq_num;
+    unsigned int mki_size = 0;
+    srtp_session_keys_t *session_keys = NULL;
 
-  /* we assume the hdr is 32-bit aligned to start */
+    /* we assume the hdr is 32-bit aligned to start */
 
-  /* check the packet length - it must at least contain a full header */
-  if (*pkt_octet_len < octets_in_rtcp_header)
-    return srtp_err_status_bad_param;
+    /* check the packet length - it must at least contain a full header */
+    if (*pkt_octet_len < octets_in_rtcp_header)
+        return srtp_err_status_bad_param;
 
-  /*
-   * look up ssrc in srtp_stream list, and process the packet with 
-   * the appropriate stream.  if we haven't seen this stream before,
-   * there's only one key for this srtp_session, and the cipher
-   * supports key-sharing, then we assume that a new stream using
-   * that key has just started up
-   */
-  stream = srtp_get_stream(ctx, hdr->ssrc);
-  if (stream == NULL) {
-    if (ctx->stream_template != NULL) {
-      srtp_stream_ctx_t *new_stream;
-      
-      /* allocate and initialize a new stream */
-      status = srtp_stream_clone(ctx->stream_template,
-				 hdr->ssrc, &new_stream); 
-      if (status)
-	return status;
-      
-      /* add new stream to the head of the stream_list */
-      new_stream->next = ctx->stream_list;
-      ctx->stream_list = new_stream;
-      
-      /* set stream (the pointer used in this function) */
-      stream = new_stream;
-    } else {
-      /* no template stream, so we return an error */
-      return srtp_err_status_no_ctx;
-    } 
-  }
-  
-  /* 
-   * verify that stream is for sending traffic - this check will
-   * detect SSRC collisions, since a stream that appears in both
-   * srtp_protect() and srtp_unprotect() will fail this test in one of
-   * those functions.
-   */
-  if (stream->direction != dir_srtp_sender) {
-    if (stream->direction == dir_unknown) {
-      stream->direction = dir_srtp_sender;
-    } else {
-      srtp_handle_event(ctx, stream, event_ssrc_collision);
+    /*
+     * look up ssrc in srtp_stream list, and process the packet with
+     * the appropriate stream.  if we haven't seen this stream before,
+     * there's only one key for this srtp_session, and the cipher
+     * supports key-sharing, then we assume that a new stream using
+     * that key has just started up
+     */
+    stream = srtp_get_stream(ctx, hdr->ssrc);
+    if (stream == NULL) {
+        if (ctx->stream_template != NULL) {
+            srtp_stream_ctx_t *new_stream;
+
+            /* allocate and initialize a new stream */
+            status =
+                srtp_stream_clone(ctx->stream_template, hdr->ssrc, &new_stream);
+            if (status)
+                return status;
+
+            /* add new stream to the head of the stream_list */
+            new_stream->next = ctx->stream_list;
+            ctx->stream_list = new_stream;
+
+            /* set stream (the pointer used in this function) */
+            stream = new_stream;
+        } else {
+            /* no template stream, so we return an error */
+            return srtp_err_status_no_ctx;
+        }
     }
-  }  
 
-  session_keys = srtp_get_session_keys_with_mki_index(stream, use_mki, mki_index);
+    /*
+     * verify that stream is for sending traffic - this check will
+     * detect SSRC collisions, since a stream that appears in both
+     * srtp_protect() and srtp_unprotect() will fail this test in one of
+     * those functions.
+     */
+    if (stream->direction != dir_srtp_sender) {
+        if (stream->direction == dir_unknown) {
+            stream->direction = dir_srtp_sender;
+        } else {
+            srtp_handle_event(ctx, stream, event_ssrc_collision);
+        }
+    }
 
-  /*
-   * Check if this is an AEAD stream (GCM mode).  If so, then dispatch
-   * the request to our AEAD handler.
-   */
-  if (session_keys->rtp_cipher->algorithm == SRTP_AES_GCM_128 ||
-      session_keys->rtp_cipher->algorithm == SRTP_AES_GCM_256) {
-      return srtp_protect_rtcp_aead(ctx, stream, rtcp_hdr,
-                                    (unsigned int*)pkt_octet_len, session_keys,
-                                    use_mki);
-  }
+    session_keys =
+        srtp_get_session_keys_with_mki_index(stream, use_mki, mki_index);
 
-  /* get tag length from stream context */
-  tag_len = srtp_auth_get_tag_length(session_keys->rtcp_auth); 
+    /*
+     * Check if this is an AEAD stream (GCM mode).  If so, then dispatch
+     * the request to our AEAD handler.
+     */
+    if (session_keys->rtp_cipher->algorithm == SRTP_AES_GCM_128 ||
+        session_keys->rtp_cipher->algorithm == SRTP_AES_GCM_256) {
+        return srtp_protect_rtcp_aead(ctx, stream, rtcp_hdr,
+                                      (unsigned int *)pkt_octet_len,
+                                      session_keys, use_mki);
+    }
 
-  /*
-   * set encryption start and encryption length - if we're not
-   * providing confidentiality, set enc_start to NULL
-   */
-  enc_start = (uint32_t *)hdr + uint32s_in_rtcp_header;  
-  enc_octet_len = *pkt_octet_len - octets_in_rtcp_header;
+    /* get tag length from stream context */
+    tag_len = srtp_auth_get_tag_length(session_keys->rtcp_auth);
 
-  /* all of the packet, except the header, gets encrypted */
-  /* NOTE: hdr->length is not usable - it refers to only the first
-	 RTCP report in the compound packet! */
-  /* NOTE: trailer is 32-bit aligned because RTCP 'packets' are always
-	 multiples of 32-bits (RFC 3550 6.1) */
-  trailer = (uint32_t *) ((char *)enc_start + enc_octet_len);
+    /*
+     * set encryption start and encryption length - if we're not
+     * providing confidentiality, set enc_start to NULL
+     */
+    enc_start = (uint32_t *)hdr + uint32s_in_rtcp_header;
+    enc_octet_len = *pkt_octet_len - octets_in_rtcp_header;
 
-  if (stream->rtcp_services & sec_serv_conf) {
-    *trailer = htonl(SRTCP_E_BIT);     /* set encrypt bit */    
-  } else {
-    enc_start = NULL;
-    enc_octet_len = 0;
-	/* 0 is network-order independant */
-    *trailer = 0x00000000;     /* set encrypt bit */    
-  }
+    /* all of the packet, except the header, gets encrypted */
+    /*
+     * NOTE: hdr->length is not usable - it refers to only the first RTCP report
+     * in the compound packet!
+     */
+    /*
+     * NOTE: trailer is 32-bit aligned because RTCP 'packets' are always
+     * multiples of 32-bits (RFC 3550 6.1)
+     */
+    trailer = (uint32_t *)((char *)enc_start + enc_octet_len);
 
-  mki_size = srtp_inject_mki((uint8_t *)hdr + *pkt_octet_len + sizeof(srtcp_trailer_t),
-                             session_keys, use_mki);
+    if (stream->rtcp_services & sec_serv_conf) {
+        *trailer = htonl(SRTCP_E_BIT); /* set encrypt bit */
+    } else {
+        enc_start = NULL;
+        enc_octet_len = 0;
+        /* 0 is network-order independant */
+        *trailer = 0x00000000; /* set encrypt bit */
+    }
 
-  /* 
-   * set the auth_start and auth_tag pointers to the proper locations
-   * (note that srtpc *always* provides authentication, unlike srtp)
-   */
-  /* Note: This would need to change for optional mikey data */
-  auth_start = (uint32_t *)hdr;
-  auth_tag = (uint8_t *)hdr + *pkt_octet_len + sizeof(srtcp_trailer_t) + mki_size; 
+    mki_size = srtp_inject_mki((uint8_t *)hdr + *pkt_octet_len +
+                                   sizeof(srtcp_trailer_t),
+                               session_keys, use_mki);
 
-  /* perform EKT processing if needed */
-  srtp_ekt_write_data(stream->ekt, auth_tag, tag_len, pkt_octet_len, 
-		      srtp_rdbx_get_packet_index(&stream->rtp_rdbx));
+    /*
+     * set the auth_start and auth_tag pointers to the proper locations
+     * (note that srtpc *always* provides authentication, unlike srtp)
+     */
+    /* Note: This would need to change for optional mikey data */
+    auth_start = (uint32_t *)hdr;
+    auth_tag =
+        (uint8_t *)hdr + *pkt_octet_len + sizeof(srtcp_trailer_t) + mki_size;
 
-  /* 
-   * check sequence number for overruns, and copy it into the packet
-   * if its value isn't too big
-   */
-  status = srtp_rdb_increment(&stream->rtcp_rdb);
-  if (status)
-    return status;
-  seq_num = srtp_rdb_get_value(&stream->rtcp_rdb);
-  *trailer |= htonl(seq_num);
-  debug_print(mod_srtp, "srtcp index: %x", seq_num);
+    /* perform EKT processing if needed */
+    srtp_ekt_write_data(stream->ekt, auth_tag, tag_len, pkt_octet_len,
+                        srtp_rdbx_get_packet_index(&stream->rtp_rdbx));
 
-  /* 
-   * if we're using rindael counter mode, set nonce and seq 
-   */
-  if (session_keys->rtcp_cipher->type->id == SRTP_AES_ICM_128 ||
-      session_keys->rtcp_cipher->type->id == SRTP_AES_ICM_192 ||
-      session_keys->rtcp_cipher->type->id == SRTP_AES_ICM_256) {
-    v128_t iv;
-    
-    iv.v32[0] = 0;
-    iv.v32[1] = hdr->ssrc;  /* still in network order! */
-    iv.v32[2] = htonl(seq_num >> 16);
-    iv.v32[3] = htonl(seq_num << 16);
-    status = srtp_cipher_set_iv(session_keys->rtcp_cipher, (uint8_t*)&iv,
-                                srtp_direction_encrypt);
-
-  } else {  
-    v128_t iv;
-    
-    /* otherwise, just set the index to seq_num */  
-    iv.v32[0] = 0;
-    iv.v32[1] = 0;
-    iv.v32[2] = 0;
-    iv.v32[3] = htonl(seq_num);
-    status = srtp_cipher_set_iv(session_keys->rtcp_cipher,
-                                (uint8_t*)&iv, srtp_direction_encrypt);
-  }
-  if (status)
-    return srtp_err_status_cipher_fail;
-
-  /* 
-   * if we're authenticating using a universal hash, put the keystream
-   * prefix into the authentication tag
-   */
-  
-  /* if auth_start is non-null, then put keystream into tag  */
-  if (auth_start) {
-
-    /* put keystream prefix into auth_tag */
-    prefix_len = srtp_auth_get_prefix_length(session_keys->rtcp_auth);    
-    status = srtp_cipher_output(session_keys->rtcp_cipher, auth_tag, &prefix_len);
-
-    debug_print(mod_srtp, "keystream prefix: %s", 
-		srtp_octet_string_hex_string(auth_tag, prefix_len));
-
+    /*
+     * check sequence number for overruns, and copy it into the packet
+     * if its value isn't too big
+     */
+    status = srtp_rdb_increment(&stream->rtcp_rdb);
     if (status)
-      return srtp_err_status_cipher_fail;
-  }
+        return status;
+    seq_num = srtp_rdb_get_value(&stream->rtcp_rdb);
+    *trailer |= htonl(seq_num);
+    debug_print(mod_srtp, "srtcp index: %x", seq_num);
 
-  /* if we're encrypting, exor keystream into the message */
-  if (enc_start) {
-    status = srtp_cipher_encrypt(session_keys->rtcp_cipher, 
-		  	        (uint8_t *)enc_start, &enc_octet_len);
+    /*
+     * if we're using rindael counter mode, set nonce and seq
+     */
+    if (session_keys->rtcp_cipher->type->id == SRTP_AES_ICM_128 ||
+        session_keys->rtcp_cipher->type->id == SRTP_AES_ICM_192 ||
+        session_keys->rtcp_cipher->type->id == SRTP_AES_ICM_256) {
+        v128_t iv;
+
+        iv.v32[0] = 0;
+        iv.v32[1] = hdr->ssrc; /* still in network order! */
+        iv.v32[2] = htonl(seq_num >> 16);
+        iv.v32[3] = htonl(seq_num << 16);
+        status = srtp_cipher_set_iv(session_keys->rtcp_cipher, (uint8_t *)&iv,
+                                    srtp_direction_encrypt);
+
+    } else {
+        v128_t iv;
+
+        /* otherwise, just set the index to seq_num */
+        iv.v32[0] = 0;
+        iv.v32[1] = 0;
+        iv.v32[2] = 0;
+        iv.v32[3] = htonl(seq_num);
+        status = srtp_cipher_set_iv(session_keys->rtcp_cipher, (uint8_t *)&iv,
+                                    srtp_direction_encrypt);
+    }
     if (status)
-      return srtp_err_status_cipher_fail;
-  }
+        return srtp_err_status_cipher_fail;
 
-  /* initialize auth func context */
-  srtp_auth_start(session_keys->rtcp_auth);
+    /*
+     * if we're authenticating using a universal hash, put the keystream
+     * prefix into the authentication tag
+     */
 
-  /* 
-   * run auth func over packet (including trailer), and write the
-   * result at auth_tag 
-   */
-  status = srtp_auth_compute(session_keys->rtcp_auth,
-			(uint8_t *)auth_start, 
-			(*pkt_octet_len) + sizeof(srtcp_trailer_t), 
-			auth_tag);
-  debug_print(mod_srtp, "srtcp auth tag:    %s", 
-	      srtp_octet_string_hex_string(auth_tag, tag_len));
-  if (status)
-    return srtp_err_status_auth_fail;   
-    
-  /* increase the packet length by the length of the auth tag and seq_num*/
-  *pkt_octet_len += (tag_len + sizeof(srtcp_trailer_t));
+    /* if auth_start is non-null, then put keystream into tag  */
+    if (auth_start) {
+        /* put keystream prefix into auth_tag */
+        prefix_len = srtp_auth_get_prefix_length(session_keys->rtcp_auth);
+        status = srtp_cipher_output(session_keys->rtcp_cipher, auth_tag,
+                                    &prefix_len);
 
-  /* increase the packet by the mki_size */
-  *pkt_octet_len += mki_size;
-    
-  return srtp_err_status_ok;  
-}
+        debug_print(mod_srtp, "keystream prefix: %s",
+                    srtp_octet_string_hex_string(auth_tag, prefix_len));
 
+        if (status)
+            return srtp_err_status_cipher_fail;
+    }
 
-srtp_err_status_t 
-srtp_unprotect_rtcp(srtp_t ctx, void *srtcp_hdr, int *pkt_octet_len) {
-    return srtp_unprotect_rtcp_mki(ctx, srtcp_hdr, pkt_octet_len, 0);
+    /* if we're encrypting, exor keystream into the message */
+    if (enc_start) {
+        status = srtp_cipher_encrypt(session_keys->rtcp_cipher,
+                                     (uint8_t *)enc_start, &enc_octet_len);
+        if (status)
+            return srtp_err_status_cipher_fail;
+    }
+
+    /* initialize auth func context */
+    srtp_auth_start(session_keys->rtcp_auth);
+
+    /*
+     * run auth func over packet (including trailer), and write the
+     * result at auth_tag
+     */
+    status =
+        srtp_auth_compute(session_keys->rtcp_auth, (uint8_t *)auth_start,
+                          (*pkt_octet_len) + sizeof(srtcp_trailer_t), auth_tag);
+    debug_print(mod_srtp, "srtcp auth tag:    %s",
+                srtp_octet_string_hex_string(auth_tag, tag_len));
+    if (status)
+        return srtp_err_status_auth_fail;
+
+    /* increase the packet length by the length of the auth tag and seq_num*/
+    *pkt_octet_len += (tag_len + sizeof(srtcp_trailer_t));
+
+    /* increase the packet by the mki_size */
+    *pkt_octet_len += mki_size;
+
+    return srtp_err_status_ok;
 }
 
 srtp_err_status_t
-srtp_unprotect_rtcp_mki(srtp_t ctx, void *srtcp_hdr, int *pkt_octet_len,
-                        unsigned int use_mki) {
-  srtcp_hdr_t *hdr = (srtcp_hdr_t *)srtcp_hdr;
-  uint32_t *enc_start;      /* pointer to start of encrypted portion  */
-  uint32_t *auth_start;     /* pointer to start of auth. portion      */
-  uint32_t *trailer;        /* pointer to start of trailer            */
-  unsigned int enc_octet_len = 0;/* number of octets in encrypted portion */
-  uint8_t *auth_tag = NULL; /* location of auth_tag within packet     */
-  uint8_t tmp_tag[SRTP_MAX_TAG_LEN];
-  uint8_t tag_copy[SRTP_MAX_TAG_LEN];
-  srtp_err_status_t status;   
-  unsigned int auth_len;
-  int tag_len;
-  srtp_stream_ctx_t *stream;
-  uint32_t prefix_len;
-  uint32_t seq_num;
-  int e_bit_in_packet;     /* whether the E-bit was found in the packet */
-  int sec_serv_confidentiality; /* whether confidentiality was requested */
-  unsigned int mki_size = 0;
-  srtp_session_keys_t *session_keys = NULL;
-
-  /* we assume the hdr is 32-bit aligned to start */
-
-  /* check that the length value is sane; we'll check again once we
-     know the tag length, but we at least want to know that it is
-     a positive value */
-  if (*pkt_octet_len < octets_in_rtcp_header + sizeof(srtcp_trailer_t))
-    return srtp_err_status_bad_param;
-
-  /*
-   * look up ssrc in srtp_stream list, and process the packet with 
-   * the appropriate stream.  if we haven't seen this stream before,
-   * there's only one key for this srtp_session, and the cipher
-   * supports key-sharing, then we assume that a new stream using
-   * that key has just started up
-   */
-  stream = srtp_get_stream(ctx, hdr->ssrc);
-  if (stream == NULL) {
-    if (ctx->stream_template != NULL) {
-      stream = ctx->stream_template;
-
-      /* 
-       * check to see if stream_template has an EKT data structure, in
-       * which case we initialize the template using the EKT policy
-       * referenced by that data (which consists of decrypting the
-       * master key from the EKT field)
-       *
-       * this function initializes a *provisional* stream, and this
-       * stream should not be accepted until and unless the packet
-       * passes its authentication check
-       */ 
-      if (stream->ekt != NULL) {
-	status = srtp_stream_init_from_ekt(stream, srtcp_hdr, *pkt_octet_len);
-	if (status)
-	  return status;
-      }
-
-      debug_print(mod_srtp, "srtcp using provisional stream (SSRC: 0x%08x)", 
-		  ntohl(hdr->ssrc));
-    } else {
-      /* no template stream, so we return an error */
-      return srtp_err_status_no_ctx;
-    } 
-  }
-
-  /*
-   * Determine if MKI is being used and what session keys should be used
-   */
-  if (use_mki) {
-      session_keys = srtp_get_session_keys(stream, (uint8_t *)hdr,
-                                           (const unsigned int*)pkt_octet_len,
-                                           &mki_size);
-
-      if (session_keys == NULL) 
-         return srtp_err_status_bad_mki;
-  } else {
-      session_keys = &stream->session_keys[0];
-  }  
-
-
-  /* get tag length from stream context */
-  tag_len = srtp_auth_get_tag_length(session_keys->rtcp_auth);
-
-  /* check the packet length - it must contain at least a full RTCP
-     header, an auth tag (if applicable), and the SRTCP encrypted flag
-     and 31-bit index value */
-  if (*pkt_octet_len < (int) (octets_in_rtcp_header + tag_len + mki_size + sizeof(srtcp_trailer_t))) {
-    return srtp_err_status_bad_param;
-  }
-
-  /*
-   * Check if this is an AEAD stream (GCM mode).  If so, then dispatch
-   * the request to our AEAD handler.
-   */
-  if (session_keys->rtp_cipher->algorithm == SRTP_AES_GCM_128 ||
-      session_keys->rtp_cipher->algorithm == SRTP_AES_GCM_256) {
-      return srtp_unprotect_rtcp_aead(ctx, stream, srtcp_hdr,
-                                      (unsigned int*)pkt_octet_len, session_keys,
-                                      mki_size);
-  }
-
-  sec_serv_confidentiality = stream->rtcp_services == sec_serv_conf ||
-      stream->rtcp_services == sec_serv_conf_and_auth;
-
-  /*
-   * set encryption start, encryption length, and trailer
-   */
-  enc_octet_len = *pkt_octet_len - 
-                  (octets_in_rtcp_header + tag_len + mki_size + sizeof(srtcp_trailer_t));
-  /* index & E (encryption) bit follow normal data.  hdr->len
-	 is the number of words (32-bit) in the normal packet minus 1 */
-  /* This should point trailer to the word past the end of the
-	 normal data. */
-  /* This would need to be modified for optional mikey data */
-  /*
-   * NOTE: trailer is 32-bit aligned because RTCP 'packets' are always
-   *	 multiples of 32-bits (RFC 3550 6.1)
-   */
-  trailer = (uint32_t *) ((char *) hdr +
-      *pkt_octet_len -(tag_len + mki_size + sizeof(srtcp_trailer_t)));
-  e_bit_in_packet =
-      (*((unsigned char *) trailer) & SRTCP_E_BYTE_BIT) == SRTCP_E_BYTE_BIT;
-  if (e_bit_in_packet != sec_serv_confidentiality) {
-    return srtp_err_status_cant_check;
-  }
-  if (sec_serv_confidentiality) {
-    enc_start = (uint32_t *)hdr + uint32s_in_rtcp_header;  
-  } else {
-    enc_octet_len = 0;
-    enc_start = NULL; /* this indicates that there's no encryption */
-  }
-
-  /* 
-   * set the auth_start and auth_tag pointers to the proper locations
-   * (note that srtcp *always* uses authentication, unlike srtp)
-   */
-  auth_start = (uint32_t *)hdr;
-
-  /*
-   * The location of the auth tag in the packet needs to know MKI 
-   * could be present.  The data needed to calculate the Auth tag
-   * must not include the MKI
-   */
-  auth_len = *pkt_octet_len - tag_len - mki_size;
-  auth_tag = (uint8_t *)hdr + auth_len + mki_size;
-
-  /* 
-   * if EKT is in use, then we make a copy of the tag from the packet,
-   * and then zeroize the location of the base tag
-   *
-   * we first re-position the auth_tag pointer so that it points to
-   * the base tag
-   */
-  if (stream->ekt) {
-    auth_tag -= srtp_ekt_octets_after_base_tag(stream->ekt);
-    memcpy(tag_copy, auth_tag, tag_len);
-    octet_string_set_to_zero(auth_tag, tag_len);
-    auth_tag = tag_copy;
-    auth_len += tag_len;
-  }
-
-  /* 
-   * check the sequence number for replays
-   */
-  /* this is easier than dealing with bitfield access */
-  seq_num = ntohl(*trailer) & SRTCP_INDEX_MASK;
-  debug_print(mod_srtp, "srtcp index: %x", seq_num);
-  status = srtp_rdb_check(&stream->rtcp_rdb, seq_num);
-  if (status)
-    return status;
-
-  /* 
-   * if we're using aes counter mode, set nonce and seq 
-   */
-  if (session_keys->rtcp_cipher->type->id == SRTP_AES_ICM_128 ||
-      session_keys->rtcp_cipher->type->id == SRTP_AES_ICM_192 ||
-      session_keys->rtcp_cipher->type->id == SRTP_AES_ICM_256) {
-    v128_t iv;
-
-    iv.v32[0] = 0;
-    iv.v32[1] = hdr->ssrc; /* still in network order! */
-    iv.v32[2] = htonl(seq_num >> 16);
-    iv.v32[3] = htonl(seq_num << 16);
-    status = srtp_cipher_set_iv(session_keys->rtcp_cipher,
-                                (uint8_t*)&iv, srtp_direction_decrypt);
-
-  } else {  
-    v128_t iv;
-    
-    /* otherwise, just set the index to seq_num */  
-    iv.v32[0] = 0;
-    iv.v32[1] = 0;
-    iv.v32[2] = 0;
-    iv.v32[3] = htonl(seq_num);
-    status = srtp_cipher_set_iv(session_keys->rtcp_cipher,
-                                (uint8_t*)&iv, srtp_direction_decrypt);
-
-  }
-  if (status)
-    return srtp_err_status_cipher_fail;
-
-  /* initialize auth func context */
-  srtp_auth_start(session_keys->rtcp_auth);
-
-  /* run auth func over packet, put result into tmp_tag */
-  status = srtp_auth_compute(session_keys->rtcp_auth, (uint8_t *)auth_start,
-			auth_len, tmp_tag);
-  debug_print(mod_srtp, "srtcp computed tag:       %s", 
-	      srtp_octet_string_hex_string(tmp_tag, tag_len));
-  if (status)
-    return srtp_err_status_auth_fail;   
-  
-  /* compare the tag just computed with the one in the packet */
-  debug_print(mod_srtp, "srtcp tag from packet:    %s", 
-	      srtp_octet_string_hex_string(auth_tag, tag_len));  
-  if (octet_string_is_eq(tmp_tag, auth_tag, tag_len))
-    return srtp_err_status_auth_fail;
-
-  /* 
-   * if we're authenticating using a universal hash, put the keystream
-   * prefix into the authentication tag
-   */
-  prefix_len = srtp_auth_get_prefix_length(session_keys->rtcp_auth);    
-  if (prefix_len) {
-    status = srtp_cipher_output(session_keys->rtcp_cipher, auth_tag, &prefix_len);
-    debug_print(mod_srtp, "keystream prefix: %s", 
-		srtp_octet_string_hex_string(auth_tag, prefix_len));
-    if (status)
-      return srtp_err_status_cipher_fail;
-  }
-
-  /* if we're decrypting, exor keystream into the message */
-  if (enc_start) {
-    status = srtp_cipher_decrypt(session_keys->rtcp_cipher, (uint8_t *)enc_start,
-                                 &enc_octet_len);
-    if (status)
-      return srtp_err_status_cipher_fail;
-  }
-
-  /* decrease the packet length by the length of the auth tag and seq_num */
-  *pkt_octet_len -= (tag_len + sizeof(srtcp_trailer_t));
-
-  /* decrease the packet length by the length of the mki_size */
-  *pkt_octet_len -= mki_size;
-
-  /*
-   * if EKT is in effect, subtract the EKT data out of the packet
-   * length
-   */
-  *pkt_octet_len -= srtp_ekt_octets_after_base_tag(stream->ekt);
-
-  /* 
-   * verify that stream is for received traffic - this check will
-   * detect SSRC collisions, since a stream that appears in both
-   * srtp_protect() and srtp_unprotect() will fail this test in one of
-   * those functions.
-   *
-   * we do this check *after* the authentication check, so that the
-   * latter check will catch any attempts to fool us into thinking
-   * that we've got a collision
-   */
-  if (stream->direction != dir_srtp_receiver) {
-    if (stream->direction == dir_unknown) {
-      stream->direction = dir_srtp_receiver;
-    } else {
-      srtp_handle_event(ctx, stream, event_ssrc_collision);
-    }
-  }
-
-  /* 
-   * if the stream is a 'provisional' one, in which the template context
-   * is used, then we need to allocate a new stream at this point, since
-   * the authentication passed
-   */
-  if (stream == ctx->stream_template) {  
-    srtp_stream_ctx_t *new_stream;
-
-    /* 
-     * allocate and initialize a new stream 
-     * 
-     * note that we indicate failure if we can't allocate the new
-     * stream, and some implementations will want to not return
-     * failure here
-     */
-    status = srtp_stream_clone(ctx->stream_template, hdr->ssrc, &new_stream); 
-    if (status)
-      return status;
-    
-    /* add new stream to the head of the stream_list */
-    new_stream->next = ctx->stream_list;
-    ctx->stream_list = new_stream;
-    
-    /* set stream (the pointer used in this function) */
-    stream = new_stream;
-  }
-
-  /* we've passed the authentication check, so add seq_num to the rdb */
-  srtp_rdb_add_index(&stream->rtcp_rdb, seq_num);
-    
-    
-  return srtp_err_status_ok;  
+srtp_unprotect_rtcp(srtp_t ctx, void *srtcp_hdr, int *pkt_octet_len)
+{
+    return srtp_unprotect_rtcp_mki(ctx, srtcp_hdr, pkt_octet_len, 0);
 }
 
+srtp_err_status_t srtp_unprotect_rtcp_mki(srtp_t ctx,
+                                          void *srtcp_hdr,
+                                          int *pkt_octet_len,
+                                          unsigned int use_mki)
+{
+    srtcp_hdr_t *hdr = (srtcp_hdr_t *)srtcp_hdr;
+    uint32_t *enc_start;            /* pointer to start of encrypted portion  */
+    uint32_t *auth_start;           /* pointer to start of auth. portion      */
+    uint32_t *trailer;              /* pointer to start of trailer            */
+    unsigned int enc_octet_len = 0; /* number of octets in encrypted portion */
+    uint8_t *auth_tag = NULL;       /* location of auth_tag within packet     */
+    uint8_t tmp_tag[SRTP_MAX_TAG_LEN];
+    uint8_t tag_copy[SRTP_MAX_TAG_LEN];
+    srtp_err_status_t status;
+    unsigned int auth_len;
+    int tag_len;
+    srtp_stream_ctx_t *stream;
+    uint32_t prefix_len;
+    uint32_t seq_num;
+    int e_bit_in_packet; /* whether the E-bit was found in the packet */
+    int sec_serv_confidentiality; /* whether confidentiality was requested */
+    unsigned int mki_size = 0;
+    srtp_session_keys_t *session_keys = NULL;
+
+    /* we assume the hdr is 32-bit aligned to start */
+
+    /*
+     * check that the length value is sane; we'll check again once we
+     * know the tag length, but we at least want to know that it is
+     * a positive value
+     */
+    if (*pkt_octet_len < octets_in_rtcp_header + sizeof(srtcp_trailer_t))
+        return srtp_err_status_bad_param;
+
+    /*
+     * look up ssrc in srtp_stream list, and process the packet with
+     * the appropriate stream.  if we haven't seen this stream before,
+     * there's only one key for this srtp_session, and the cipher
+     * supports key-sharing, then we assume that a new stream using
+     * that key has just started up
+     */
+    stream = srtp_get_stream(ctx, hdr->ssrc);
+    if (stream == NULL) {
+        if (ctx->stream_template != NULL) {
+            stream = ctx->stream_template;
+
+            /*
+             * check to see if stream_template has an EKT data structure, in
+             * which case we initialize the template using the EKT policy
+             * referenced by that data (which consists of decrypting the
+             * master key from the EKT field)
+             *
+             * this function initializes a *provisional* stream, and this
+             * stream should not be accepted until and unless the packet
+             * passes its authentication check
+             */
+            if (stream->ekt != NULL) {
+                status = srtp_stream_init_from_ekt(stream, srtcp_hdr,
+                                                   *pkt_octet_len);
+                if (status)
+                    return status;
+            }
+
+            debug_print(mod_srtp,
+                        "srtcp using provisional stream (SSRC: 0x%08x)",
+                        ntohl(hdr->ssrc));
+        } else {
+            /* no template stream, so we return an error */
+            return srtp_err_status_no_ctx;
+        }
+    }
+
+    /*
+     * Determine if MKI is being used and what session keys should be used
+     */
+    if (use_mki) {
+        session_keys = srtp_get_session_keys(
+            stream, (uint8_t *)hdr, (const unsigned int *)pkt_octet_len,
+            &mki_size);
+
+        if (session_keys == NULL)
+            return srtp_err_status_bad_mki;
+    } else {
+        session_keys = &stream->session_keys[0];
+    }
+
+    /* get tag length from stream context */
+    tag_len = srtp_auth_get_tag_length(session_keys->rtcp_auth);
+
+    /* check the packet length - it must contain at least a full RTCP
+       header, an auth tag (if applicable), and the SRTCP encrypted flag
+       and 31-bit index value */
+    if (*pkt_octet_len < (int)(octets_in_rtcp_header + tag_len + mki_size +
+                               sizeof(srtcp_trailer_t))) {
+        return srtp_err_status_bad_param;
+    }
+
+    /*
+     * Check if this is an AEAD stream (GCM mode).  If so, then dispatch
+     * the request to our AEAD handler.
+     */
+    if (session_keys->rtp_cipher->algorithm == SRTP_AES_GCM_128 ||
+        session_keys->rtp_cipher->algorithm == SRTP_AES_GCM_256) {
+        return srtp_unprotect_rtcp_aead(ctx, stream, srtcp_hdr,
+                                        (unsigned int *)pkt_octet_len,
+                                        session_keys, mki_size);
+    }
+
+    sec_serv_confidentiality = stream->rtcp_services == sec_serv_conf ||
+                               stream->rtcp_services == sec_serv_conf_and_auth;
+
+    /*
+     * set encryption start, encryption length, and trailer
+     */
+    enc_octet_len = *pkt_octet_len - (octets_in_rtcp_header + tag_len +
+                                      mki_size + sizeof(srtcp_trailer_t));
+    /*
+     *index & E (encryption) bit follow normal data. hdr->len is the number of
+     * words (32-bit) in the normal packet minus 1
+     */
+    /* This should point trailer to the word past the end of the normal data. */
+    /* This would need to be modified for optional mikey data */
+    /*
+     * NOTE: trailer is 32-bit aligned because RTCP 'packets' are always
+     *   multiples of 32-bits (RFC 3550 6.1)
+     */
+    trailer = (uint32_t *)((char *)hdr + *pkt_octet_len -
+                           (tag_len + mki_size + sizeof(srtcp_trailer_t)));
+    e_bit_in_packet =
+        (*((unsigned char *)trailer) & SRTCP_E_BYTE_BIT) == SRTCP_E_BYTE_BIT;
+    if (e_bit_in_packet != sec_serv_confidentiality) {
+        return srtp_err_status_cant_check;
+    }
+    if (sec_serv_confidentiality) {
+        enc_start = (uint32_t *)hdr + uint32s_in_rtcp_header;
+    } else {
+        enc_octet_len = 0;
+        enc_start = NULL; /* this indicates that there's no encryption */
+    }
+
+    /*
+     * set the auth_start and auth_tag pointers to the proper locations
+     * (note that srtcp *always* uses authentication, unlike srtp)
+     */
+    auth_start = (uint32_t *)hdr;
+
+    /*
+     * The location of the auth tag in the packet needs to know MKI
+     * could be present.  The data needed to calculate the Auth tag
+     * must not include the MKI
+     */
+    auth_len = *pkt_octet_len - tag_len - mki_size;
+    auth_tag = (uint8_t *)hdr + auth_len + mki_size;
+
+    /*
+     * if EKT is in use, then we make a copy of the tag from the packet,
+     * and then zeroize the location of the base tag
+     *
+     * we first re-position the auth_tag pointer so that it points to
+     * the base tag
+     */
+    if (stream->ekt) {
+        auth_tag -= srtp_ekt_octets_after_base_tag(stream->ekt);
+        memcpy(tag_copy, auth_tag, tag_len);
+        octet_string_set_to_zero(auth_tag, tag_len);
+        auth_tag = tag_copy;
+        auth_len += tag_len;
+    }
+
+    /*
+     * check the sequence number for replays
+     */
+    /* this is easier than dealing with bitfield access */
+    seq_num = ntohl(*trailer) & SRTCP_INDEX_MASK;
+    debug_print(mod_srtp, "srtcp index: %x", seq_num);
+    status = srtp_rdb_check(&stream->rtcp_rdb, seq_num);
+    if (status)
+        return status;
+
+    /*
+     * if we're using aes counter mode, set nonce and seq
+     */
+    if (session_keys->rtcp_cipher->type->id == SRTP_AES_ICM_128 ||
+        session_keys->rtcp_cipher->type->id == SRTP_AES_ICM_192 ||
+        session_keys->rtcp_cipher->type->id == SRTP_AES_ICM_256) {
+        v128_t iv;
+
+        iv.v32[0] = 0;
+        iv.v32[1] = hdr->ssrc; /* still in network order! */
+        iv.v32[2] = htonl(seq_num >> 16);
+        iv.v32[3] = htonl(seq_num << 16);
+        status = srtp_cipher_set_iv(session_keys->rtcp_cipher, (uint8_t *)&iv,
+                                    srtp_direction_decrypt);
+
+    } else {
+        v128_t iv;
+
+        /* otherwise, just set the index to seq_num */
+        iv.v32[0] = 0;
+        iv.v32[1] = 0;
+        iv.v32[2] = 0;
+        iv.v32[3] = htonl(seq_num);
+        status = srtp_cipher_set_iv(session_keys->rtcp_cipher, (uint8_t *)&iv,
+                                    srtp_direction_decrypt);
+    }
+    if (status)
+        return srtp_err_status_cipher_fail;
+
+    /* initialize auth func context */
+    srtp_auth_start(session_keys->rtcp_auth);
+
+    /* run auth func over packet, put result into tmp_tag */
+    status = srtp_auth_compute(session_keys->rtcp_auth, (uint8_t *)auth_start,
+                               auth_len, tmp_tag);
+    debug_print(mod_srtp, "srtcp computed tag:       %s",
+                srtp_octet_string_hex_string(tmp_tag, tag_len));
+    if (status)
+        return srtp_err_status_auth_fail;
+
+    /* compare the tag just computed with the one in the packet */
+    debug_print(mod_srtp, "srtcp tag from packet:    %s",
+                srtp_octet_string_hex_string(auth_tag, tag_len));
+    if (octet_string_is_eq(tmp_tag, auth_tag, tag_len))
+        return srtp_err_status_auth_fail;
+
+    /*
+     * if we're authenticating using a universal hash, put the keystream
+     * prefix into the authentication tag
+     */
+    prefix_len = srtp_auth_get_prefix_length(session_keys->rtcp_auth);
+    if (prefix_len) {
+        status = srtp_cipher_output(session_keys->rtcp_cipher, auth_tag,
+                                    &prefix_len);
+        debug_print(mod_srtp, "keystream prefix: %s",
+                    srtp_octet_string_hex_string(auth_tag, prefix_len));
+        if (status)
+            return srtp_err_status_cipher_fail;
+    }
+
+    /* if we're decrypting, exor keystream into the message */
+    if (enc_start) {
+        status = srtp_cipher_decrypt(session_keys->rtcp_cipher,
+                                     (uint8_t *)enc_start, &enc_octet_len);
+        if (status)
+            return srtp_err_status_cipher_fail;
+    }
+
+    /* decrease the packet length by the length of the auth tag and seq_num */
+    *pkt_octet_len -= (tag_len + sizeof(srtcp_trailer_t));
+
+    /* decrease the packet length by the length of the mki_size */
+    *pkt_octet_len -= mki_size;
+
+    /*
+     * if EKT is in effect, subtract the EKT data out of the packet
+     * length
+     */
+    *pkt_octet_len -= srtp_ekt_octets_after_base_tag(stream->ekt);
+
+    /*
+     * verify that stream is for received traffic - this check will
+     * detect SSRC collisions, since a stream that appears in both
+     * srtp_protect() and srtp_unprotect() will fail this test in one of
+     * those functions.
+     *
+     * we do this check *after* the authentication check, so that the
+     * latter check will catch any attempts to fool us into thinking
+     * that we've got a collision
+     */
+    if (stream->direction != dir_srtp_receiver) {
+        if (stream->direction == dir_unknown) {
+            stream->direction = dir_srtp_receiver;
+        } else {
+            srtp_handle_event(ctx, stream, event_ssrc_collision);
+        }
+    }
+
+    /*
+     * if the stream is a 'provisional' one, in which the template context
+     * is used, then we need to allocate a new stream at this point, since
+     * the authentication passed
+     */
+    if (stream == ctx->stream_template) {
+        srtp_stream_ctx_t *new_stream;
+
+        /*
+         * allocate and initialize a new stream
+         *
+         * note that we indicate failure if we can't allocate the new
+         * stream, and some implementations will want to not return
+         * failure here
+         */
+        status =
+            srtp_stream_clone(ctx->stream_template, hdr->ssrc, &new_stream);
+        if (status)
+            return status;
+
+        /* add new stream to the head of the stream_list */
+        new_stream->next = ctx->stream_list;
+        ctx->stream_list = new_stream;
+
+        /* set stream (the pointer used in this function) */
+        stream = new_stream;
+    }
+
+    /* we've passed the authentication check, so add seq_num to the rdb */
+    srtp_rdb_add_index(&stream->rtcp_rdb, seq_num);
+
+    return srtp_err_status_ok;
+}
 
 /*
  * user data within srtp_t context
  */
 
-void
-srtp_set_user_data(srtp_t ctx, void *data) {
-  ctx->user_data = data;
+void srtp_set_user_data(srtp_t ctx, void *data)
+{
+    ctx->user_data = data;
 }
 
-void*
-srtp_get_user_data(srtp_t ctx) {
-  return ctx->user_data;
+void *srtp_get_user_data(srtp_t ctx)
+{
+    return ctx->user_data;
 }
-
 
 /*
- * dtls keying for srtp 
+ * dtls keying for srtp
  */
 
 srtp_err_status_t
-srtp_crypto_policy_set_from_profile_for_rtp(srtp_crypto_policy_t *policy, 
-				            srtp_profile_t profile) {
-
-  /* set SRTP policy from the SRTP profile in the key set */
-  switch(profile) {
-  case srtp_profile_aes128_cm_sha1_80:
-    srtp_crypto_policy_set_aes_cm_128_hmac_sha1_80(policy);
-    break;
-  case srtp_profile_aes128_cm_sha1_32:
-    srtp_crypto_policy_set_aes_cm_128_hmac_sha1_32(policy);
-    break;
-  case srtp_profile_null_sha1_80:
-    srtp_crypto_policy_set_null_cipher_hmac_sha1_80(policy);
-    break;
-#if defined(OPENSSL)
-  case srtp_profile_aead_aes_128_gcm:
-    srtp_crypto_policy_set_aes_gcm_128_16_auth(policy);
-    break;
-  case srtp_profile_aead_aes_256_gcm:
-    srtp_crypto_policy_set_aes_gcm_256_16_auth(policy);
-    break;
-#endif
-    /* the following profiles are not (yet) supported */
-  case srtp_profile_null_sha1_32:
-  default:
-    return srtp_err_status_bad_param;
-  }
-
-  return srtp_err_status_ok;
-}
-
-srtp_err_status_t
-srtp_crypto_policy_set_from_profile_for_rtcp(srtp_crypto_policy_t *policy, 
-					     srtp_profile_t profile) {
-
-  /* set SRTP policy from the SRTP profile in the key set */
-  switch(profile) {
-  case srtp_profile_aes128_cm_sha1_80:
-    srtp_crypto_policy_set_aes_cm_128_hmac_sha1_80(policy);
-    break;
-  case srtp_profile_aes128_cm_sha1_32:
-    /* We do not honor the 32-bit auth tag request since
-     * this is not compliant with RFC 3711 */
-    srtp_crypto_policy_set_aes_cm_128_hmac_sha1_80(policy);
-    break;
-  case srtp_profile_null_sha1_80:
-    srtp_crypto_policy_set_null_cipher_hmac_sha1_80(policy);
-    break;
-#if defined(OPENSSL)
-  case srtp_profile_aead_aes_128_gcm:
-    srtp_crypto_policy_set_aes_gcm_128_16_auth(policy);
-    break;
-  case srtp_profile_aead_aes_256_gcm:
-    srtp_crypto_policy_set_aes_gcm_256_16_auth(policy);
-    break;
-#endif
-    /* the following profiles are not (yet) supported */
-  case srtp_profile_null_sha1_32:
-  default:
-    return srtp_err_status_bad_param;
-  }
-
-  return srtp_err_status_ok;
-}
-
-void srtp_append_salt_to_key(uint8_t *key, unsigned int bytes_in_key, uint8_t *salt, unsigned int bytes_in_salt) {
-  memcpy(key + bytes_in_key, salt, bytes_in_salt);
-}
-
-unsigned int
-srtp_profile_get_master_key_length(srtp_profile_t profile) {
-
-  switch(profile) {
-  case srtp_profile_aes128_cm_sha1_80:
-    return SRTP_AES_128_KEY_LEN;
-    break;
-  case srtp_profile_aes128_cm_sha1_32:
-    return SRTP_AES_128_KEY_LEN;
-    break;
-  case srtp_profile_null_sha1_80:
-    return SRTP_AES_128_KEY_LEN;
-    break;
-  case srtp_profile_aead_aes_128_gcm:
-    return SRTP_AES_128_KEY_LEN;
-    break;
-  case srtp_profile_aead_aes_256_gcm:
-    return SRTP_AES_256_KEY_LEN;
-    break;
-    /* the following profiles are not (yet) supported */
-  case srtp_profile_null_sha1_32:
-  default:
-    return 0;  /* indicate error by returning a zero */
-  }
-}
-
-unsigned int
-srtp_profile_get_master_salt_length(srtp_profile_t profile) {
-
-  switch(profile) {
-  case srtp_profile_aes128_cm_sha1_80:
-    return SRTP_SALT_LEN;
-    break;
-  case srtp_profile_aes128_cm_sha1_32:
-    return SRTP_SALT_LEN;
-    break;
-  case srtp_profile_null_sha1_80:
-    return SRTP_SALT_LEN;
-    break;
-  case srtp_profile_aead_aes_128_gcm:
-    return SRTP_AEAD_SALT_LEN;
-    break;
-  case srtp_profile_aead_aes_256_gcm:
-    return SRTP_AEAD_SALT_LEN;
-    break;
-    /* the following profiles are not (yet) supported */
-  case srtp_profile_null_sha1_32:
-  default:
-    return 0;  /* indicate error by returning a zero */
-  }
-}
-
-srtp_err_status_t
-srtp_get_protect_trailer_length(srtp_t session,
-                                uint32_t use_mki,
-                                uint32_t mki_index,
-                                uint32_t *length) 
+srtp_crypto_policy_set_from_profile_for_rtp(srtp_crypto_policy_t *policy,
+                                            srtp_profile_t profile)
 {
-    srtp_stream_ctx_t *stream;
-
-    if (session == NULL)
-      return srtp_err_status_bad_param;
-
-    *length = 0;
-
-    /* Try obtaining stream from stream_list */
-    stream = session->stream_list;
-
-    if (stream == NULL) {
-        /* Try obtaining the template stream */
-        stream = session->stream_template;
-    }
-
-    if (stream == NULL) {
+    /* set SRTP policy from the SRTP profile in the key set */
+    switch (profile) {
+    case srtp_profile_aes128_cm_sha1_80:
+        srtp_crypto_policy_set_aes_cm_128_hmac_sha1_80(policy);
+        break;
+    case srtp_profile_aes128_cm_sha1_32:
+        srtp_crypto_policy_set_aes_cm_128_hmac_sha1_32(policy);
+        break;
+    case srtp_profile_null_sha1_80:
+        srtp_crypto_policy_set_null_cipher_hmac_sha1_80(policy);
+        break;
+#if defined(OPENSSL)
+    case srtp_profile_aead_aes_128_gcm:
+        srtp_crypto_policy_set_aes_gcm_128_16_auth(policy);
+        break;
+    case srtp_profile_aead_aes_256_gcm:
+        srtp_crypto_policy_set_aes_gcm_256_16_auth(policy);
+        break;
+#endif
+    /* the following profiles are not (yet) supported */
+    case srtp_profile_null_sha1_32:
+    default:
         return srtp_err_status_bad_param;
-    }
-
-    if (use_mki) {
-       if (mki_index > stream->num_master_keys)
-           return srtp_err_status_bad_mki;
-
-       *length += stream->session_keys[mki_index].mki_size;
-       *length += srtp_auth_get_tag_length(stream->session_keys[mki_index].rtp_auth);
-    } else {
-       *length += srtp_auth_get_tag_length(stream->session_keys[0].rtp_auth);
     }
 
     return srtp_err_status_ok;
 }
 
 srtp_err_status_t
-srtp_get_protect_rtcp_trailer_length(srtp_t session,
-                                     uint32_t use_mki,
-                                     uint32_t mki_index,
-                                     uint32_t *length) 
+srtp_crypto_policy_set_from_profile_for_rtcp(srtp_crypto_policy_t *policy,
+                                             srtp_profile_t profile)
+{
+    /* set SRTP policy from the SRTP profile in the key set */
+    switch (profile) {
+    case srtp_profile_aes128_cm_sha1_80:
+        srtp_crypto_policy_set_aes_cm_128_hmac_sha1_80(policy);
+        break;
+    case srtp_profile_aes128_cm_sha1_32:
+        /* We do not honor the 32-bit auth tag request since
+         * this is not compliant with RFC 3711 */
+        srtp_crypto_policy_set_aes_cm_128_hmac_sha1_80(policy);
+        break;
+    case srtp_profile_null_sha1_80:
+        srtp_crypto_policy_set_null_cipher_hmac_sha1_80(policy);
+        break;
+#if defined(OPENSSL)
+    case srtp_profile_aead_aes_128_gcm:
+        srtp_crypto_policy_set_aes_gcm_128_16_auth(policy);
+        break;
+    case srtp_profile_aead_aes_256_gcm:
+        srtp_crypto_policy_set_aes_gcm_256_16_auth(policy);
+        break;
+#endif
+    /* the following profiles are not (yet) supported */
+    case srtp_profile_null_sha1_32:
+    default:
+        return srtp_err_status_bad_param;
+    }
+
+    return srtp_err_status_ok;
+}
+
+void srtp_append_salt_to_key(uint8_t *key,
+                             unsigned int bytes_in_key,
+                             uint8_t *salt,
+                             unsigned int bytes_in_salt)
+{
+    memcpy(key + bytes_in_key, salt, bytes_in_salt);
+}
+
+unsigned int srtp_profile_get_master_key_length(srtp_profile_t profile)
+{
+    switch (profile) {
+    case srtp_profile_aes128_cm_sha1_80:
+        return SRTP_AES_128_KEY_LEN;
+        break;
+    case srtp_profile_aes128_cm_sha1_32:
+        return SRTP_AES_128_KEY_LEN;
+        break;
+    case srtp_profile_null_sha1_80:
+        return SRTP_AES_128_KEY_LEN;
+        break;
+    case srtp_profile_aead_aes_128_gcm:
+        return SRTP_AES_128_KEY_LEN;
+        break;
+    case srtp_profile_aead_aes_256_gcm:
+        return SRTP_AES_256_KEY_LEN;
+        break;
+    /* the following profiles are not (yet) supported */
+    case srtp_profile_null_sha1_32:
+    default:
+        return 0; /* indicate error by returning a zero */
+    }
+}
+
+unsigned int srtp_profile_get_master_salt_length(srtp_profile_t profile)
+{
+    switch (profile) {
+    case srtp_profile_aes128_cm_sha1_80:
+        return SRTP_SALT_LEN;
+        break;
+    case srtp_profile_aes128_cm_sha1_32:
+        return SRTP_SALT_LEN;
+        break;
+    case srtp_profile_null_sha1_80:
+        return SRTP_SALT_LEN;
+        break;
+    case srtp_profile_aead_aes_128_gcm:
+        return SRTP_AEAD_SALT_LEN;
+        break;
+    case srtp_profile_aead_aes_256_gcm:
+        return SRTP_AEAD_SALT_LEN;
+        break;
+    /* the following profiles are not (yet) supported */
+    case srtp_profile_null_sha1_32:
+    default:
+        return 0; /* indicate error by returning a zero */
+    }
+}
+
+srtp_err_status_t srtp_get_protect_trailer_length(srtp_t session,
+                                                  uint32_t use_mki,
+                                                  uint32_t mki_index,
+                                                  uint32_t *length)
 {
     srtp_stream_ctx_t *stream;
 
     if (session == NULL)
-      return srtp_err_status_bad_param;
+        return srtp_err_status_bad_param;
 
     *length = 0;
 
@@ -4556,20 +4603,58 @@ srtp_get_protect_rtcp_trailer_length(srtp_t session,
     }
 
     if (use_mki) {
-       if (mki_index > stream->num_master_keys)
-           return srtp_err_status_bad_mki;
+        if (mki_index > stream->num_master_keys)
+            return srtp_err_status_bad_mki;
 
-       *length += stream->session_keys[mki_index].mki_size;
-       *length += srtp_auth_get_tag_length(stream->session_keys[mki_index].rtcp_auth);
+        *length += stream->session_keys[mki_index].mki_size;
+        *length +=
+            srtp_auth_get_tag_length(stream->session_keys[mki_index].rtp_auth);
     } else {
-       *length += srtp_auth_get_tag_length(stream->session_keys[0].rtcp_auth);
+        *length += srtp_auth_get_tag_length(stream->session_keys[0].rtp_auth);
     }
- 
+
+    return srtp_err_status_ok;
+}
+
+srtp_err_status_t srtp_get_protect_rtcp_trailer_length(srtp_t session,
+                                                       uint32_t use_mki,
+                                                       uint32_t mki_index,
+                                                       uint32_t *length)
+{
+    srtp_stream_ctx_t *stream;
+
+    if (session == NULL)
+        return srtp_err_status_bad_param;
+
+    *length = 0;
+
+    /* Try obtaining stream from stream_list */
+    stream = session->stream_list;
+
+    if (stream == NULL) {
+        /* Try obtaining the template stream */
+        stream = session->stream_template;
+    }
+
+    if (stream == NULL) {
+        return srtp_err_status_bad_param;
+    }
+
+    if (use_mki) {
+        if (mki_index > stream->num_master_keys)
+            return srtp_err_status_bad_mki;
+
+        *length += stream->session_keys[mki_index].mki_size;
+        *length +=
+            srtp_auth_get_tag_length(stream->session_keys[mki_index].rtcp_auth);
+    } else {
+        *length += srtp_auth_get_tag_length(stream->session_keys[0].rtcp_auth);
+    }
+
     *length += sizeof(srtcp_trailer_t);
 
     return srtp_err_status_ok;
 }
-
 
 /*
  * SRTP debug interface
@@ -4591,26 +4676,34 @@ srtp_err_status_t srtp_list_debug_modules(void)
  */
 
 static srtp_log_handler_func_t *srtp_log_handler = NULL;
-static void * srtp_log_handler_data = NULL;
+static void *srtp_log_handler_data = NULL;
 
-void srtp_err_handler(srtp_err_reporting_level_t level, const char * msg)
+void srtp_err_handler(srtp_err_reporting_level_t level, const char *msg)
 {
     if (srtp_log_handler) {
         srtp_log_level_t log_level = srtp_log_level_error;
-        switch(level) {
-            case srtp_err_level_error: log_level = srtp_log_level_error; break;
-            case srtp_err_level_warning: log_level = srtp_log_level_warning; break;
-            case srtp_err_level_info: log_level = srtp_log_level_info; break;
-            case srtp_err_level_debug: log_level = srtp_log_level_debug; break;
+        switch (level) {
+        case srtp_err_level_error:
+            log_level = srtp_log_level_error;
+            break;
+        case srtp_err_level_warning:
+            log_level = srtp_log_level_warning;
+            break;
+        case srtp_err_level_info:
+            log_level = srtp_log_level_info;
+            break;
+        case srtp_err_level_debug:
+            log_level = srtp_log_level_debug;
+            break;
         }
 
         srtp_log_handler(log_level, msg, srtp_log_handler_data);
     }
 }
 
-srtp_err_status_t srtp_install_log_handler(srtp_log_handler_func_t func, void * data)
+srtp_err_status_t srtp_install_log_handler(srtp_log_handler_func_t func,
+                                           void *data)
 {
-
     /*
      * note that we accept NULL arguments intentionally - calling this
      * function with a NULL arguments removes a log handler that's
@@ -4629,7 +4722,8 @@ srtp_err_status_t srtp_install_log_handler(srtp_log_handler_func_t func, void * 
 }
 
 srtp_err_status_t
-srtp_set_stream_roc(srtp_t session, uint32_t ssrc, uint32_t roc) {
+srtp_set_stream_roc(srtp_t session, uint32_t ssrc, uint32_t roc)
+{
     srtp_stream_t stream;
 
     stream = srtp_get_stream(session, htonl(ssrc));
@@ -4642,7 +4736,8 @@ srtp_set_stream_roc(srtp_t session, uint32_t ssrc, uint32_t roc) {
 }
 
 srtp_err_status_t
-srtp_get_stream_roc(srtp_t session, uint32_t ssrc, uint32_t *roc) {
+srtp_get_stream_roc(srtp_t session, uint32_t ssrc, uint32_t *roc)
+{
     srtp_stream_t stream;
 
     stream = srtp_get_stream(session, htonl(ssrc));


### PR DESCRIPTION
Here is a suggestion of a clang-format file (and the results of applying this formatting to two functions) in order to resolve #254 .

If someone prefers wider column limits or different style of braces let me know and I will attempt to tune the format file! I am happy as long as we standardize on something. :-)

If this looks OK I will apply it to the project files and go through and manually fix up for example comments that have been split across multiple lines and other nitpicks and make a new PR.