### PR TITLE
Fix unprotect when pktlen < (2*mki_size + tag_len)

### DIFF
--- a/srtp/srtp.c
+++ b/srtp/srtp.c
@@ -1563,8 +1563,8 @@ srtp_session_keys_t *srtp_get_session_keys(srtp_stream_ctx_t *stream,
             *mki_size = stream->session_keys[i].mki_size;
             mki_start_location = base_mki_start_location - *mki_size;
 
-            if (memcmp(hdr + mki_start_location,
-                       stream->session_keys[i].mki_id, *mki_size) == 0) {
+            if (memcmp(hdr + mki_start_location, stream->session_keys[i].mki_id,
+                       *mki_size) == 0) {
                 return &stream->session_keys[i];
             }
         }

--- a/srtp/srtp.c
+++ b/srtp/srtp.c
@@ -1563,9 +1563,8 @@ srtp_session_keys_t *srtp_get_session_keys(srtp_stream_ctx_t *stream,
             *mki_size = stream->session_keys[i].mki_size;
             mki_start_location = base_mki_start_location - *mki_size;
 
-            if (mki_start_location >= *mki_size &&
-                memcmp(hdr + mki_start_location, stream->session_keys[i].mki_id,
-                       *mki_size) == 0) {
+            if (memcmp(hdr + mki_start_location,
+                       stream->session_keys[i].mki_id, *mki_size) == 0) {
                 return &stream->session_keys[i];
             }
         }


### PR DESCRIPTION
The condition mki_start_location >= *mki_size in
srtp_get_session_keys() should use base_mki_start_location.
Now the condition is false for packets < 2*mki_size + tag_len.
But as of commit d4bd43c the correct condition is now checked
earlier so we simply remove the expression altogether.