### PR TITLE
Add extern to global variables

### DIFF
--- a/crypto/include/cipher_types.h
+++ b/crypto/include/cipher_types.h
@@ -44,38 +44,38 @@
  * cipher types that can be included in the kernel
  */
 
-const srtp_cipher_type_t srtp_null_cipher;
-const srtp_cipher_type_t srtp_aes_icm_128;
-const srtp_cipher_type_t srtp_aes_icm_256;
+extern const srtp_cipher_type_t srtp_null_cipher;
+extern const srtp_cipher_type_t srtp_aes_icm_128;
+extern const srtp_cipher_type_t srtp_aes_icm_256;
 #ifdef OPENSSL
-const srtp_cipher_type_t srtp_aes_icm_192;
-const srtp_cipher_type_t srtp_aes_gcm_128_openssl;
-const srtp_cipher_type_t srtp_aes_gcm_256_openssl;
+extern const srtp_cipher_type_t srtp_aes_icm_192;
+extern const srtp_cipher_type_t srtp_aes_gcm_128_openssl;
+extern const srtp_cipher_type_t srtp_aes_gcm_256_openssl;
 #endif
 
 /*
  * auth func types that can be included in the kernel
  */
 
-const srtp_auth_type_t srtp_null_auth;
-const srtp_auth_type_t srtp_hmac;
+extern const srtp_auth_type_t srtp_null_auth;
+extern const srtp_auth_type_t srtp_hmac;
 
 /*
  * other generic debug modules that can be included in the kernel
  */
 
-srtp_debug_module_t srtp_mod_auth;
-srtp_debug_module_t srtp_mod_cipher;
-srtp_debug_module_t mod_stat;
-srtp_debug_module_t mod_alloc;
+extern srtp_debug_module_t srtp_mod_auth;
+extern srtp_debug_module_t srtp_mod_cipher;
+extern srtp_debug_module_t mod_stat;
+extern srtp_debug_module_t mod_alloc;
 
 /* debug modules for cipher types */
-srtp_debug_module_t srtp_mod_aes_icm;
+extern srtp_debug_module_t srtp_mod_aes_icm;
 #ifdef OPENSSL
-srtp_debug_module_t srtp_mod_aes_gcm;
+extern srtp_debug_module_t srtp_mod_aes_gcm;
 #endif
 
 /* debug modules for auth types */
-srtp_debug_module_t srtp_mod_hmac;
+extern srtp_debug_module_t srtp_mod_hmac;
 
 #endif

--- a/crypto/include/cipher_types.h
+++ b/crypto/include/cipher_types.h
@@ -66,8 +66,8 @@ extern const srtp_auth_type_t srtp_hmac;
 
 extern srtp_debug_module_t srtp_mod_auth;
 extern srtp_debug_module_t srtp_mod_cipher;
-extern srtp_debug_module_t mod_stat;
-extern srtp_debug_module_t mod_alloc;
+extern srtp_debug_module_t srtp_mod_stat;
+extern srtp_debug_module_t srtp_mod_alloc;
 
 /* debug modules for cipher types */
 extern srtp_debug_module_t srtp_mod_aes_icm;

--- a/crypto/kernel/alloc.c
+++ b/crypto/kernel/alloc.c
@@ -51,7 +51,7 @@
 
 /* the debug module for memory allocation */
 
-srtp_debug_module_t mod_alloc = {
+srtp_debug_module_t srtp_mod_alloc = {
     0,      /* debugging is off by default */
     "alloc" /* printable name for module   */
 };
@@ -78,9 +78,9 @@ void *srtp_crypto_alloc(size_t size)
     ptr = calloc(1, size);
 
     if (ptr) {
-        debug_print(mod_alloc, "(location: %p) allocated", ptr);
+        debug_print(srtp_mod_alloc, "(location: %p) allocated", ptr);
     } else {
-        debug_print(mod_alloc, "allocation failed (asked for %d bytes)\n",
+        debug_print(srtp_mod_alloc, "allocation failed (asked for %d bytes)\n",
                     size);
     }
 
@@ -89,7 +89,7 @@ void *srtp_crypto_alloc(size_t size)
 
 void srtp_crypto_free(void *ptr)
 {
-    debug_print(mod_alloc, "(location: %p) freed", ptr);
+    debug_print(srtp_mod_alloc, "(location: %p) freed", ptr);
 
     free(ptr);
 }

--- a/crypto/kernel/crypto_kernel.c
+++ b/crypto/kernel/crypto_kernel.c
@@ -101,11 +101,11 @@ srtp_err_status_t srtp_crypto_kernel_init()
     if (status) {
         return status;
     }
-    status = srtp_crypto_kernel_load_debug_module(&mod_stat);
+    status = srtp_crypto_kernel_load_debug_module(&srtp_mod_stat);
     if (status) {
         return status;
     }
-    status = srtp_crypto_kernel_load_debug_module(&mod_alloc);
+    status = srtp_crypto_kernel_load_debug_module(&srtp_mod_alloc);
     if (status) {
         return status;
     }

--- a/crypto/kernel/crypto_kernel.c
+++ b/crypto/kernel/crypto_kernel.c
@@ -512,7 +512,7 @@ srtp_err_status_t srtp_crypto_kernel_load_debug_module(
     srtp_kernel_debug_module_t *kdm, *new;
 
     /* defensive coding */
-    if (new_dm == NULL) {
+    if (new_dm == NULL || new_dm->name == NULL) {
         return srtp_err_status_bad_param;
     }
 

--- a/crypto/math/stat.c
+++ b/crypto/math/stat.c
@@ -49,7 +49,7 @@
 
 #include "stat.h"
 
-srtp_debug_module_t mod_stat = {
+srtp_debug_module_t srtp_mod_stat = {
     0,                  /* debugging is off by default */
     (char *)"stat test" /* printable module name       */
 };
@@ -72,7 +72,7 @@ srtp_err_status_t stat_test_monobit(uint8_t *data)
         data++;
     }
 
-    debug_print(mod_stat, "bit count: %d", ones_count);
+    debug_print(srtp_mod_stat, "bit count: %d", ones_count);
 
     if ((ones_count < 9725) || (ones_count > 10275))
         return srtp_err_status_algo_fail;
@@ -100,7 +100,7 @@ srtp_err_status_t stat_test_poker(uint8_t *data)
     poker *= (16.0 / 5000.0);
     poker -= 5000.0;
 
-    debug_print(mod_stat, "poker test: %f\n", poker);
+    debug_print(srtp_mod_stat, "poker test: %f\n", poker);
 
     if ((poker < 2.16) || (poker > 46.17))
         return srtp_err_status_algo_fail;
@@ -139,14 +139,14 @@ srtp_err_status_t stat_test_runs(uint8_t *data)
 
                     /* check for long runs */
                     if (state > 25) {
-                        debug_print(mod_stat, ">25 runs: %d", state);
+                        debug_print(srtp_mod_stat, ">25 runs: %d", state);
                         return srtp_err_status_algo_fail;
                     }
 
                 } else if (state < 0) {
                     /* prefix is a gap  */
                     if (state < -25) {
-                        debug_print(mod_stat, ">25 gaps: %d", state);
+                        debug_print(srtp_mod_stat, ">25 gaps: %d", state);
                         return srtp_err_status_algo_fail; /* long-runs test
                                                              failed   */
                     }
@@ -164,7 +164,7 @@ srtp_err_status_t stat_test_runs(uint8_t *data)
                 if (state > 0) {
                     /* prefix is a run */
                     if (state > 25) {
-                        debug_print(mod_stat, ">25 runs (2): %d", state);
+                        debug_print(srtp_mod_stat, ">25 runs (2): %d", state);
                         return srtp_err_status_algo_fail; /* long-runs test
                                                              failed   */
                     }
@@ -180,7 +180,7 @@ srtp_err_status_t stat_test_runs(uint8_t *data)
 
                     /* check for long gaps */
                     if (state < -25) {
-                        debug_print(mod_stat, ">25 gaps (2): %d", state);
+                        debug_print(srtp_mod_stat, ">25 gaps (2): %d", state);
                         return srtp_err_status_algo_fail;
                     }
 
@@ -195,12 +195,12 @@ srtp_err_status_t stat_test_runs(uint8_t *data)
         data++;
     }
 
-    if (mod_stat.on) {
-        debug_print(mod_stat, "runs test", NULL);
+    if (srtp_mod_stat.on) {
+        debug_print(srtp_mod_stat, "runs test", NULL);
         for (i = 0; i < 6; i++)
-            debug_print(mod_stat, "  runs[]: %d", runs[i]);
+            debug_print(srtp_mod_stat, "  runs[]: %d", runs[i]);
         for (i = 0; i < 6; i++)
-            debug_print(mod_stat, "  gaps[]: %d", gaps[i]);
+            debug_print(srtp_mod_stat, "  gaps[]: %d", gaps[i]);
     }
 
     /* check run and gap counts against the fixed limits */


### PR DESCRIPTION
Prevents multiple definitions. Depending on linker
it was possible that there would be one definition per
compilation unit.