### PR TITLE
Add clang-format check in traivs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,6 +21,7 @@ matrix:
     - os: osx
       env: CONFIGURE_FLAGS=--enable-openssl
 before_script:
+  - if [ $TRAVIS_OS_NAME == osx ]; then brew update; fi
   - if [ $TRAVIS_OS_NAME == osx ]; then brew install ccache; fi
   - if [ $TRAVIS_OS_NAME == linux ]; then ./format.sh -d; fi
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,10 @@ sudo: false
 language: c
 cache: ccache
 osx_image: xcode8.2
+addons:
+  apt:
+    packages:
+      - clang-format-3.9
 compiler:
   - clang
   - gcc
@@ -18,6 +22,7 @@ matrix:
       env: CONFIGURE_FLAGS=--enable-openssl
 before_script:
   - if [ $TRAVIS_OS_NAME == osx ]; then brew install ccache; fi
+  - if [ $TRAVIS_OS_NAME == linux ]; then ./format.sh -d; fi
 script:
   - ./configure $CONFIGURE_FLAGS
   - make

--- a/format.sh
+++ b/format.sh
@@ -3,14 +3,33 @@
 # format.sh
 #
 # run clang-format on each .c & .h file
+#
+# assumes git tree is clean when reporting status
 
 if [ -z "${CLANG_FORMAT}" ]; then
     CLANG_FORMAT=clang-format
 fi
 
-a=`git ls-files | grep "\.h$\|\.c$"`
+a=`git ls-files '*.h' '*.c'`
 for x in $a; do
-     if [ $x != "config_in.h" ]; then
-         $CLANG_FORMAT -i -style=file $x
-     fi
+    if [ $x != "config_in.h" ]; then
+        $CLANG_FORMAT -i -style=file $x
+    fi
 done
+
+m=`git ls-files -m`
+if [ -n "$m" ]; then
+    v=`$CLANG_FORMAT -version`
+    echo "Fromatting required when checking with $v"
+    echo
+    echo "The following files required formatting:"
+    for f in $m; do
+        echo $f
+    done
+    if [ "$1" = "-d" ]; then
+        echo
+        git diff
+    fi
+    exit 1
+fi
+exit 0


### PR DESCRIPTION
If formatting is required the build will fail and
the required diff printed

Currently works against clang-format-3.9.

All linux configurations will run the check on travis,
should consider making a specific configuration for format
checking and letting normal builds finish.

This should be the end of #254 for now.
