### PR TITLE
Add coverity scan to tavis builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,10 @@ dist: trusty
 sudo: false
 language: c
 
+env:
+  global:
+    - secure: "YJSSinoWNfMicNYCdxsnlgZc9AIi1yKkgJTmKk41zRI23r8c5Z339Zl1p/boxOxD+YLCQshBYR00ckJXT9R8wQy0WhpWdA3YJYAMWjnVkbBMBNf3VEQSIvHwV8kLDBMPBikhks7b4ACPG3UYLsQrxUJFfJz4Grn7z8tbUedv1Gk="
+
 matrix:
   include:
 
@@ -109,3 +113,20 @@ matrix:
         - test/srtp_driver -v
         - file test/test_srtp
         - test/test_srtp
+
+    # coverity scan
+    - os: linux
+      env:
+        - TEST="Coverity Scan"
+      addons:
+        coverity_scan:
+          project:
+            name: "cisco-libSRTP"
+            description: "Build submitted via Travis CI"
+            version: 2
+          notification_email: pabuhler@cisco.com
+          build_command_prepend: "./configure"
+          build_command: "make"
+          branch_pattern: master
+      script:
+        - echo -n | openssl s_client -connect scan.coverity.com:443 | sed -ne '/-BEGIN CERTIFICATE-/,/-END CERTIFICATE-/p' | sudo tee -a /etc/ssl/certs/ca-

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ language: c
 
 env:
   global:
-    - secure: "YJSSinoWNfMicNYCdxsnlgZc9AIi1yKkgJTmKk41zRI23r8c5Z339Zl1p/boxOxD+YLCQshBYR00ckJXT9R8wQy0WhpWdA3YJYAMWjnVkbBMBNf3VEQSIvHwV8kLDBMPBikhks7b4ACPG3UYLsQrxUJFfJz4Grn7z8tbUedv1Gk="
+    - secure: "QD09MuUxftXRXtz7ZrB7S0NV/3O9yVhjvIlCSbXN8B87rNSDC8wxMThKMT7iZewnqGk53m+Up19PiMw5ERlHose5tm2cmY1FO/l+c9oAyWZaAL+4XNXryq6zI5F5FX5I61NbfqV3xcnfLTI2QIJF6WqDojNxhPjTbNzQGxIDuqw="
 
 matrix:
   include:


### PR DESCRIPTION
Current will run the scan on the master branch with
each build in master. If the frequency of commits
increases then can consider a coverity_scan branch.

Results can be found at:
https://scan.coverity.com/projects/cisco-libsrtp

This should resolve issue #251.