### PR TITLE
add a big endian build on travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -84,3 +84,28 @@ matrix:
         - ./configure --enable-openssl
         - make
         - make runtest-valgrind
+
+    # big-endian
+    - os: linux
+      sudo: true
+      env:
+        - TEST="big-endian"
+      services:
+        - docker
+      addons:
+        apt:
+          packages:
+            - qemu-user-static
+            - qemu-system-mips
+      before_install:
+        - sudo docker run --volume $(pwd):/src --workdir /src --name mipsX --tty --detach ubuntu:16.04 tail
+        - sudo docker exec --tty mipsX apt-get update
+        - sudo docker exec --tty mipsX apt-get install build-essential -y
+        - sudo docker exec --tty mipsX apt-get install gcc-mips-linux-gnu -y
+      script:
+        - sudo docker exec --tty mipsX bash -c 'EXTRA_CFLAGS=-static CC=mips-linux-gnu-gcc ./configure --host=x86_64-linux-gnu'
+        - sudo docker exec --tty mipsX make
+        - file test/srtp_driver
+        - test/srtp_driver -v
+        - file test/test_srtp
+        - test/test_srtp


### PR DESCRIPTION
This should prevent breaking big endian support.

As Ubunty 14.04 does not have stable cross compiler for
mips a 16.04 docker container is used to compile the tests.
The test are then run on host using qemu user static.