### PR TITLE
Use explicit clang-format version on travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -71,7 +71,7 @@ matrix:
           packages:
             - clang-format-3.9
       script:
-        - ./format.sh -d
+        - CLANG_FORMAT=clang-format-3.9 ./format.sh -d
 
     # valgrind
     - os: linux


### PR DESCRIPTION
When travis upgrade's clang it breaks current
formatting that was done with 3.9 . Better to explicitly
set the version to use.