### PR TITLE
fixed non-const redeclaraion error

### DIFF
--- a/crypto/kernel/crypto_kernel.c
+++ b/crypto/kernel/crypto_kernel.c
@@ -70,9 +70,9 @@ extern srtp_debug_module_t mod_alloc;
  * cipher types that can be included in the kernel
  */
 
-extern srtp_cipher_type_t srtp_null_cipher;
-extern srtp_cipher_type_t srtp_aes_icm_128;
-extern srtp_cipher_type_t srtp_aes_icm_256;
+extern const srtp_cipher_type_t srtp_null_cipher;
+extern const srtp_cipher_type_t srtp_aes_icm_128;
+extern const srtp_cipher_type_t srtp_aes_icm_256;
 #ifdef OPENSSL
 extern srtp_cipher_type_t srtp_aes_icm_192;
 extern srtp_cipher_type_t srtp_aes_gcm_128_openssl;
@@ -89,8 +89,8 @@ extern srtp_debug_module_t srtp_mod_aes_gcm;
  * auth func types that can be included in the kernel
  */
 
-extern srtp_auth_type_t srtp_null_auth;
-extern srtp_auth_type_t srtp_hmac;
+extern const srtp_auth_type_t srtp_null_auth;
+extern const srtp_auth_type_t srtp_hmac;
 
 /* debug modules for auth types */
 extern srtp_debug_module_t srtp_mod_hmac;


### PR DESCRIPTION
Without this fix libsrtp fails to compile as part of Firefox with errors like this:

 0:33.90 In file included from /Users/nohlmeier/src/mozilla-central/objdir-x86_64-apple/netwerk/srtp/src/Unified_c_netwerk_srtp_src0.c:83:
 0:33.90 /Users/nohlmeier/src/mozilla-central/netwerk/srtp/src/crypto/kernel/crypto_kernel.c:73:27: error: redeclaration of 'srtp_null_cipher' with a different type: 'srtp_cipher_type_t' (aka 'struct srtp_cipher_type_t') vs 'const srtp_cipher_type_t' (aka 'const struct srtp_cipher_type_t')
 0:33.90 extern srtp_cipher_type_t srtp_null_cipher;
 0:33.90                           ^
 0:33.90 /Users/nohlmeier/src/mozilla-central/netwerk/srtp/src/crypto/cipher/null_cipher.c:144:26: note: previous definition is here
 0:33.90 const srtp_cipher_type_t srtp_null_cipher = {
 0:33.90                          ^
