### PR TITLE
Fix memory access issue in srtp_get_session_keys()

### DIFF
--- a/srtp/srtp.c
+++ b/srtp/srtp.c
@@ -1604,7 +1604,8 @@ srtp_session_keys_t *srtp_get_session_keys(srtp_stream_ctx_t *stream,
     base_mki_start_location -= tag_len;
 
     for (i = 0; i < stream->num_master_keys; i++) {
-        if (stream->session_keys[i].mki_size != 0) {
+        if (stream->session_keys[i].mki_size != 0 &&
+            stream->session_keys[i].mki_size <= base_mki_start_location) {
             *mki_size = stream->session_keys[i].mki_size;
             mki_start_location = base_mki_start_location - *mki_size;
 


### PR DESCRIPTION
I found the following issue when using libsrtp with MKI:

There was a crash when calling `srtp_unprotect_mki()` on iOS platform.

Further research showed that the crash happened in `srtp_get_session_keys()`, because the received RTP packet’s size was smaller than expected: When packet size is greater than auth tag length but smaller than (auth tag length + MKI size), the `mki_start_location` would take on incredible huge values, leading to memory access issue when calling `memcmp()` later on.

Please see my code analysis below (actual values at the time added as comments):

```
1581 srtp_session_keys_t *srtp_get_session_keys(srtp_stream_ctx_t *stream,
1582                                            uint8_t *hdr,
1583                                            const unsigned int *pkt_octet_len,  // value of pkt_octet_len was "37"
1584                                            unsigned int *mki_size)
1585 {
1586     unsigned int base_mki_start_location = *pkt_octet_len;  // base_mki_start_location was initialized to "37"
1587     unsigned int mki_start_location = 0;

...

1604     base_mki_start_location -= tag_len;  // tag_len was "32", so base_mki_start_location takes value of "5" here
1605 
1606     for (i = 0; i < stream->num_master_keys; i++) {
1607         if (stream->session_keys[i].mki_size != 0) {
1608             *mki_size = stream->session_keys[i].mki_size;  // value of mki_size was "16" here
1609             mki_start_location = base_mki_start_location - *mki_size;  // since base_mki_start_location is "5" and *mki_size is "16", this calculation would lead to negative value of "-11" for mki_start_location
1610                                                                        // But since mki_start_location is of type "unsigned int", it would effectively take on incredibly huge value ("4294967285" on most platforms)
1611             if (mki_start_location >= *mki_size &&
1612                 memcmp(hdr + mki_start_location, stream->session_keys[i].mki_id,
1613                        *mki_size) == 0) {  // When calling memcmp() here with above huge mki_start_location value, it would lead to memory access violation and consecutive crash on iOS platform
1614                 return &stream->session_keys[i];
1615             }
1616         }
1617     }
```

Of course the partner still is at fault for sending us RTP packet with too small size in the first place, but that is a different issue. IMHO libsrtp should perform sanity check here in any case to prevent memory access issues.

Please consider this PRQ a suggestion to prevent the memory access issue.