### PR TITLE
Return NULL when allocating memory of size zero

### DIFF
--- a/crypto/kernel/alloc.c
+++ b/crypto/kernel/alloc.c
@@ -71,6 +71,10 @@ void *srtp_crypto_alloc(size_t size)
 {
     void *ptr;
 
+    if (!size) {
+        return NULL;
+    }
+
     ptr = calloc(1, size);
 
     if (ptr) {


### PR DESCRIPTION
If calls to srtp_crypto_alloc are for zero-length buffer sizes, ensure we always return NULL since calloc does not necessarily do that.