### PR TITLE
change srtp_crypto_alloc to initialize memory to zero

### DIFF
--- a/crypto/cipher/aes_gcm_ossl.c
+++ b/crypto/cipher/aes_gcm_ossl.c
@@ -108,7 +108,6 @@ static srtp_err_status_t srtp_aes_gcm_openssl_alloc(srtp_cipher_t **c,
     if (*c == NULL) {
         return (srtp_err_status_alloc_fail);
     }
-    memset(*c, 0x0, sizeof(srtp_cipher_t));
 
     gcm = (srtp_aes_gcm_ctx_t *)srtp_crypto_alloc(sizeof(srtp_aes_gcm_ctx_t));
     if (gcm == NULL) {
@@ -116,7 +115,6 @@ static srtp_err_status_t srtp_aes_gcm_openssl_alloc(srtp_cipher_t **c,
         *c = NULL;
         return (srtp_err_status_alloc_fail);
     }
-    memset(gcm, 0x0, sizeof(srtp_aes_gcm_ctx_t));
 
     gcm->ctx = EVP_CIPHER_CTX_new();
     if (gcm->ctx == NULL) {

--- a/crypto/cipher/aes_icm.c
+++ b/crypto/cipher/aes_icm.c
@@ -118,14 +118,12 @@ static srtp_err_status_t srtp_aes_icm_alloc(srtp_cipher_t **c,
     if (*c == NULL) {
         return srtp_err_status_alloc_fail;
     }
-    memset(*c, 0x0, sizeof(srtp_cipher_t));
 
     icm = (srtp_aes_icm_ctx_t *)srtp_crypto_alloc(sizeof(srtp_aes_icm_ctx_t));
     if (icm == NULL) {
         srtp_crypto_free(*c);
         return srtp_err_status_alloc_fail;
     }
-    memset(icm, 0x0, sizeof(srtp_aes_icm_ctx_t));
 
     /* set pointers */
     (*c)->state = icm;

--- a/crypto/cipher/aes_icm_ossl.c
+++ b/crypto/cipher/aes_icm_ossl.c
@@ -131,7 +131,6 @@ static srtp_err_status_t srtp_aes_icm_openssl_alloc(srtp_cipher_t **c,
     if (*c == NULL) {
         return srtp_err_status_alloc_fail;
     }
-    memset(*c, 0x0, sizeof(srtp_cipher_t));
 
     icm = (srtp_aes_icm_ctx_t *)srtp_crypto_alloc(sizeof(srtp_aes_icm_ctx_t));
     if (icm == NULL) {
@@ -139,7 +138,6 @@ static srtp_err_status_t srtp_aes_icm_openssl_alloc(srtp_cipher_t **c,
         *c = NULL;
         return srtp_err_status_alloc_fail;
     }
-    memset(icm, 0x0, sizeof(srtp_aes_icm_ctx_t));
 
     icm->ctx = EVP_CIPHER_CTX_new();
     if (icm->ctx == NULL) {

--- a/crypto/cipher/null_cipher.c
+++ b/crypto/cipher/null_cipher.c
@@ -71,7 +71,6 @@ static srtp_err_status_t srtp_null_cipher_alloc(srtp_cipher_t **c,
     if (*c == NULL) {
         return srtp_err_status_alloc_fail;
     }
-    memset(*c, 0x0, sizeof(srtp_cipher_t));
 
     /* set pointers */
     (*c)->algorithm = SRTP_NULL_CIPHER;

--- a/crypto/include/alloc.h
+++ b/crypto/include/alloc.h
@@ -51,8 +51,22 @@
 extern "C" {
 #endif
 
+/*
+ * srtp_crypto_alloc
+ *
+ * Allocates a block of memory  of given size. The memory will be
+ * initialized to zero's. Free the memory with a call to srtp_crypto_free.
+ *
+ * returns pointer to memory on success or else NULL
+ */
 void *srtp_crypto_alloc(size_t size);
 
+/*
+ * srtp_crypto_free
+ *
+ * Frees the block of memory  ptr previously  allocated with
+ * srtp_crypto_alloc
+ */
 void srtp_crypto_free(void *ptr);
 
 #ifdef __cplusplus

--- a/crypto/kernel/alloc.c
+++ b/crypto/kernel/alloc.c
@@ -71,7 +71,7 @@ void *srtp_crypto_alloc(size_t size)
 {
     void *ptr;
 
-    ptr = malloc(size);
+    ptr = calloc(1, size);
 
     if (ptr) {
         debug_print(mod_alloc, "(location: %p) allocated", ptr);

--- a/crypto/math/datatypes.c
+++ b/crypto/math/datatypes.c
@@ -335,7 +335,6 @@ int bitvector_alloc(bitvector_t *v, unsigned long length)
     else {
         v->word = (uint32_t *)srtp_crypto_alloc(l);
         if (v->word == NULL) {
-            v->word = NULL;
             v->length = 0;
             return -1;
         }

--- a/crypto/test/cipher_driver.c
+++ b/crypto/test/cipher_driver.c
@@ -49,7 +49,6 @@
 
 #include <stdio.h>  /* for printf() */
 #include <stdlib.h> /* for rand() */
-#include <string.h> /* for memset() */
 #include "getopt_s.h"
 #include "cipher.h"
 #ifdef OPENSSL
@@ -542,7 +541,6 @@ uint64_t cipher_array_bits_per_second(srtp_cipher_t *cipher_array[],
     enc_buf = srtp_crypto_alloc(octets_in_buffer + 17);
     if (enc_buf == NULL)
         return 0; /* indicate bad parameters by returning null */
-    memset(enc_buf, 0, octets_in_buffer);
 
     /* time repeated trials */
     v128_set_to_zero(&nonce);

--- a/srtp/srtp.c
+++ b/srtp/srtp.c
@@ -215,7 +215,6 @@ srtp_err_status_t srtp_stream_alloc(srtp_stream_ctx_t **str_ptr,
     if (str == NULL)
         return srtp_err_status_alloc_fail;
 
-    memset(str, 0, sizeof(srtp_stream_ctx_t));
     *str_ptr = str;
 
     /*
@@ -235,9 +234,6 @@ srtp_err_status_t srtp_stream_alloc(srtp_stream_ctx_t **str_ptr,
         srtp_stream_free(str);
         return srtp_err_status_alloc_fail;
     }
-
-    memset(str->session_keys, 0,
-           sizeof(srtp_session_keys_t) * str->num_master_keys);
 
     for (i = 0; i < str->num_master_keys; i++) {
         session_keys = &str->session_keys[i];
@@ -513,7 +509,6 @@ srtp_err_status_t srtp_stream_clone(const srtp_stream_ctx_t *stream_template,
     str = (srtp_stream_ctx_t *)srtp_crypto_alloc(sizeof(srtp_stream_ctx_t));
     if (str == NULL)
         return srtp_err_status_alloc_fail;
-    memset(str, 0x0, sizeof(srtp_stream_ctx_t));
     *str_ptr = str;
 
     str->num_master_keys = stream_template->num_master_keys;
@@ -525,8 +520,6 @@ srtp_err_status_t srtp_stream_clone(const srtp_stream_ctx_t *stream_template,
         *str_ptr = NULL;
         return srtp_err_status_alloc_fail;
     }
-    memset(str->session_keys, 0x0,
-           sizeof(srtp_session_keys_t) * str->num_master_keys);
 
     for (i = 0; i < stream_template->num_master_keys; i++) {
         session_keys = &str->session_keys[i];
@@ -552,7 +545,6 @@ srtp_err_status_t srtp_stream_clone(const srtp_stream_ctx_t *stream_template,
                 *str_ptr = NULL;
                 return srtp_err_status_init_fail;
             }
-            memset(session_keys->mki_id, 0x0, session_keys->mki_size);
             memcpy(session_keys->mki_id, template_session_keys->mki_id,
                    session_keys->mki_size);
         }
@@ -949,7 +941,6 @@ srtp_err_status_t srtp_stream_init_keys(srtp_stream_ctx_t *srtp,
         if (session_keys->mki_id == NULL) {
             return srtp_err_status_init_fail;
         }
-        memset(session_keys->mki_id, 0x0, master_key->mki_size);
         memcpy(session_keys->mki_id, master_key->mki_id, master_key->mki_size);
     } else {
         session_keys->mki_id = NULL;


### PR DESCRIPTION
Proactively prevent accessing uninitialized memory.
Majority of calls to srtp_crypto_alloc had a corresponding
call to memset.