### PR TITLE
clang-format remain files

### DIFF
--- a/crypto/cipher/null_cipher.c
+++ b/crypto/cipher/null_cipher.c
@@ -125,17 +125,17 @@ static srtp_err_status_t srtp_null_cipher_encrypt(void *cv,
 static const char srtp_null_cipher_description[] = "null cipher";
 
 static const srtp_cipher_test_case_t srtp_null_cipher_test_0 = {
-    0,         /* octets in key            */
-    NULL,      /* key                      */
-    0,         /* packet index             */
-    0,         /* octets in plaintext      */
-    NULL,      /* plaintext                */
-    0,         /* octets in plaintext      */
-    NULL,      /* ciphertext               */
-    0,         /* */
-    NULL,      /* */
-    0,         /* */
-    NULL       /* pointer to next testcase */
+    0,    /* octets in key            */
+    NULL, /* key                      */
+    0,    /* packet index             */
+    0,    /* octets in plaintext      */
+    NULL, /* plaintext                */
+    0,    /* octets in plaintext      */
+    NULL, /* ciphertext               */
+    0,    /* */
+    NULL, /* */
+    0,    /* */
+    NULL  /* pointer to next testcase */
 };
 
 /*

--- a/format.sh
+++ b/format.sh
@@ -5,7 +5,7 @@
 # run clang-format on each .c & .h file
 
 if [ -z "${CLANG_FORMAT}" ]; then
-    CLANG_FORMAT=clang-format-3.9
+    CLANG_FORMAT=clang-format
 fi
 
 a=`git ls-files | grep "\.h$\|\.c$"`

--- a/format.sh
+++ b/format.sh
@@ -1,0 +1,16 @@
+#!/bin/sh
+#
+# format.sh
+#
+# run clang-format on each .c & .h file
+
+if [ -z "${CLANG_FORMAT}" ]; then
+    CLANG_FORMAT=clang-format-3.9
+fi
+
+a=`git ls-files | grep "\.h$\|\.c$"`
+for x in $a; do
+     if [ $x != "config_in.h" ]; then
+         $CLANG_FORMAT -i -style=file $x
+     fi
+done

--- a/srtp/ekt.c
+++ b/srtp/ekt.c
@@ -2,31 +2,31 @@
  * ekt.c
  *
  * Encrypted Key Transport for SRTP
- * 
+ *
  * David McGrew
  * Cisco Systems, Inc.
  */
 /*
- *	
+ *
  * Copyright (c) 2001-2017 Cisco Systems, Inc.
  * All rights reserved.
- * 
+ *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
  * are met:
- * 
+ *
  *   Redistributions of source code must retain the above copyright
  *   notice, this list of conditions and the following disclaimer.
- * 
+ *
  *   Redistributions in binary form must reproduce the above
  *   copyright notice, this list of conditions and the following
  *   disclaimer in the documentation and/or other materials provided
  *   with the distribution.
- * 
+ *
  *   Neither the name of the Cisco Systems, Inc. nor the names of its
  *   contributors may be used to endorse or promote products derived
  *   from this software without specific prior written permission.
- * 
+ *
  * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
  * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
  * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
@@ -41,7 +41,6 @@
  * OF THE POSSIBILITY OF SUCH DAMAGE.
  *
  */
-
 
 #include "srtp_priv.h"
 #include "err.h"
@@ -64,195 +63,219 @@ extern srtp_debug_module_t mod_srtp;
  *   |    Initial Sequence Number    |   Security Parameter Index    |
  *   +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
  *
- */			 
+ */
 
 #define EKT_OCTETS_AFTER_BASE_TAG 24
-#define EKT_OCTETS_AFTER_EMK       8
-#define EKT_OCTETS_AFTER_ROC       4
-#define EKT_SPI_LEN                2
+#define EKT_OCTETS_AFTER_EMK 8
+#define EKT_OCTETS_AFTER_ROC 4
+#define EKT_SPI_LEN 2
 
-unsigned srtp_ekt_octets_after_base_tag(srtp_ekt_stream_t ekt) {
-  /*
-   * if the pointer ekt is NULL, then EKT is not in effect, so we
-   * indicate this by returning zero
-   */
-  if (!ekt)
+unsigned srtp_ekt_octets_after_base_tag(srtp_ekt_stream_t ekt)
+{
+    /*
+     * if the pointer ekt is NULL, then EKT is not in effect, so we
+     * indicate this by returning zero
+     */
+    if (!ekt)
+        return 0;
+
+    switch (ekt->data->ekt_cipher_type) {
+    case SRTP_EKT_CIPHER_AES_128_ECB:
+        return 16 + EKT_OCTETS_AFTER_EMK;
+        break;
+    default:
+        break;
+    }
     return 0;
-
-  switch(ekt->data->ekt_cipher_type) {
-  case SRTP_EKT_CIPHER_AES_128_ECB:
-    return 16 + EKT_OCTETS_AFTER_EMK;
-    break;
-  default:
-    break;
-  }
-  return 0;
 }
 
-static inline srtp_ekt_spi_t srtcp_packet_get_ekt_spi(const uint8_t *packet_start, unsigned pkt_octet_len) {
-  const uint8_t *spi_location;
-  
-  spi_location = packet_start + (pkt_octet_len - EKT_SPI_LEN);
-  
-  return *((const srtp_ekt_spi_t *)spi_location);
+static inline srtp_ekt_spi_t srtcp_packet_get_ekt_spi(
+    const uint8_t *packet_start,
+    unsigned pkt_octet_len)
+{
+    const uint8_t *spi_location;
+
+    spi_location = packet_start + (pkt_octet_len - EKT_SPI_LEN);
+
+    return *((const srtp_ekt_spi_t *)spi_location);
 }
 
-static inline uint32_t srtcp_packet_get_ekt_roc(const uint8_t *packet_start, unsigned pkt_octet_len) {
-  const uint8_t *roc_location;
-  
-  roc_location = packet_start + (pkt_octet_len - EKT_OCTETS_AFTER_ROC);
-  
-  return *((const uint32_t *)roc_location);
+static inline uint32_t srtcp_packet_get_ekt_roc(const uint8_t *packet_start,
+                                                unsigned pkt_octet_len)
+{
+    const uint8_t *roc_location;
+
+    roc_location = packet_start + (pkt_octet_len - EKT_OCTETS_AFTER_ROC);
+
+    return *((const uint32_t *)roc_location);
 }
 
-static inline const uint8_t * srtcp_packet_get_emk_location(const uint8_t *packet_start, unsigned pkt_octet_len) {
-  const uint8_t *location;
-  
-  location = packet_start + (pkt_octet_len - EKT_OCTETS_AFTER_BASE_TAG);
+static inline const uint8_t *srtcp_packet_get_emk_location(
+    const uint8_t *packet_start,
+    unsigned pkt_octet_len)
+{
+    const uint8_t *location;
 
-  return location;
+    location = packet_start + (pkt_octet_len - EKT_OCTETS_AFTER_BASE_TAG);
+
+    return location;
 }
 
+srtp_err_status_t srtp_ekt_alloc(srtp_ekt_stream_t *stream_data,
+                                 srtp_ekt_policy_t policy)
+{
+    /*
+     * if the policy pointer is NULL, then EKT is not in use
+     * so we just set the EKT stream data pointer to NULL
+     */
+    if (!policy) {
+        *stream_data = NULL;
+        return srtp_err_status_ok;
+    }
 
-srtp_err_status_t srtp_ekt_alloc(srtp_ekt_stream_t *stream_data, srtp_ekt_policy_t policy) {
-
-  /*
-   * if the policy pointer is NULL, then EKT is not in use
-   * so we just set the EKT stream data pointer to NULL
-   */
-  if (!policy) {
+    /* TODO */
     *stream_data = NULL;
+
     return srtp_err_status_ok;
-  }
-
-  /* TODO */
-  *stream_data = NULL;
-
-  return srtp_err_status_ok;
 }
 
-srtp_err_status_t srtp_ekt_stream_init_from_policy(srtp_ekt_stream_t stream_data, srtp_ekt_policy_t policy) {
-  if (!stream_data)
-    return srtp_err_status_ok;
+srtp_err_status_t srtp_ekt_stream_init_from_policy(
+    srtp_ekt_stream_t stream_data,
+    srtp_ekt_policy_t policy)
+{
+    if (!stream_data)
+        return srtp_err_status_ok;
 
-  return srtp_err_status_ok;
+    return srtp_err_status_ok;
 }
 
-
-void aes_decrypt_with_raw_key(void *ciphertext, const void *key, int key_len) {
+void aes_decrypt_with_raw_key(void *ciphertext, const void *key, int key_len)
+{
 #ifndef OPENSSL
-//FIXME: need to get this working through the crypto module interface
-  srtp_aes_expanded_key_t expanded_key;
+    // FIXME: need to get this working through the crypto module interface
+    srtp_aes_expanded_key_t expanded_key;
 
-  srtp_aes_expand_decryption_key(key, key_len, &expanded_key);
-  srtp_aes_decrypt(ciphertext, &expanded_key);
+    srtp_aes_expand_decryption_key(key, key_len, &expanded_key);
+    srtp_aes_decrypt(ciphertext, &expanded_key);
 #endif
 }
 
 /*
  * The function srtp_stream_init_from_ekt() initializes a stream using
- * the EKT data from an SRTCP trailer.  
+ * the EKT data from an SRTCP trailer.
  */
 
-srtp_err_status_t srtp_stream_init_from_ekt(srtp_stream_t stream, const void *srtcp_hdr, unsigned pkt_octet_len) {
-  srtp_err_status_t err;
-  const uint8_t *master_key;
-  srtp_policy_t srtp_policy;
-  uint32_t roc;
+srtp_err_status_t srtp_stream_init_from_ekt(srtp_stream_t stream,
+                                            const void *srtcp_hdr,
+                                            unsigned pkt_octet_len)
+{
+    srtp_err_status_t err;
+    const uint8_t *master_key;
+    srtp_policy_t srtp_policy;
+    uint32_t roc;
 
-  /*
-   * NOTE: at present, we only support a single ekt_policy at a time.  
-   */
-  if (stream->ekt->data->spi != 
-      srtcp_packet_get_ekt_spi(srtcp_hdr, pkt_octet_len))
-    return srtp_err_status_no_ctx;
+    /*
+     * NOTE: at present, we only support a single ekt_policy at a time.
+     */
+    if (stream->ekt->data->spi !=
+        srtcp_packet_get_ekt_spi(srtcp_hdr, pkt_octet_len))
+        return srtp_err_status_no_ctx;
 
-  if (stream->ekt->data->ekt_cipher_type != SRTP_EKT_CIPHER_AES_128_ECB)
-    return srtp_err_status_bad_param;
+    if (stream->ekt->data->ekt_cipher_type != SRTP_EKT_CIPHER_AES_128_ECB)
+        return srtp_err_status_bad_param;
 
-  /* decrypt the Encrypted Master Key field */
-  master_key = srtcp_packet_get_emk_location(srtcp_hdr, pkt_octet_len);
-  /* FIX!? This decrypts the master key in-place, and never uses it */
-  /* FIX!? It's also passing to ekt_dec_key (which is an aes_expanded_key_t)
-   * to a function which expects a raw (unexpanded) key */
-  aes_decrypt_with_raw_key((void*)master_key, &stream->ekt->data->ekt_dec_key, 16);
+    /* decrypt the Encrypted Master Key field */
+    master_key = srtcp_packet_get_emk_location(srtcp_hdr, pkt_octet_len);
+    /* FIX!? This decrypts the master key in-place, and never uses it */
+    /* FIX!? It's also passing to ekt_dec_key (which is an aes_expanded_key_t)
+     * to a function which expects a raw (unexpanded) key */
+    aes_decrypt_with_raw_key((void *)master_key,
+                             &stream->ekt->data->ekt_dec_key, 16);
 
-  /* set the SRTP ROC */
-  roc = srtcp_packet_get_ekt_roc(srtcp_hdr, pkt_octet_len);
-  err = srtp_rdbx_set_roc(&stream->rtp_rdbx, roc);
-  if (err) return err;
+    /* set the SRTP ROC */
+    roc = srtcp_packet_get_ekt_roc(srtcp_hdr, pkt_octet_len);
+    err = srtp_rdbx_set_roc(&stream->rtp_rdbx, roc);
+    if (err)
+        return err;
 
-  err = srtp_stream_init(stream, &srtp_policy);
-  if (err) return err;
+    err = srtp_stream_init(stream, &srtp_policy);
+    if (err)
+        return err;
 
-  return srtp_err_status_ok;
+    return srtp_err_status_ok;
 }
 
-void srtp_ekt_write_data(srtp_ekt_stream_t ekt, uint8_t *base_tag, unsigned base_tag_len, int *packet_len, srtp_xtd_seq_num_t pkt_index) {
-  uint32_t roc;
-  uint16_t isn;
-  unsigned emk_len;
-  uint8_t *packet;
+void srtp_ekt_write_data(srtp_ekt_stream_t ekt,
+                         uint8_t *base_tag,
+                         unsigned base_tag_len,
+                         int *packet_len,
+                         srtp_xtd_seq_num_t pkt_index)
+{
+    uint32_t roc;
+    uint16_t isn;
+    unsigned emk_len;
+    uint8_t *packet;
 
-  /* if the pointer ekt is NULL, then EKT is not in effect */
-  if (!ekt) {
-    debug_print(mod_srtp, "EKT not in use", NULL);
-    return;
-  }
+    /* if the pointer ekt is NULL, then EKT is not in effect */
+    if (!ekt) {
+        debug_print(mod_srtp, "EKT not in use", NULL);
+        return;
+    }
 
-  /* write zeros into the location of the base tag */
-  octet_string_set_to_zero(base_tag, base_tag_len);
-  packet = base_tag + base_tag_len;
+    /* write zeros into the location of the base tag */
+    octet_string_set_to_zero(base_tag, base_tag_len);
+    packet = base_tag + base_tag_len;
 
-  /* copy encrypted master key into packet */
-  emk_len = srtp_ekt_octets_after_base_tag(ekt);
-  memcpy(packet, ekt->encrypted_master_key, emk_len);
-  debug_print(mod_srtp, "writing EKT EMK: %s,", 
-	      srtp_octet_string_hex_string(packet, emk_len));
-  packet += emk_len;
+    /* copy encrypted master key into packet */
+    emk_len = srtp_ekt_octets_after_base_tag(ekt);
+    memcpy(packet, ekt->encrypted_master_key, emk_len);
+    debug_print(mod_srtp, "writing EKT EMK: %s,",
+                srtp_octet_string_hex_string(packet, emk_len));
+    packet += emk_len;
 
-  /* copy ROC into packet */
-  roc = (uint32_t)(pkt_index >> 16);
-  *((uint32_t *)packet) = be32_to_cpu(roc);
-  debug_print(mod_srtp, "writing EKT ROC: %s,", 
-	      srtp_octet_string_hex_string(packet, sizeof(roc)));
-  packet += sizeof(roc);
+    /* copy ROC into packet */
+    roc = (uint32_t)(pkt_index >> 16);
+    *((uint32_t *)packet) = be32_to_cpu(roc);
+    debug_print(mod_srtp, "writing EKT ROC: %s,",
+                srtp_octet_string_hex_string(packet, sizeof(roc)));
+    packet += sizeof(roc);
 
-  /* copy ISN into packet */
-  isn = (uint16_t)pkt_index;
-  *((uint16_t *)packet) = htons(isn);
-  debug_print(mod_srtp, "writing EKT ISN: %s,", 
-	      srtp_octet_string_hex_string(packet, sizeof(isn)));
-  packet += sizeof(isn);
+    /* copy ISN into packet */
+    isn = (uint16_t)pkt_index;
+    *((uint16_t *)packet) = htons(isn);
+    debug_print(mod_srtp, "writing EKT ISN: %s,",
+                srtp_octet_string_hex_string(packet, sizeof(isn)));
+    packet += sizeof(isn);
 
-  /* copy SPI into packet */
-  *((uint16_t *)packet) = htons(ekt->data->spi);
-  debug_print(mod_srtp, "writing EKT SPI: %s,", 
-	      srtp_octet_string_hex_string(packet, sizeof(ekt->data->spi)));
+    /* copy SPI into packet */
+    *((uint16_t *)packet) = htons(ekt->data->spi);
+    debug_print(mod_srtp, "writing EKT SPI: %s,",
+                srtp_octet_string_hex_string(packet, sizeof(ekt->data->spi)));
 
-  /* increase packet length appropriately */
-  *packet_len += EKT_OCTETS_AFTER_EMK + emk_len;
+    /* increase packet length appropriately */
+    *packet_len += EKT_OCTETS_AFTER_EMK + emk_len;
 }
-
 
 /*
  * The function call srtcp_ekt_trailer(ekt, auth_len, auth_tag   )
- * 
+ *
  * If the pointer ekt is NULL, then the other inputs are unaffected.
  *
  * auth_tag is a pointer to the pointer to the location of the
  * authentication tag in the packet.  If EKT is in effect, then the
- * auth_tag pointer is set to the location 
+ * auth_tag pointer is set to the location
  */
 
-void srtcp_ekt_trailer(srtp_ekt_stream_t ekt, unsigned *auth_len, void **auth_tag, void *tag_copy) { 
-  /* 
-   * if there is no EKT policy, then the other inputs are unaffected
-   */
-  if (!ekt) 
-    return;
-      
-  /* copy auth_tag into temporary location */
-  
-}
+void srtcp_ekt_trailer(srtp_ekt_stream_t ekt,
+                       unsigned *auth_len,
+                       void **auth_tag,
+                       void *tag_copy)
+{
+    /*
+     * if there is no EKT policy, then the other inputs are unaffected
+     */
+    if (!ekt)
+        return;
 
+    /* copy auth_tag into temporary location */
+}

--- a/srtp/srtp.c
+++ b/srtp/srtp.c
@@ -525,8 +525,8 @@ srtp_err_status_t srtp_stream_clone(const srtp_stream_ctx_t *stream_template,
         *str_ptr = NULL;
         return srtp_err_status_alloc_fail;
     }
-    memset(str->session_keys, 0x0, sizeof(srtp_session_keys_t) *
-                                   str->num_master_keys);
+    memset(str->session_keys, 0x0,
+           sizeof(srtp_session_keys_t) * str->num_master_keys);
 
     for (i = 0; i < stream_template->num_master_keys; i++) {
         session_keys = &str->session_keys[i];
@@ -649,8 +649,10 @@ typedef struct {
     const EVP_CIPHER *evp;
 } srtp_kdf_t;
 
-static srtp_err_status_t
-srtp_kdf_init(srtp_kdf_t *kdf, const uint8_t *key, int key_len, int salt_len)
+static srtp_err_status_t srtp_kdf_init(srtp_kdf_t *kdf,
+                                       const uint8_t *key,
+                                       int key_len,
+                                       int salt_len)
 {
     memset(kdf, 0x0, sizeof(srtp_kdf_t));
 
@@ -725,8 +727,9 @@ typedef struct {
     srtp_cipher_t *cipher; /* cipher used for key derivation  */
 } srtp_kdf_t;
 
-static srtp_err_status_t
-srtp_kdf_init(srtp_kdf_t *kdf, const uint8_t *key, int key_len)
+static srtp_err_status_t srtp_kdf_init(srtp_kdf_t *kdf,
+                                       const uint8_t *key,
+                                       int key_len)
 {
     srtp_cipher_type_id_t cipher_id;
     switch (key_len) {
@@ -846,10 +849,10 @@ unsigned int srtp_validate_policy_master_keys(const srtp_policy_t *policy)
     return 1;
 }
 
-srtp_session_keys_t *
-srtp_get_session_keys_with_mki_index(srtp_stream_ctx_t *stream,
-                                     unsigned int use_mki,
-                                     unsigned int mki_index)
+srtp_session_keys_t *srtp_get_session_keys_with_mki_index(
+    srtp_stream_ctx_t *stream,
+    unsigned int use_mki,
+    unsigned int mki_index)
 {
     if (use_mki) {
         if (mki_index < stream->num_master_keys) {
@@ -878,11 +881,11 @@ unsigned int srtp_inject_mki(uint8_t *mki_tag_location,
     return mki_size;
 }
 
-srtp_err_status_t
-srtp_stream_init_all_master_keys(srtp_stream_ctx_t *srtp,
-                                 unsigned char *key,
-                                 srtp_master_key_t **keys,
-                                 const unsigned int max_master_keys)
+srtp_err_status_t srtp_stream_init_all_master_keys(
+    srtp_stream_ctx_t *srtp,
+    unsigned char *key,
+    srtp_master_key_t **keys,
+    const unsigned int max_master_keys)
 {
     int i = 0;
     srtp_err_status_t status = srtp_err_status_ok;
@@ -1425,10 +1428,10 @@ static int srtp_protect_extension_header(srtp_stream_ctx_t *stream, int id)
 /*
  * extensions header encryption RFC 6904
  */
-static srtp_err_status_t
-srtp_process_header_encryption(srtp_stream_ctx_t *stream,
-                               srtp_hdr_xtnd_t *xtn_hdr,
-                               srtp_session_keys_t *session_keys)
+static srtp_err_status_t srtp_process_header_encryption(
+    srtp_stream_ctx_t *stream,
+    srtp_hdr_xtnd_t *xtn_hdr,
+    srtp_session_keys_t *session_keys)
 {
     srtp_err_status_t status;
     uint8_t keystream[257]; /* Maximum 2 bytes header + 255 bytes data. */
@@ -2082,8 +2085,9 @@ static srtp_err_status_t srtp_unprotect_aead(srtp_ctx_t *ctx,
     return srtp_err_status_ok;
 }
 
-srtp_err_status_t
-srtp_protect(srtp_ctx_t *ctx, void *rtp_hdr, int *pkt_octet_len)
+srtp_err_status_t srtp_protect(srtp_ctx_t *ctx,
+                               void *rtp_hdr,
+                               int *pkt_octet_len)
 {
     return srtp_protect_mki(ctx, rtp_hdr, pkt_octet_len, 0, 0);
 }
@@ -2407,8 +2411,9 @@ srtp_err_status_t srtp_protect_mki(srtp_ctx_t *ctx,
     return srtp_err_status_ok;
 }
 
-srtp_err_status_t
-srtp_unprotect(srtp_ctx_t *ctx, void *srtp_hdr, int *pkt_octet_len)
+srtp_err_status_t srtp_unprotect(srtp_ctx_t *ctx,
+                                 void *srtp_hdr,
+                                 int *pkt_octet_len)
 {
     return srtp_unprotect_mki(ctx, srtp_hdr, pkt_octet_len, 0);
 }
@@ -3489,11 +3494,11 @@ void srtp_crypto_policy_set_aes_gcm_256_16_auth(srtp_crypto_policy_t *p)
  *          if seq_num is invalid
  *
  */
-static srtp_err_status_t
-srtp_calc_aead_iv_srtcp(srtp_session_keys_t *session_keys,
-                        v128_t *iv,
-                        uint32_t seq_num,
-                        srtcp_hdr_t *hdr)
+static srtp_err_status_t srtp_calc_aead_iv_srtcp(
+    srtp_session_keys_t *session_keys,
+    v128_t *iv,
+    uint32_t seq_num,
+    srtcp_hdr_t *hdr)
 {
     v128_t in;
     v128_t salt;
@@ -3534,13 +3539,13 @@ srtp_calc_aead_iv_srtcp(srtp_session_keys_t *session_keys,
  * This code handles AEAD ciphers for outgoing RTCP.  We currently support
  * AES-GCM mode with 128 or 256 bit keys.
  */
-static srtp_err_status_t
-srtp_protect_rtcp_aead(srtp_t ctx,
-                       srtp_stream_ctx_t *stream,
-                       void *rtcp_hdr,
-                       unsigned int *pkt_octet_len,
-                       srtp_session_keys_t *session_keys,
-                       unsigned int use_mki)
+static srtp_err_status_t srtp_protect_rtcp_aead(
+    srtp_t ctx,
+    srtp_stream_ctx_t *stream,
+    void *rtcp_hdr,
+    unsigned int *pkt_octet_len,
+    srtp_session_keys_t *session_keys,
+    unsigned int use_mki)
 {
     srtcp_hdr_t *hdr = (srtcp_hdr_t *)rtcp_hdr;
     uint32_t *enc_start;            /* pointer to start of encrypted portion  */
@@ -3705,13 +3710,13 @@ srtp_protect_rtcp_aead(srtp_t ctx,
  * at the end of the packet stream and is automatically checked by GCM
  * when decrypting the payload.
  */
-static srtp_err_status_t
-srtp_unprotect_rtcp_aead(srtp_t ctx,
-                         srtp_stream_ctx_t *stream,
-                         void *srtcp_hdr,
-                         unsigned int *pkt_octet_len,
-                         srtp_session_keys_t *session_keys,
-                         unsigned int use_mki)
+static srtp_err_status_t srtp_unprotect_rtcp_aead(
+    srtp_t ctx,
+    srtp_stream_ctx_t *stream,
+    void *srtcp_hdr,
+    unsigned int *pkt_octet_len,
+    srtp_session_keys_t *session_keys,
+    unsigned int use_mki)
 {
     srtcp_hdr_t *hdr = (srtcp_hdr_t *)srtcp_hdr;
     uint32_t *enc_start;            /* pointer to start of encrypted portion  */
@@ -3898,8 +3903,9 @@ srtp_unprotect_rtcp_aead(srtp_t ctx,
     return srtp_err_status_ok;
 }
 
-srtp_err_status_t
-srtp_protect_rtcp(srtp_t ctx, void *rtcp_hdr, int *pkt_octet_len)
+srtp_err_status_t srtp_protect_rtcp(srtp_t ctx,
+                                    void *rtcp_hdr,
+                                    int *pkt_octet_len)
 {
     return srtp_protect_rtcp_mki(ctx, rtcp_hdr, pkt_octet_len, 0, 0);
 }
@@ -4126,8 +4132,9 @@ srtp_err_status_t srtp_protect_rtcp_mki(srtp_t ctx,
     return srtp_err_status_ok;
 }
 
-srtp_err_status_t
-srtp_unprotect_rtcp(srtp_t ctx, void *srtcp_hdr, int *pkt_octet_len)
+srtp_err_status_t srtp_unprotect_rtcp(srtp_t ctx,
+                                      void *srtcp_hdr,
+                                      int *pkt_octet_len)
 {
     return srtp_unprotect_rtcp_mki(ctx, srtcp_hdr, pkt_octet_len, 0);
 }
@@ -4461,9 +4468,9 @@ void *srtp_get_user_data(srtp_t ctx)
  * dtls keying for srtp
  */
 
-srtp_err_status_t
-srtp_crypto_policy_set_from_profile_for_rtp(srtp_crypto_policy_t *policy,
-                                            srtp_profile_t profile)
+srtp_err_status_t srtp_crypto_policy_set_from_profile_for_rtp(
+    srtp_crypto_policy_t *policy,
+    srtp_profile_t profile)
 {
     /* set SRTP policy from the SRTP profile in the key set */
     switch (profile) {
@@ -4493,9 +4500,9 @@ srtp_crypto_policy_set_from_profile_for_rtp(srtp_crypto_policy_t *policy,
     return srtp_err_status_ok;
 }
 
-srtp_err_status_t
-srtp_crypto_policy_set_from_profile_for_rtcp(srtp_crypto_policy_t *policy,
-                                             srtp_profile_t profile)
+srtp_err_status_t srtp_crypto_policy_set_from_profile_for_rtcp(
+    srtp_crypto_policy_t *policy,
+    srtp_profile_t profile)
 {
     /* set SRTP policy from the SRTP profile in the key set */
     switch (profile) {
@@ -4728,8 +4735,9 @@ srtp_err_status_t srtp_install_log_handler(srtp_log_handler_func_t func,
     return srtp_err_status_ok;
 }
 
-srtp_err_status_t
-srtp_set_stream_roc(srtp_t session, uint32_t ssrc, uint32_t roc)
+srtp_err_status_t srtp_set_stream_roc(srtp_t session,
+                                      uint32_t ssrc,
+                                      uint32_t roc)
 {
     srtp_stream_t stream;
 
@@ -4742,8 +4750,9 @@ srtp_set_stream_roc(srtp_t session, uint32_t ssrc, uint32_t roc)
     return srtp_err_status_ok;
 }
 
-srtp_err_status_t
-srtp_get_stream_roc(srtp_t session, uint32_t ssrc, uint32_t *roc)
+srtp_err_status_t srtp_get_stream_roc(srtp_t session,
+                                      uint32_t ssrc,
+                                      uint32_t *roc)
 {
     srtp_stream_t stream;
 

--- a/test/cutest.h
+++ b/test/cutest.h
@@ -10,10 +10,10 @@
  * the rights to use, copy, modify, merge, publish, distribute, sublicense,
  * and/or sell copies of the Software, and to permit persons to whom the
  * Software is furnished to do so, subject to the following conditions:
- * 
+ *
  * The above copyright notice and this permission notice shall be included in
  * all copies or substantial portions of the Software.
- * 
+ *
  * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
  * OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
  * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
@@ -25,7 +25,6 @@
 
 #ifndef CUTEST_H__
 #define CUTEST_H__
-
 
 /************************
  *** Public interface ***
@@ -56,8 +55,7 @@
  *
  *   void test_func(void);
  */
-#define TEST_LIST              const struct test__ test_list__[]
-
+#define TEST_LIST const struct test__ test_list__[]
 
 /* Macros for testing whether an unit test succeeds or fails. These macros
  * can be used arbitrarily in functions implementing the unit tests.
@@ -78,9 +76,9 @@
  *       TEST_CHECK(ptr->member2 > 200);
  *   }
  */
-#define TEST_CHECK_(cond,...)  test_check__((cond), __FILE__, __LINE__, __VA_ARGS__)
-#define TEST_CHECK(cond)       test_check__((cond), __FILE__, __LINE__, "%s", #cond)
-
+#define TEST_CHECK_(cond, ...)                                                 \
+    test_check__((cond), __FILE__, __LINE__, __VA_ARGS__)
+#define TEST_CHECK(cond) test_check__((cond), __FILE__, __LINE__, "%s", #cond)
 
 /**********************
  *** Implementation ***
@@ -94,47 +92,43 @@
 #include <string.h>
 
 #if defined(unix) || defined(__unix__) || defined(__unix) || defined(__APPLE__)
-    #define CUTEST_UNIX__    1
-    #include <errno.h>
-    #include <unistd.h>
-    #include <sys/types.h>
-    #include <sys/wait.h>
-    #include <signal.h>
+#define CUTEST_UNIX__ 1
+#include <errno.h>
+#include <unistd.h>
+#include <sys/types.h>
+#include <sys/wait.h>
+#include <signal.h>
 #endif
 
 #if defined(_WIN32) || defined(__WIN32__) || defined(__WINDOWS__)
-    #define CUTEST_WIN__     1
-    #include <windows.h>
-    #include <io.h>
+#define CUTEST_WIN__ 1
+#include <windows.h>
+#include <io.h>
 #endif
 
 #ifdef __cplusplus
-    #include <exception>
+#include <exception>
 #endif
-
 
 /* Note our global private identifiers end with '__' to mitigate risk of clash
  * with the unit tests implementation. */
 
-
 #ifdef __cplusplus
-    extern "C" {
+extern "C" {
 #endif
 
-
 struct test__ {
-    const char* name;
+    const char *name;
     void (*func)(void);
 };
 
 extern const struct test__ test_list__[];
 
-int test_check__(int cond, const char* file, int line, const char* fmt, ...);
-
+int test_check__(int cond, const char *file, int line, const char *fmt, ...);
 
 #ifndef TEST_NO_MAIN
 
-static char* test_argv0__ = NULL;
+static char *test_argv0__ = NULL;
 static int test_count__ = 0;
 static int test_no_exec__ = 0;
 static int test_no_summary__ = 0;
@@ -143,21 +137,20 @@ static int test_skip_mode__ = 0;
 static int test_stat_failed_units__ = 0;
 static int test_stat_run_units__ = 0;
 
-static const struct test__* test_current_unit__ = NULL;
+static const struct test__ *test_current_unit__ = NULL;
 static int test_current_already_logged__ = 0;
 static int test_verbose_level__ = 2;
 static int test_current_failures__ = 0;
 static int test_colorize__ = 0;
 
-#define CUTEST_COLOR_DEFAULT__               0
-#define CUTEST_COLOR_GREEN__                 1
-#define CUTEST_COLOR_RED__                   2
-#define CUTEST_COLOR_DEFAULT_INTENSIVE__     3
-#define CUTEST_COLOR_GREEN_INTENSIVE__       4
-#define CUTEST_COLOR_RED_INTENSIVE__         5
+#define CUTEST_COLOR_DEFAULT__ 0
+#define CUTEST_COLOR_GREEN__ 1
+#define CUTEST_COLOR_RED__ 2
+#define CUTEST_COLOR_DEFAULT_INTENSIVE__ 3
+#define CUTEST_COLOR_GREEN_INTENSIVE__ 4
+#define CUTEST_COLOR_RED_INTENSIVE__ 5
 
-static size_t
-test_print_in_color__(int color, const char* fmt, ...)
+static size_t test_print_in_color__(int color, const char *fmt, ...)
 {
     va_list args;
     char buffer[256];
@@ -166,22 +159,34 @@ test_print_in_color__(int color, const char* fmt, ...)
     va_start(args, fmt);
     vsnprintf(buffer, sizeof(buffer), fmt, args);
     va_end(args);
-    buffer[sizeof(buffer)-1] = '\0';
+    buffer[sizeof(buffer) - 1] = '\0';
 
-    if(!test_colorize__) {
+    if (!test_colorize__) {
         return printf("%s", buffer);
     }
 
 #if defined CUTEST_UNIX__
     {
-        const char* col_str;
-        switch(color) {
-            case CUTEST_COLOR_GREEN__:             col_str = "\033[0;32m"; break;
-            case CUTEST_COLOR_RED__:               col_str = "\033[0;31m"; break;
-            case CUTEST_COLOR_GREEN_INTENSIVE__:   col_str = "\033[1;32m"; break;
-            case CUTEST_COLOR_RED_INTENSIVE__:     col_str = "\033[1;30m"; break;
-            case CUTEST_COLOR_DEFAULT_INTENSIVE__: col_str = "\033[1m"; break;
-            default:                               col_str = "\033[0m"; break;
+        const char *col_str;
+        switch (color) {
+        case CUTEST_COLOR_GREEN__:
+            col_str = "\033[0;32m";
+            break;
+        case CUTEST_COLOR_RED__:
+            col_str = "\033[0;31m";
+            break;
+        case CUTEST_COLOR_GREEN_INTENSIVE__:
+            col_str = "\033[1;32m";
+            break;
+        case CUTEST_COLOR_RED_INTENSIVE__:
+            col_str = "\033[1;30m";
+            break;
+        case CUTEST_COLOR_DEFAULT_INTENSIVE__:
+            col_str = "\033[1m";
+            break;
+        default:
+            col_str = "\033[0m";
+            break;
         }
         printf("%s", col_str);
         n = printf("%s", buffer);
@@ -197,15 +202,28 @@ test_print_in_color__(int color, const char* fmt, ...)
         h = GetStdHandle(STD_OUTPUT_HANDLE);
         GetConsoleScreenBufferInfo(h, &info);
 
-        switch(color) {
-            case CUTEST_COLOR_GREEN__:             attr = FOREGROUND_GREEN; break;
-            case CUTEST_COLOR_RED__:               attr = FOREGROUND_RED; break;
-            case CUTEST_COLOR_GREEN_INTENSIVE__:   attr = FOREGROUND_GREEN | FOREGROUND_INTENSITY; break;
-            case CUTEST_COLOR_RED_INTENSIVE__:     attr = FOREGROUND_RED | FOREGROUND_INTENSITY; break;
-            case CUTEST_COLOR_DEFAULT_INTENSIVE__: attr = FOREGROUND_BLUE | FOREGROUND_GREEN | FOREGROUND_RED | FOREGROUND_INTENSITY; break;
-            default:                               attr = 0; break;
+        switch (color) {
+        case CUTEST_COLOR_GREEN__:
+            attr = FOREGROUND_GREEN;
+            break;
+        case CUTEST_COLOR_RED__:
+            attr = FOREGROUND_RED;
+            break;
+        case CUTEST_COLOR_GREEN_INTENSIVE__:
+            attr = FOREGROUND_GREEN | FOREGROUND_INTENSITY;
+            break;
+        case CUTEST_COLOR_RED_INTENSIVE__:
+            attr = FOREGROUND_RED | FOREGROUND_INTENSITY;
+            break;
+        case CUTEST_COLOR_DEFAULT_INTENSIVE__:
+            attr = FOREGROUND_BLUE | FOREGROUND_GREEN | FOREGROUND_RED |
+                   FOREGROUND_INTENSITY;
+            break;
+        default:
+            attr = 0;
+            break;
         }
-        if(attr != 0)
+        if (attr != 0)
             SetConsoleTextAttribute(h, attr);
         n = printf("%s", buffer);
         SetConsoleTextAttribute(h, info.wAttributes);
@@ -217,19 +235,18 @@ test_print_in_color__(int color, const char* fmt, ...)
 #endif
 }
 
-int
-test_check__(int cond, const char* file, int line, const char* fmt, ...)
+int test_check__(int cond, const char *file, int line, const char *fmt, ...)
 {
     const char *result_str;
     int result_color;
     int verbose_level;
 
-    if(cond) {
+    if (cond) {
         result_str = "ok";
         result_color = CUTEST_COLOR_GREEN__;
         verbose_level = 3;
     } else {
-        if(!test_current_already_logged__  &&  test_current_unit__ != NULL) {
+        if (!test_current_already_logged__ && test_current_unit__ != NULL) {
             printf("[ ");
             test_print_in_color__(CUTEST_COLOR_RED_INTENSIVE__, "FAILED");
             printf(" ]\n");
@@ -241,13 +258,13 @@ test_check__(int cond, const char* file, int line, const char* fmt, ...)
         test_current_already_logged__++;
     }
 
-    if(test_verbose_level__ >= verbose_level) {
+    if (test_verbose_level__ >= verbose_level) {
         size_t n = 0;
         va_list args;
 
         printf("  ");
 
-        if(file != NULL)
+        if (file != NULL)
             n += printf("%s:%d: Check ", file, line);
 
         va_start(args, fmt);
@@ -263,23 +280,21 @@ test_check__(int cond, const char* file, int line, const char* fmt, ...)
     return (cond != 0);
 }
 
-static void
-test_list_names__(void)
+static void test_list_names__(void)
 {
-    const struct test__* test;
+    const struct test__ *test;
 
     printf("Unit tests:\n");
-    for(test = &test_list__[0]; test->func != NULL; test++)
+    for (test = &test_list__[0]; test->func != NULL; test++)
         printf("  %s\n", test->name);
 }
 
-static const struct test__*
-test_by_name__(const char* name)
+static const struct test__ *test_by_name__(const char *name)
 {
-    const struct test__* test;
+    const struct test__ *test;
 
-    for(test = &test_list__[0]; test->func != NULL; test++) {
-        if(strcmp(test->name, name) == 0)
+    for (test = &test_list__[0]; test->func != NULL; test++) {
+        if (strcmp(test->name, name) == 0)
             return test;
     }
 
@@ -287,24 +302,25 @@ test_by_name__(const char* name)
 }
 
 /* Call directly the given test unit function. */
-static int
-test_do_run__(const struct test__* test)
+static int test_do_run__(const struct test__ *test)
 {
     test_current_unit__ = test;
     test_current_failures__ = 0;
     test_current_already_logged__ = 0;
 
-    if(test_verbose_level__ >= 3) {
-        test_print_in_color__(CUTEST_COLOR_DEFAULT_INTENSIVE__, "Test %s:\n", test->name);
+    if (test_verbose_level__ >= 3) {
+        test_print_in_color__(CUTEST_COLOR_DEFAULT_INTENSIVE__, "Test %s:\n",
+                              test->name);
         test_current_already_logged__++;
-    } else if(test_verbose_level__ >= 1) {
+    } else if (test_verbose_level__ >= 1) {
         size_t n;
         char spaces[32];
 
-        n = test_print_in_color__(CUTEST_COLOR_DEFAULT_INTENSIVE__, "Test %s... ", test->name);
+        n = test_print_in_color__(CUTEST_COLOR_DEFAULT_INTENSIVE__,
+                                  "Test %s... ", test->name);
         memset(spaces, ' ', sizeof(spaces));
-        if(n < sizeof(spaces))
-            printf("%.*s", (int) (sizeof(spaces) - n), spaces);
+        if (n < sizeof(spaces))
+            printf("%.*s", (int)(sizeof(spaces) - n), spaces);
     } else {
         test_current_already_logged__ = 1;
     }
@@ -320,24 +336,34 @@ test_do_run__(const struct test__* test)
         test->func();
 
 #ifdef __cplusplus
-    } catch(std::exception& e) {
-        const char* what = e.what();
-        if(what != NULL)
+    } catch (std::exception &e) {
+        const char *what = e.what();
+        if (what != NULL)
             test_check__(0, NULL, 0, "Threw std::exception: %s", what);
         else
             test_check__(0, NULL, 0, "Threw std::exception");
-    } catch(...) {
+    } catch (...) {
         test_check__(0, NULL, 0, "Threw an exception");
     }
 #endif
 
-    if(test_verbose_level__ >= 3) {
-        switch(test_current_failures__) {
-            case 0:  test_print_in_color__(CUTEST_COLOR_GREEN_INTENSIVE__, "  All conditions have passed.\n\n"); break;
-            case 1:  test_print_in_color__(CUTEST_COLOR_RED_INTENSIVE__, "  One condition has FAILED.\n\n"); break;
-            default: test_print_in_color__(CUTEST_COLOR_RED_INTENSIVE__, "  %d conditions have FAILED.\n\n", test_current_failures__); break;
+    if (test_verbose_level__ >= 3) {
+        switch (test_current_failures__) {
+        case 0:
+            test_print_in_color__(CUTEST_COLOR_GREEN_INTENSIVE__,
+                                  "  All conditions have passed.\n\n");
+            break;
+        case 1:
+            test_print_in_color__(CUTEST_COLOR_RED_INTENSIVE__,
+                                  "  One condition has FAILED.\n\n");
+            break;
+        default:
+            test_print_in_color__(CUTEST_COLOR_RED_INTENSIVE__,
+                                  "  %d conditions have FAILED.\n\n",
+                                  test_current_failures__);
+            break;
         }
-    } else if(test_verbose_level__ >= 1 && test_current_failures__ == 0) {
+    } else if (test_verbose_level__ >= 1 && test_current_failures__ == 0) {
         printf("[   ");
         test_print_in_color__(CUTEST_COLOR_GREEN_INTENSIVE__, "OK");
         printf("   ]\n");
@@ -351,21 +377,21 @@ test_do_run__(const struct test__* test)
 /* Called if anything goes bad in cutest, or if the unit test ends in other
  * way then by normal returning from its function (e.g. exception or some
  * abnormal child process termination). */
-static void
-test_error__(const char* fmt, ...)
+static void test_error__(const char *fmt, ...)
 {
     va_list args;
 
-    if(test_verbose_level__ == 0)
+    if (test_verbose_level__ == 0)
         return;
 
-    if(test_verbose_level__ <= 2  &&  !test_current_already_logged__  &&  test_current_unit__ != NULL) {
+    if (test_verbose_level__ <= 2 && !test_current_already_logged__ &&
+        test_current_unit__ != NULL) {
         printf("[ ");
         test_print_in_color__(CUTEST_COLOR_RED_INTENSIVE__, "FAILED");
         printf(" ]\n");
     }
 
-    if(test_verbose_level__ >= 2) {
+    if (test_verbose_level__ >= 2) {
         test_print_in_color__(CUTEST_COLOR_RED_INTENSIVE__, "  Error: ");
         va_start(args, fmt);
         vprintf(fmt, args);
@@ -378,51 +404,73 @@ test_error__(const char* fmt, ...)
 /* Trigger the unit test. If possible (and not suppressed) it starts a child
  * process who calls test_do_run__(), otherwise it calls test_do_run__()
  * directly. */
-static void
-test_run__(const struct test__* test)
+static void test_run__(const struct test__ *test)
 {
     int failed = 1;
 
     test_current_unit__ = test;
     test_current_already_logged__ = 0;
 
-    if(!test_no_exec__) {
-
+    if (!test_no_exec__) {
 #if defined(CUTEST_UNIX__)
 
         pid_t pid;
         int exit_code;
 
         pid = fork();
-        if(pid == (pid_t)-1) {
+        if (pid == (pid_t)-1) {
             test_error__("Cannot fork. %s [%d]", strerror(errno), errno);
             failed = 1;
-        } else if(pid == 0) {
+        } else if (pid == 0) {
             /* Child: Do the test. */
             failed = (test_do_run__(test) != 0);
             exit(failed ? 1 : 0);
         } else {
             /* Parent: Wait until child terminates and analyze its exit code. */
             waitpid(pid, &exit_code, 0);
-            if(WIFEXITED(exit_code)) {
-                switch(WEXITSTATUS(exit_code)) {
-                    case 0:   failed = 0; break;   /* test has passed. */
-                    case 1:   /* noop */ break;    /* "normal" failure. */
-                    default:  test_error__("Unexpected exit code [%d]", WEXITSTATUS(exit_code));
+            if (WIFEXITED(exit_code)) {
+                switch (WEXITSTATUS(exit_code)) {
+                case 0:
+                    failed = 0;
+                    break; /* test has passed. */
+                case 1:    /* noop */
+                    break; /* "normal" failure. */
+                default:
+                    test_error__("Unexpected exit code [%d]",
+                                 WEXITSTATUS(exit_code));
                 }
-            } else if(WIFSIGNALED(exit_code)) {
+            } else if (WIFSIGNALED(exit_code)) {
                 char tmp[32];
-                const char* signame;
-                switch(WTERMSIG(exit_code)) {
-                    case SIGINT:  signame = "SIGINT"; break;
-                    case SIGHUP:  signame = "SIGHUP"; break;
-                    case SIGQUIT: signame = "SIGQUIT"; break;
-                    case SIGABRT: signame = "SIGABRT"; break;
-                    case SIGKILL: signame = "SIGKILL"; break;
-                    case SIGSEGV: signame = "SIGSEGV"; break;
-                    case SIGILL:  signame = "SIGILL"; break;
-                    case SIGTERM: signame = "SIGTERM"; break;
-                    default:      sprintf(tmp, "signal %d", WTERMSIG(exit_code)); signame = tmp; break;
+                const char *signame;
+                switch (WTERMSIG(exit_code)) {
+                case SIGINT:
+                    signame = "SIGINT";
+                    break;
+                case SIGHUP:
+                    signame = "SIGHUP";
+                    break;
+                case SIGQUIT:
+                    signame = "SIGQUIT";
+                    break;
+                case SIGABRT:
+                    signame = "SIGABRT";
+                    break;
+                case SIGKILL:
+                    signame = "SIGKILL";
+                    break;
+                case SIGSEGV:
+                    signame = "SIGSEGV";
+                    break;
+                case SIGILL:
+                    signame = "SIGILL";
+                    break;
+                case SIGTERM:
+                    signame = "SIGTERM";
+                    break;
+                default:
+                    sprintf(tmp, "signal %d", WTERMSIG(exit_code));
+                    signame = tmp;
+                    break;
                 }
                 test_error__("Test interrupted by %s", signame);
             } else {
@@ -432,26 +480,28 @@ test_run__(const struct test__* test)
 
 #elif defined(CUTEST_WIN__)
 
-        char buffer[512] = {0};
-        STARTUPINFOA startupInfo = {0};
+        char buffer[512] = { 0 };
+        STARTUPINFOA startupInfo = { 0 };
         PROCESS_INFORMATION processInfo;
         DWORD exitCode;
 
         /* Windows has no fork(). So we propagate all info into the child
          * through a command line arguments. */
-        _snprintf(buffer, sizeof(buffer)-1,
-                 "%s --no-exec --no-summary --verbose=%d --color=%s -- \"%s\"",
-                 test_argv0__, test_verbose_level__,
-                 test_colorize__ ? "always" : "never", test->name);
+        _snprintf(buffer, sizeof(buffer) - 1,
+                  "%s --no-exec --no-summary --verbose=%d --color=%s -- \"%s\"",
+                  test_argv0__, test_verbose_level__,
+                  test_colorize__ ? "always" : "never", test->name);
         startupInfo.cb = sizeof(STARTUPINFO);
-        if(CreateProcessA(NULL, buffer, NULL, NULL, FALSE, 0, NULL, NULL, &startupInfo, &processInfo)) {
+        if (CreateProcessA(NULL, buffer, NULL, NULL, FALSE, 0, NULL, NULL,
+                           &startupInfo, &processInfo)) {
             WaitForSingleObject(processInfo.hProcess, INFINITE);
             GetExitCodeProcess(processInfo.hProcess, &exitCode);
             CloseHandle(processInfo.hThread);
             CloseHandle(processInfo.hProcess);
             failed = (exitCode != 0);
         } else {
-            test_error__("Cannot create unit test subprocess [%ld].", GetLastError());
+            test_error__("Cannot create unit test subprocess [%ld].",
+                         GetLastError());
             failed = 1;
         }
 
@@ -470,14 +520,13 @@ test_run__(const struct test__* test)
     test_current_unit__ = NULL;
 
     test_stat_run_units__++;
-    if(failed)
+    if (failed)
         test_stat_failed_units__++;
 }
 
 #if defined(CUTEST_WIN__)
 /* Callback for SEH events. */
-static LONG CALLBACK
-test_exception_filter__(EXCEPTION_POINTERS *ptrs)
+static LONG CALLBACK test_exception_filter__(EXCEPTION_POINTERS *ptrs)
 {
     test_error__("Unhandled SEH exception %08lx at %p.",
                  ptrs->ExceptionRecord->ExceptionCode,
@@ -488,35 +537,42 @@ test_exception_filter__(EXCEPTION_POINTERS *ptrs)
 }
 #endif
 
-static void
-test_help__(void)
+static void test_help__(void)
 {
     printf("Usage: %s [options] [test...]\n", test_argv0__);
-    printf("Run the specified unit tests; or if the option '--skip' is used, run all\n");
-    printf("tests in the suite but those listed.  By default, if no tests are specified\n");
+    printf("Run the specified unit tests; or if the option '--skip' is used, "
+           "run all\n");
+    printf("tests in the suite but those listed.  By default, if no tests are "
+           "specified\n");
     printf("on the command line, all unit tests in the suite are run.\n");
     printf("\n");
     printf("Options:\n");
-    printf("  -s, --skip            Execute all unit tests but the listed ones\n");
-    printf("      --no-exec         Do not execute unit tests as child processes\n");
-    printf("      --no-summary      Suppress printing of test results summary\n");
+    printf(
+        "  -s, --skip            Execute all unit tests but the listed ones\n");
+    printf("      --no-exec         Do not execute unit tests as child "
+           "processes\n");
+    printf(
+        "      --no-summary      Suppress printing of test results summary\n");
     printf("  -l, --list            List unit tests in the suite and exit\n");
     printf("  -v, --verbose         Enable more verbose output\n");
     printf("      --verbose=LEVEL   Set verbose level to LEVEL:\n");
     printf("                          0 ... Be silent\n");
-    printf("                          1 ... Output one line per test (and summary)\n");
-    printf("                          2 ... As 1 and failed conditions (this is default)\n");
-    printf("                          3 ... As 1 and all conditions (and extended summary)\n");
-    printf("      --color=WHEN      Enable colorized output (WHEN is one of 'auto', 'always', 'never')\n");
+    printf("                          1 ... Output one line per test (and "
+           "summary)\n");
+    printf("                          2 ... As 1 and failed conditions (this "
+           "is default)\n");
+    printf("                          3 ... As 1 and all conditions (and "
+           "extended summary)\n");
+    printf("      --color=WHEN      Enable colorized output (WHEN is one of "
+           "'auto', 'always', 'never')\n");
     printf("  -h, --help            Display this help and exit\n");
     printf("\n");
     test_list_names__();
 }
 
-int
-main(int argc, char** argv)
+int main(int argc, char **argv)
 {
-    const struct test__** tests = NULL;
+    const struct test__ **tests = NULL;
     int i, j, n = 0;
     int seen_double_dash = 0;
 
@@ -531,42 +587,50 @@ main(int argc, char** argv)
 #endif
 
     /* Parse options */
-    for(i = 1; i < argc; i++) {
-        if(seen_double_dash || argv[i][0] != '-') {
-            tests = (const struct test__**) realloc((void*)tests, (n+1) * sizeof(const struct test__*));
-            if(tests == NULL) {
+    for (i = 1; i < argc; i++) {
+        if (seen_double_dash || argv[i][0] != '-') {
+            tests = (const struct test__ **)realloc(
+                (void *)tests, (n + 1) * sizeof(const struct test__ *));
+            if (tests == NULL) {
                 fprintf(stderr, "Out of memory.\n");
                 exit(2);
             }
             tests[n] = test_by_name__(argv[i]);
-            if(tests[n] == NULL) {
-                fprintf(stderr, "%s: Unrecognized unit test '%s'\n", argv[0], argv[i]);
-                fprintf(stderr, "Try '%s --list' for list of unit tests.\n", argv[0]);
+            if (tests[n] == NULL) {
+                fprintf(stderr, "%s: Unrecognized unit test '%s'\n", argv[0],
+                        argv[i]);
+                fprintf(stderr, "Try '%s --list' for list of unit tests.\n",
+                        argv[0]);
                 exit(2);
             }
             n++;
-        } else if(strcmp(argv[i], "--") == 0) {
+        } else if (strcmp(argv[i], "--") == 0) {
             seen_double_dash = 1;
-        } else if(strcmp(argv[i], "--help") == 0 || strcmp(argv[i], "-h") == 0) {
+        } else if (strcmp(argv[i], "--help") == 0 ||
+                   strcmp(argv[i], "-h") == 0) {
             test_help__();
             exit(0);
-        } else if(strcmp(argv[i], "--verbose") == 0 || strcmp(argv[i], "-v") == 0) {
+        } else if (strcmp(argv[i], "--verbose") == 0 ||
+                   strcmp(argv[i], "-v") == 0) {
             test_verbose_level__++;
-        } else if(strncmp(argv[i], "--verbose=", 10) == 0) {
+        } else if (strncmp(argv[i], "--verbose=", 10) == 0) {
             test_verbose_level__ = atoi(argv[i] + 10);
-        } else if(strcmp(argv[i], "--color=auto") == 0) {
+        } else if (strcmp(argv[i], "--color=auto") == 0) {
             /* noop (set from above) */
-        } else if(strcmp(argv[i], "--color=always") == 0 || strcmp(argv[i], "--color") == 0) {
+        } else if (strcmp(argv[i], "--color=always") == 0 ||
+                   strcmp(argv[i], "--color") == 0) {
             test_colorize__ = 1;
-        } else if(strcmp(argv[i], "--color=never") == 0) {
+        } else if (strcmp(argv[i], "--color=never") == 0) {
             test_colorize__ = 0;
-        } else if(strcmp(argv[i], "--skip") == 0 || strcmp(argv[i], "-s") == 0) {
+        } else if (strcmp(argv[i], "--skip") == 0 ||
+                   strcmp(argv[i], "-s") == 0) {
             test_skip_mode__ = 1;
-        } else if(strcmp(argv[i], "--no-exec") == 0) {
+        } else if (strcmp(argv[i], "--no-exec") == 0) {
             test_no_exec__ = 1;
-        } else if(strcmp(argv[i], "--no-summary") == 0) {
+        } else if (strcmp(argv[i], "--no-summary") == 0) {
             test_no_summary__ = 1;
-        } else if(strcmp(argv[i], "--list") == 0 || strcmp(argv[i], "-l") == 0) {
+        } else if (strcmp(argv[i], "--list") == 0 ||
+                   strcmp(argv[i], "-l") == 0) {
             test_list_names__();
             exit(0);
         } else {
@@ -582,66 +646,68 @@ main(int argc, char** argv)
 
     /* Count all test units */
     test_count__ = 0;
-    for(i = 0; test_list__[i].func != NULL; i++)
+    for (i = 0; test_list__[i].func != NULL; i++)
         test_count__++;
 
     /* Run the tests */
-    if(n == 0) {
+    if (n == 0) {
         /* Run all tests */
-        for(i = 0; test_list__[i].func != NULL; i++)
+        for (i = 0; test_list__[i].func != NULL; i++)
             test_run__(&test_list__[i]);
-    } else if(!test_skip_mode__) {
+    } else if (!test_skip_mode__) {
         /* Run the listed tests */
-        for(i = 0; i < n; i++)
+        for (i = 0; i < n; i++)
             test_run__(tests[i]);
     } else {
         /* Run all tests except those listed */
-        for(i = 0; test_list__[i].func != NULL; i++) {
+        for (i = 0; test_list__[i].func != NULL; i++) {
             int want_skip = 0;
-            for(j = 0; j < n; j++) {
-                if(tests[j] == &test_list__[i]) {
+            for (j = 0; j < n; j++) {
+                if (tests[j] == &test_list__[i]) {
                     want_skip = 1;
                     break;
                 }
             }
-            if(!want_skip)
+            if (!want_skip)
                 test_run__(&test_list__[i]);
         }
     }
 
     /* Write a summary */
-    if(!test_no_summary__ && test_verbose_level__ >= 1) {
+    if (!test_no_summary__ && test_verbose_level__ >= 1) {
         test_print_in_color__(CUTEST_COLOR_DEFAULT_INTENSIVE__, "\nSummary:\n");
 
-        if(test_verbose_level__ >= 3) {
+        if (test_verbose_level__ >= 3) {
             printf("  Count of all unit tests:     %4d\n", test_count__);
-            printf("  Count of run unit tests:     %4d\n", test_stat_run_units__);
-            printf("  Count of failed unit tests:  %4d\n", test_stat_failed_units__);
-            printf("  Count of skipped unit tests: %4d\n", test_count__ - test_stat_run_units__);
+            printf("  Count of run unit tests:     %4d\n",
+                   test_stat_run_units__);
+            printf("  Count of failed unit tests:  %4d\n",
+                   test_stat_failed_units__);
+            printf("  Count of skipped unit tests: %4d\n",
+                   test_count__ - test_stat_run_units__);
         }
 
-        if(test_stat_failed_units__ == 0) {
+        if (test_stat_failed_units__ == 0) {
             test_print_in_color__(CUTEST_COLOR_GREEN_INTENSIVE__,
-                    "  SUCCESS: All unit tests have passed.\n");
+                                  "  SUCCESS: All unit tests have passed.\n");
         } else {
-            test_print_in_color__(CUTEST_COLOR_RED_INTENSIVE__,
-                    "  FAILED: %d of %d unit tests have failed.\n",
-                    test_stat_failed_units__, test_stat_run_units__);
+            test_print_in_color__(
+                CUTEST_COLOR_RED_INTENSIVE__,
+                "  FAILED: %d of %d unit tests have failed.\n",
+                test_stat_failed_units__, test_stat_run_units__);
         }
     }
 
-    if(tests != NULL)
-        free((void*)tests);
+    if (tests != NULL)
+        free((void *)tests);
 
     return (test_stat_failed_units__ == 0) ? 0 : 1;
 }
 
-
-#endif  /* #ifndef TEST_NO_MAIN */
+#endif /* #ifndef TEST_NO_MAIN */
 
 #ifdef __cplusplus
-    }  /* extern "C" */
+} /* extern "C" */
 #endif
 
-
-#endif  /* #ifndef CUTEST_H__ */
+#endif /* #ifndef CUTEST_H__ */

--- a/test/getopt_s.c
+++ b/test/getopt_s.c
@@ -3,30 +3,30 @@
  *
  * a minimal implementation of the getopt() function, written so that
  * test applications that use that function can run on non-POSIX
- * platforms 
+ * platforms
  *
  */
 /*
- *	
+ *
  * Copyright (c) 2001-2017 Cisco Systems, Inc.
  * All rights reserved.
- * 
+ *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
  * are met:
- * 
+ *
  *   Redistributions of source code must retain the above copyright
  *   notice, this list of conditions and the following disclaimer.
- * 
+ *
  *   Redistributions in binary form must reproduce the above
  *   copyright notice, this list of conditions and the following
  *   disclaimer in the documentation and/or other materials provided
  *   with the distribution.
- * 
+ *
  *   Neither the name of the Cisco Systems, Inc. nor the names of its
  *   contributors may be used to endorse or promote products derived
  *   from this software without specific prior written permission.
- * 
+ *
  * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
  * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
  * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
@@ -42,71 +42,67 @@
  *
  */
 
-#include <stdlib.h>  /* for NULL */
+#include <stdlib.h> /* for NULL */
 
 int optind_s = 0;
 
 char *optarg_s;
 
-#define GETOPT_FOUND_WITHOUT_ARGUMENT    2
-#define GETOPT_FOUND_WITH_ARGUMENT       1
-#define GETOPT_NOT_FOUND                 0 
+#define GETOPT_FOUND_WITHOUT_ARGUMENT 2
+#define GETOPT_FOUND_WITH_ARGUMENT 1
+#define GETOPT_NOT_FOUND 0
 
-static int 
-getopt_check_character(char c, const char *string) {
-  unsigned int max_string_len = 128;
+static int getopt_check_character(char c, const char *string)
+{
+    unsigned int max_string_len = 128;
 
-  while (*string != 0) {
-    if (max_string_len == 0) {
-      return '?';
+    while (*string != 0) {
+        if (max_string_len == 0) {
+            return '?';
+        }
+        if (*string++ == c) {
+            if (*string == ':') {
+                return GETOPT_FOUND_WITH_ARGUMENT;
+            } else {
+                return GETOPT_FOUND_WITHOUT_ARGUMENT;
+            }
+        }
     }
-    if (*string++ == c) {
-      if (*string == ':') {
-	return GETOPT_FOUND_WITH_ARGUMENT;
-      } else {
-	return GETOPT_FOUND_WITHOUT_ARGUMENT;
-      }
-    }
-  }
-  return GETOPT_NOT_FOUND;
+    return GETOPT_NOT_FOUND;
 }
 
-int
-getopt_s(int argc, 
-       char * const argv[], 
-       const char *optstring) {
+int getopt_s(int argc, char *const argv[], const char *optstring)
+{
+    while (optind_s + 1 < argc) {
+        char *string;
 
+        /* move 'string' on to next argument */
+        optind_s++;
+        string = argv[optind_s];
 
-  while (optind_s + 1 < argc) {
-    char *string;
-    
-    /* move 'string' on to next argument */
-    optind_s++;
-    string = argv[optind_s];
+        if (string == NULL)
+            return '?'; /* NULL argument string */
 
-    if (string == NULL)
-      return '?'; /* NULL argument string */
+        if (string[0] != '-')
+            return -1; /* found an unexpected character */
 
-    if (string[0] != '-')
-      return -1; /* found an unexpected character */
-
-    switch(getopt_check_character(string[1], optstring)) {
-    case GETOPT_FOUND_WITH_ARGUMENT:
-      if (optind_s + 1 < argc) {
-	optind_s++;
-	optarg_s = argv[optind_s];
-	return string[1]; 
-      } else {
-	return '?';  /* argument missing */
-      }
-    case GETOPT_FOUND_WITHOUT_ARGUMENT:
-      return string[1];
-    case GETOPT_NOT_FOUND:
-    default:
-      return '?'; /* didn't find expected character */
-      break;
+        switch (getopt_check_character(string[1], optstring)) {
+        case GETOPT_FOUND_WITH_ARGUMENT:
+            if (optind_s + 1 < argc) {
+                optind_s++;
+                optarg_s = argv[optind_s];
+                return string[1];
+            } else {
+                return '?'; /* argument missing */
+            }
+        case GETOPT_FOUND_WITHOUT_ARGUMENT:
+            return string[1];
+        case GETOPT_NOT_FOUND:
+        default:
+            return '?'; /* didn't find expected character */
+            break;
+        }
     }
-  }
 
-  return -1;
+    return -1;
 }


### PR DESCRIPTION
This should be the last formatting change to existing code required to complete #254.
The provide script can be used to run clang-format on all source code in git repo, this can be used before creating a PR to check that new code is formatted correctly.
Will try to modify the travis build script to fail if running this script results in any changes to a PR.
