### PR TITLE
bitvector of length zero is not valid

### DIFF
--- a/crypto/math/datatypes.c
+++ b/crypto/math/datatypes.c
@@ -328,9 +328,11 @@ int bitvector_alloc(bitvector_t *v, unsigned long length)
     l = length / bits_per_word * bytes_per_word;
 
     /* allocate memory, then set parameters */
-    if (l == 0)
+    if (l == 0) {
         v->word = NULL;
-    else {
+        v->length = 0;
+        return -1;
+    } else {
         v->word = (uint32_t *)srtp_crypto_alloc(l);
         if (v->word == NULL) {
             v->length = 0;


### PR DESCRIPTION
Fixes coverity scan issues 179781

If the length resulted in l == 0 then there was no
allocation of word, which could subsequently be
dereferenced. Treat length of zero as invalid to
avoid dealing with it.