### PR TITLE
Set gcm IV directly with EVP_CipherInit_ex

### DIFF
--- a/crypto/cipher/aes_gcm_ossl.c
+++ b/crypto/cipher/aes_gcm_ossl.c
@@ -220,20 +220,12 @@ static srtp_err_status_t srtp_aes_gcm_openssl_set_iv(
     debug_print(srtp_mod_aes_gcm, "setting iv: %s",
                 v128_hex_string((v128_t *)iv));
 
-    if (!EVP_CipherInit_ex(c->ctx, NULL, NULL, NULL, NULL,
-                           (c->dir == srtp_direction_encrypt ? 1 : 0))) {
-        return (srtp_err_status_init_fail);
-    }
-
-    /* set IV len  and the IV value, the followiong 3 calls are required */
     if (!EVP_CIPHER_CTX_ctrl(c->ctx, EVP_CTRL_GCM_SET_IVLEN, 12, 0)) {
         return (srtp_err_status_init_fail);
     }
-    if (!EVP_CIPHER_CTX_ctrl(c->ctx, EVP_CTRL_GCM_SET_IV_FIXED, -1,
-                             (void *)iv)) {
-        return (srtp_err_status_init_fail);
-    }
-    if (!EVP_CIPHER_CTX_ctrl(c->ctx, EVP_CTRL_GCM_IV_GEN, 0, (void *)iv)) {
+
+    if (!EVP_CipherInit_ex(c->ctx, NULL, NULL, NULL, iv,
+                           (c->dir == srtp_direction_encrypt ? 1 : 0))) {
         return (srtp_err_status_init_fail);
     }
 


### PR DESCRIPTION
Setting the IV directly with EVP_CipherInit_ex will
save two calls to openssl and simplify the code.

There is a comment that the 3 calls are required but
I am not sure why, EVP_CTRL_GCM_SET_IV_FIXED will
just store the vector and EVP_CTRL_GCM_IV_GEN will use
it internally and then increment the last digits before
returning it in iv variable passed in.
EVP_CipherInit_ex will store the iv and use it internally.
Incrementing and retrieving the new IV is not required for
SRTP-GCM, a new IV is used for each packet.

Tested with openssl 1.0.1d & 1.0.2g

This will also address the issue with #371 