### PR TITLE
Travis fixes

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,7 +20,7 @@ matrix:
           packages:
           - gcc-6
       script:
-        - ./configure
+        - CC=gcc-6 ./configure
         - make
         - make runtest
 
@@ -35,7 +35,7 @@ matrix:
           packages:
             - gcc-6
       script:
-        - ./configure --enable-openssl
+        - CC=gcc-6 ./configure --enable-openssl
         - make
         - make runtest
 
@@ -85,7 +85,7 @@ matrix:
             - gcc-6
             - valgrind
       script:
-        - ./configure --enable-openssl
+        - CC=gcc-6 ./configure --enable-openssl
         - make
         - make runtest-valgrind
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -20,7 +20,7 @@ matrix:
           packages:
           - gcc-6
       script:
-        - CC=gcc-6 ./configure
+        - CC=gcc-6 EXTRA_CFLAGS=-Werror ./configure
         - make
         - make runtest
 
@@ -35,7 +35,7 @@ matrix:
           packages:
             - gcc-6
       script:
-        - CC=gcc-6 ./configure --enable-openssl
+        - CC=gcc-6 EXTRA_CFLAGS=-Werror ./configure --enable-openssl
         - make
         - make runtest
 
@@ -48,7 +48,7 @@ matrix:
           packages:
             - clang
       script:
-        - CC=clang ./configure --enable-openssl
+        - CC=clang EXTRA_CFLAGS=-Werror ./configure --enable-openssl
         - make
         - make runtest
 
@@ -58,7 +58,7 @@ matrix:
         - TEST="osx XCode 8.2"
       osx_image: xcode8.2
       script:
-        - ./configure
+        - EXTRA_CFLAGS=-Werror ./configure
         - make
         - make runtest
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -107,12 +107,11 @@ matrix:
         - sudo docker exec --tty mipsX apt-get install build-essential -y
         - sudo docker exec --tty mipsX apt-get install gcc-mips-linux-gnu -y
       script:
-        - sudo docker exec --tty mipsX bash -c 'EXTRA_CFLAGS=-static CC=mips-linux-gnu-gcc ./configure --host=x86_64-linux-gnu'
+        - sudo docker exec --tty mipsX bash -c 'EXTRA_CFLAGS=-static CC=mips-linux-gnu-gcc ./configure --host=mips-linux-gnu'
         - sudo docker exec --tty mipsX make
+        - sudo docker kill mipsX
         - file test/srtp_driver
-        - test/srtp_driver -v
-        - file test/test_srtp
-        - test/test_srtp
+        - make runtest
 
     # coverity scan
     - os: linux

--- a/Makefile.in
+++ b/Makefile.in
@@ -157,8 +157,8 @@ endif
 
 crypto_testapp = $(AES_CALC) crypto/test/cipher_driver$(EXE) \
 	crypto/test/datatypes_driver$(EXE) crypto/test/kernel_driver$(EXE) \
-	crypto/test/sha1_driver$(EXE) \
-	crypto/test/stat_driver$(EXE)
+	crypto/test/sha1_driver$(EXE) crypto/test/stat_driver$(EXE) \
+	crypto/test/env$(EXE)
 
 testapp = $(crypto_testapp) test/srtp_driver$(EXE) test/replay_driver$(EXE) \
 	  test/roc_driver$(EXE) test/rdbx_driver$(EXE) test/rtpw$(EXE) \
@@ -207,10 +207,7 @@ crypto/test/cipher_driver$(EXE): crypto/test/cipher_driver.c test/getopt_s.c
 crypto/test/kernel_driver$(EXE): crypto/test/kernel_driver.c test/getopt_s.c
 	$(COMPILE) $(LDFLAGS) -o $@ $^ $(LIBS) $(SRTPLIB)
 
-crypto/test/rand_gen$(EXE): crypto/test/rand_gen.c test/getopt_s.c
-	$(COMPILE) $(LDFLAGS) -o $@ $^ $(LIBS) $(SRTPLIB)
-
-crypto/test/rand_gen_soak$(EXE): crypto/test/rand_gen_soak.c test/getopt_s.c
+crypto/test/env$(EXE): crypto/test/env.c test/getopt_s.c
 	$(COMPILE) $(LDFLAGS) -o $@ $^ $(LIBS) $(SRTPLIB)
 
 test: $(testapp)


### PR DESCRIPTION
A few small fixes to travis builds:

- fix mips build to use correct host 
- use gcc version that was installed by the script
- treat warnings as errors