### PR TITLE
patch from libjingle

### DIFF
--- a/crypto/replay/rdbx.c
+++ b/crypto/replay/rdbx.c
@@ -142,7 +142,7 @@ int32_t srtp_index_guess(const srtp_xtd_seq_num_t *local,
     if (local_seq < seq_num_median) {
         if (s - local_seq > seq_num_median) {
             guess_roc = local_roc - 1;
-            difference = s - local_seq - seq_num_max;
+            difference = seq_num_max - s + local_seq;
         } else {
             guess_roc = local_roc;
             difference = s - local_seq;
@@ -150,7 +150,7 @@ int32_t srtp_index_guess(const srtp_xtd_seq_num_t *local,
     } else {
         if (local_seq - seq_num_median > s) {
             guess_roc = local_roc + 1;
-            difference = s - local_seq + seq_num_max;
+            difference = seq_num_max - local_seq + s;
         } else {
             guess_roc = local_roc;
             difference = s - local_seq;


### PR DESCRIPTION
This patch has been used in the Firefox code base for a long time.
It got originally landed in as part of a bigger patch referencing upstream libjingle as the source here https://bugzilla.mozilla.org/page.cgi?id=splinter.html&bug=792325&attachment=662542

I can't really explain or justify why it's good, but I did not wanted to withhold this in case it fixes a potential issue.
In other words: a real expert should review this :-)