### PR TITLE
Travis nss build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -87,6 +87,26 @@ matrix:
         - make
         - make runtest
 
+    # osx build with nss
+    - os: osx
+      env:
+        - TEST="osx (nss)"
+      osx_image: xcode8.2
+      before_install:
+            - wget https://ftp.mozilla.org/pub/security/nss/releases/NSS_3_38_RTM/src/nss-3.38-with-nspr-4.19.tar.gz
+            - tar -xzvf nss-3.38-with-nspr-4.19.tar.gz
+            - pushd nss-3.38/nss
+            - USE_64=1 make nss_build_all
+            - pushd ../dist/$(<../dist/latest)
+            - export NSS_DIR=$(pwd)
+            - echo $NSS_DIR
+            - popd
+            - popd
+      script:
+        - EXTRA_CFLAGS=-Werror ./configure --enable-nss --with-nss-dir=$NSS_DIR
+        - make
+        - make runtest
+
     # code format check
     - os: linux
       env:

--- a/.travis.yml
+++ b/.travis.yml
@@ -52,6 +52,31 @@ matrix:
         - make
         - make runtest
 
+    # linux build with nss
+    - os: linux
+      env:
+        - TEST="linux gcc (nss)"
+      addons:
+        apt:
+          sources:
+            - ubuntu-toolchain-r-test
+          packages:
+            - gcc-6
+      before_install:
+            - wget https://ftp.mozilla.org/pub/security/nss/releases/NSS_3_38_RTM/src/nss-3.38-with-nspr-4.19.tar.gz
+            - tar -xzvf nss-3.38-with-nspr-4.19.tar.gz
+            - pushd nss-3.38/nss
+            - USE_64=1 make nss_build_all
+            - pushd ../dist/$(<../dist/latest)
+            - export NSS_DIR=$(pwd)
+            - echo $NSS_DIR
+            - popd
+            - popd
+      script:
+        - CC=gcc-6 EXTRA_CFLAGS=-Werror ./configure --enable-nss --with-nss-dir=$NSS_DIR
+        - make
+        - make runtest
+
     # default osx build with xcode (clang)
     - os: osx
       env:

--- a/.travis.yml
+++ b/.travis.yml
@@ -62,18 +62,9 @@ matrix:
             - ubuntu-toolchain-r-test
           packages:
             - gcc-6
-      before_install:
-            - wget https://ftp.mozilla.org/pub/security/nss/releases/NSS_3_38_RTM/src/nss-3.38-with-nspr-4.19.tar.gz
-            - tar -xzvf nss-3.38-with-nspr-4.19.tar.gz
-            - pushd nss-3.38/nss
-            - USE_64=1 make nss_build_all
-            - pushd ../dist/$(<../dist/latest)
-            - export NSS_DIR=$(pwd)
-            - echo $NSS_DIR
-            - popd
-            - popd
+            - libnss3-dev
       script:
-        - CC=gcc-6 EXTRA_CFLAGS=-Werror ./configure --enable-nss --with-nss-dir=$NSS_DIR
+        - CC=gcc-6 EXTRA_CFLAGS=-Werror ./configure --enable-nss
         - make
         - make runtest
 
@@ -93,17 +84,9 @@ matrix:
         - TEST="osx (nss)"
       osx_image: xcode8.2
       before_install:
-            - wget https://ftp.mozilla.org/pub/security/nss/releases/NSS_3_38_RTM/src/nss-3.38-with-nspr-4.19.tar.gz
-            - tar -xzvf nss-3.38-with-nspr-4.19.tar.gz
-            - pushd nss-3.38/nss
-            - USE_64=1 make nss_build_all
-            - pushd ../dist/$(<../dist/latest)
-            - export NSS_DIR=$(pwd)
-            - echo $NSS_DIR
-            - popd
-            - popd
+            - brew install nss
       script:
-        - EXTRA_CFLAGS=-Werror ./configure --enable-nss --with-nss-dir=$NSS_DIR
+        - PKG_CONFIG_PATH=/usr/local/opt/nss/lib/pkgconfig EXTRA_CFLAGS=-Werror ./configure --enable-nss
         - make
         - make runtest
 

--- a/Makefile.in
+++ b/Makefile.in
@@ -25,13 +25,16 @@ HAVE_PCAP = @HAVE_PCAP@
 # not possible to pass this in from the outside; we have to specify
 # it for any subprocesses we call. No support for dynamic linked
 # tests on Windows.
-ifneq ($(OS),Windows_NT)
-	UNAME_S = $(shell uname -s)
-	ifeq ($(UNAME_S),Linux)
-		FIND_LIBRARIES = LD_LIBRARY_PATH=$(CRYPTO_LIBDIR)
-	endif
-	ifeq ($(UNAME_S),Darwin)
-		FIND_LIBRARIES = DYLD_LIBRARY_PATH=$(CRYPTO_LIBDIR)
+ifneq ($(strip $(CRYPTO_LIBDIR)),)
+	ifneq ($(OS),Windows_NT)
+		UNAME_S = $(shell uname -s)
+		ifeq ($(UNAME_S),Linux)
+			FIND_LIBRARIES = LD_LIBRARY_PATH=$(CRYPTO_LIBDIR)
+		endif
+		ifeq ($(UNAME_S),Darwin)
+			FIND_LIBRARIES = DYLD_LIBRARY_PATH=$(CRYPTO_LIBDIR)
+		endif
+		CRYPTO_LIBDIR_FORWARD = CRYPTO_LIBDIR=$(CRYPTO_LIBDIR)
 	endif
 endif
 
@@ -49,9 +52,9 @@ runtest: test
 	$(FIND_LIBRARIES) test/roc_driver$(EXE) -v >/dev/null
 	$(FIND_LIBRARIES) test/replay_driver$(EXE) -v >/dev/null
 	$(FIND_LIBRARIES) test/dtls_srtp_driver$(EXE) >/dev/null
-	$(FIND_LIBRARIES) cd test; $(abspath $(srcdir))/test/rtpw_test.sh -w $(abspath $(srcdir))/test/words.txt >/dev/null
+	cd test; $(CRYPTO_LIBDIR_FORWARD) $(abspath $(srcdir))/test/rtpw_test.sh -w $(abspath $(srcdir))/test/words.txt >/dev/null
 ifeq (1, $(USE_EXTERNAL_CRYPTO))
-	$(FIND_LIBRARIES) cd test; $(abspath $(srcdir))/test/rtpw_test_gcm.sh -w $(abspath $(srcdir))/test/words.txt >/dev/null
+	cd test; $(CRYPTO_LIBDIR_FORWARD) $(abspath $(srcdir))/test/rtpw_test_gcm.sh -w $(abspath $(srcdir))/test/words.txt >/dev/null
 endif
 	@echo "libsrtp2 test applications passed."
 	$(MAKE) -C crypto runtest

--- a/configure
+++ b/configure
@@ -627,6 +627,8 @@ PCAP_LIB
 HAVE_PCAP
 HMAC_OBJS
 AES_ICM_OBJS
+nss_LIBS
+nss_CFLAGS
 CRYPTO_LIBDIR
 USE_EXTERNAL_CRYPTO
 crypto_LIBS
@@ -725,7 +727,9 @@ PKG_CONFIG
 PKG_CONFIG_PATH
 PKG_CONFIG_LIBDIR
 crypto_CFLAGS
-crypto_LIBS'
+crypto_LIBS
+nss_CFLAGS
+nss_LIBS'
 
 
 # Initialize some variables set by options.
@@ -1372,6 +1376,8 @@ Some influential environment variables:
   crypto_CFLAGS
               C compiler flags for crypto, overriding pkg-config
   crypto_LIBS linker flags for crypto, overriding pkg-config
+  nss_CFLAGS  C compiler flags for nss, overriding pkg-config
+  nss_LIBS    linker flags for nss, overriding pkg-config
 
 Use these variables to override the choices made by `configure' or to help
 it to find libraries and programs with nonstandard names/locations.
@@ -5711,15 +5717,23 @@ $as_echo_n "checking for user specified NSS directory... " >&6; }
 
 # Check whether --with-nss-dir was given.
 if test "${with_nss_dir+set}" = set; then :
-  withval=$with_nss_dir; if test -d $with_nss_dir/lib; then
-         CFLAGS="$CFLAGS -I$with_nss_dir/include/"
-         CFLAGS="$CFLAGS -I$with_nss_dir/../public/nss/"
+  withval=$with_nss_dir; if test "x$PKG_CONFIG" != "x" && test -f $with_nss_dir/lib/pkgconfig/nss.pc; then
+         if test "x$PKG_CONFIG_PATH" = "x"; then
+           export PKG_CONFIG_PATH="$with_nss_dir/lib/pkgconfig"
+         else
+           export PKG_CONFIG_PATH="$with_nss_dir/lib/pkgconfig:$PKG_CONFIG_PATH"
+         fi
+         { $as_echo "$as_me:${as_lineno-$LINENO}: result: $with_nss_dir" >&5
+$as_echo "$with_nss_dir" >&6; }
+       elif test -d $with_nss_dir/lib; then
+         CFLAGS="$CFLAGS -I$with_nss_dir/include"
+         CFLAGS="$CFLAGS -I$with_nss_dir/../public/nss"
          if test "x$LDFLAGS" = "x"; then
            LDFLAGS="-L$with_nss_dir/lib"
          else
            LDFLAGS="$LDFLAGS -L$with_nss_dir/lib"
          fi
-         LIBS="-lnss3 -lnssutil3 -lnspr4 $LIBS"
+         nss_skip_pkg_config=yes
          { $as_echo "$as_me:${as_lineno-$LINENO}: result: $with_nss_dir" >&5
 $as_echo "$with_nss_dir" >&6; }
        else
@@ -5729,12 +5743,111 @@ $as_echo "invalid" >&6; }
 $as_echo "$as_me: error: in \`$ac_pwd':" >&2;}
 as_fn_error $? "Invalid NSS location: $with_nss_dir
 See \`config.log' for more details" "$LINENO" 5; }
-      fi
+       fi
+       CRYPTO_LIBDIR=$with_nss_dir/lib
+
 else
   { $as_echo "$as_me:${as_lineno-$LINENO}: result: no" >&5
 $as_echo "no" >&6; }
 fi
 
+
+   if test "x$PKG_CONFIG" != "x" && test "$nss_skip_pkg_config" != "yes"; then
+
+pkg_failed=no
+{ $as_echo "$as_me:${as_lineno-$LINENO}: checking for nss" >&5
+$as_echo_n "checking for nss... " >&6; }
+
+if test -n "$nss_CFLAGS"; then
+    pkg_cv_nss_CFLAGS="$nss_CFLAGS"
+ elif test -n "$PKG_CONFIG"; then
+    if test -n "$PKG_CONFIG" && \
+    { { $as_echo "$as_me:${as_lineno-$LINENO}: \$PKG_CONFIG --exists --print-errors \"nss\""; } >&5
+  ($PKG_CONFIG --exists --print-errors "nss") 2>&5
+  ac_status=$?
+  $as_echo "$as_me:${as_lineno-$LINENO}: \$? = $ac_status" >&5
+  test $ac_status = 0; }; then
+  pkg_cv_nss_CFLAGS=`$PKG_CONFIG --cflags "nss" 2>/dev/null`
+		      test "x$?" != "x0" && pkg_failed=yes
+else
+  pkg_failed=yes
+fi
+ else
+    pkg_failed=untried
+fi
+if test -n "$nss_LIBS"; then
+    pkg_cv_nss_LIBS="$nss_LIBS"
+ elif test -n "$PKG_CONFIG"; then
+    if test -n "$PKG_CONFIG" && \
+    { { $as_echo "$as_me:${as_lineno-$LINENO}: \$PKG_CONFIG --exists --print-errors \"nss\""; } >&5
+  ($PKG_CONFIG --exists --print-errors "nss") 2>&5
+  ac_status=$?
+  $as_echo "$as_me:${as_lineno-$LINENO}: \$? = $ac_status" >&5
+  test $ac_status = 0; }; then
+  pkg_cv_nss_LIBS=`$PKG_CONFIG --libs "nss" 2>/dev/null`
+		      test "x$?" != "x0" && pkg_failed=yes
+else
+  pkg_failed=yes
+fi
+ else
+    pkg_failed=untried
+fi
+
+
+
+if test $pkg_failed = yes; then
+        { $as_echo "$as_me:${as_lineno-$LINENO}: result: no" >&5
+$as_echo "no" >&6; }
+
+if $PKG_CONFIG --atleast-pkgconfig-version 0.20; then
+        _pkg_short_errors_supported=yes
+else
+        _pkg_short_errors_supported=no
+fi
+        if test $_pkg_short_errors_supported = yes; then
+	        nss_PKG_ERRORS=`$PKG_CONFIG --short-errors --print-errors --cflags --libs "nss" 2>&1`
+        else
+	        nss_PKG_ERRORS=`$PKG_CONFIG --print-errors --cflags --libs "nss" 2>&1`
+        fi
+	# Put the nasty error message in config.log where it belongs
+	echo "$nss_PKG_ERRORS" >&5
+
+	as_fn_error $? "Package requirements (nss) were not met:
+
+$nss_PKG_ERRORS
+
+Consider adjusting the PKG_CONFIG_PATH environment variable if you
+installed software in a non-standard prefix.
+
+Alternatively, you may set the environment variables nss_CFLAGS
+and nss_LIBS to avoid the need to call pkg-config.
+See the pkg-config man page for more details." "$LINENO" 5
+elif test $pkg_failed = untried; then
+        { $as_echo "$as_me:${as_lineno-$LINENO}: result: no" >&5
+$as_echo "no" >&6; }
+	{ { $as_echo "$as_me:${as_lineno-$LINENO}: error: in \`$ac_pwd':" >&5
+$as_echo "$as_me: error: in \`$ac_pwd':" >&2;}
+as_fn_error $? "The pkg-config script could not be found or is too old.  Make sure it
+is in your PATH or set the PKG_CONFIG environment variable to the full
+path to pkg-config.
+
+Alternatively, you may set the environment variables nss_CFLAGS
+and nss_LIBS to avoid the need to call pkg-config.
+See the pkg-config man page for more details.
+
+To get pkg-config, see <http://pkg-config.freedesktop.org/>.
+See \`config.log' for more details" "$LINENO" 5; }
+else
+	nss_CFLAGS=$pkg_cv_nss_CFLAGS
+	nss_LIBS=$pkg_cv_nss_LIBS
+        { $as_echo "$as_me:${as_lineno-$LINENO}: result: yes" >&5
+$as_echo "yes" >&6; }
+	CFLAGS="$CFLAGS $nss_CFLAGS"
+         LIBS="$nss_LIBS $LIBS"
+fi
+   else
+     LIBS="-lnss3 -lnssutil3 -lnspr4 $LIBS"
+   fi
 
 
 $as_echo "#define GCM 1" >>confdefs.h
@@ -5750,8 +5863,6 @@ $as_echo "#define NSS 1" >>confdefs.h
    # TODO(RLB): Use NSS for KDF
 
    USE_EXTERNAL_CRYPTO=1
-
-   CRYPTO_LIBDIR=$with_nss_dir/lib
 
 else
    AES_ICM_OBJS="crypto/cipher/aes_icm.o crypto/cipher/aes.o"

--- a/configure
+++ b/configure
@@ -5846,7 +5846,122 @@ $as_echo "yes" >&6; }
          LIBS="$nss_LIBS $LIBS"
 fi
    else
-     LIBS="-lnss3 -lnssutil3 -lnspr4 $LIBS"
+     for ac_header in nss.h
+do :
+  ac_fn_c_check_header_compile "$LINENO" "nss.h" "ac_cv_header_nss_h" "$ac_includes_default
+"
+if test "x$ac_cv_header_nss_h" = xyes; then :
+  cat >>confdefs.h <<_ACEOF
+#define HAVE_NSS_H 1
+_ACEOF
+
+else
+  { { $as_echo "$as_me:${as_lineno-$LINENO}: error: in \`$ac_pwd':" >&5
+$as_echo "$as_me: error: in \`$ac_pwd':" >&2;}
+as_fn_error $? "can't find useable NSS headers
+See \`config.log' for more details" "$LINENO" 5; }
+fi
+
+done
+
+     { $as_echo "$as_me:${as_lineno-$LINENO}: checking for PR_GetError in -lnspr4" >&5
+$as_echo_n "checking for PR_GetError in -lnspr4... " >&6; }
+if ${ac_cv_lib_nspr4_PR_GetError+:} false; then :
+  $as_echo_n "(cached) " >&6
+else
+  ac_check_lib_save_LIBS=$LIBS
+LIBS="-lnspr4  $LIBS"
+cat confdefs.h - <<_ACEOF >conftest.$ac_ext
+/* end confdefs.h.  */
+
+/* Override any GCC internal prototype to avoid an error.
+   Use char because int might match the return type of a GCC
+   builtin and then its argument prototype would still apply.  */
+#ifdef __cplusplus
+extern "C"
+#endif
+char PR_GetError ();
+int
+main ()
+{
+return PR_GetError ();
+  ;
+  return 0;
+}
+_ACEOF
+if ac_fn_c_try_link "$LINENO"; then :
+  ac_cv_lib_nspr4_PR_GetError=yes
+else
+  ac_cv_lib_nspr4_PR_GetError=no
+fi
+rm -f core conftest.err conftest.$ac_objext \
+    conftest$ac_exeext conftest.$ac_ext
+LIBS=$ac_check_lib_save_LIBS
+fi
+{ $as_echo "$as_me:${as_lineno-$LINENO}: result: $ac_cv_lib_nspr4_PR_GetError" >&5
+$as_echo "$ac_cv_lib_nspr4_PR_GetError" >&6; }
+if test "x$ac_cv_lib_nspr4_PR_GetError" = xyes; then :
+  cat >>confdefs.h <<_ACEOF
+#define HAVE_LIBNSPR4 1
+_ACEOF
+
+  LIBS="-lnspr4 $LIBS"
+
+else
+  { $as_echo "$as_me:${as_lineno-$LINENO}: WARNING: can't find libnspr4" >&5
+$as_echo "$as_me: WARNING: can't find libnspr4" >&2;}
+fi
+
+     { $as_echo "$as_me:${as_lineno-$LINENO}: checking for NSS_NoDB_Init in -lnss3" >&5
+$as_echo_n "checking for NSS_NoDB_Init in -lnss3... " >&6; }
+if ${ac_cv_lib_nss3_NSS_NoDB_Init+:} false; then :
+  $as_echo_n "(cached) " >&6
+else
+  ac_check_lib_save_LIBS=$LIBS
+LIBS="-lnss3  $LIBS"
+cat confdefs.h - <<_ACEOF >conftest.$ac_ext
+/* end confdefs.h.  */
+
+/* Override any GCC internal prototype to avoid an error.
+   Use char because int might match the return type of a GCC
+   builtin and then its argument prototype would still apply.  */
+#ifdef __cplusplus
+extern "C"
+#endif
+char NSS_NoDB_Init ();
+int
+main ()
+{
+return NSS_NoDB_Init ();
+  ;
+  return 0;
+}
+_ACEOF
+if ac_fn_c_try_link "$LINENO"; then :
+  ac_cv_lib_nss3_NSS_NoDB_Init=yes
+else
+  ac_cv_lib_nss3_NSS_NoDB_Init=no
+fi
+rm -f core conftest.err conftest.$ac_objext \
+    conftest$ac_exeext conftest.$ac_ext
+LIBS=$ac_check_lib_save_LIBS
+fi
+{ $as_echo "$as_me:${as_lineno-$LINENO}: result: $ac_cv_lib_nss3_NSS_NoDB_Init" >&5
+$as_echo "$ac_cv_lib_nss3_NSS_NoDB_Init" >&6; }
+if test "x$ac_cv_lib_nss3_NSS_NoDB_Init" = xyes; then :
+  cat >>confdefs.h <<_ACEOF
+#define HAVE_LIBNSS3 1
+_ACEOF
+
+  LIBS="-lnss3 $LIBS"
+
+else
+  { { $as_echo "$as_me:${as_lineno-$LINENO}: error: in \`$ac_pwd':" >&5
+$as_echo "$as_me: error: in \`$ac_pwd':" >&2;}
+as_fn_error $? "can't find useable libnss3
+See \`config.log' for more details" "$LINENO" 5; }
+fi
+
    fi
 
 

--- a/configure.ac
+++ b/configure.ac
@@ -330,7 +330,16 @@ elif test "$enable_nss" = "yes"; then
        [CFLAGS="$CFLAGS $nss_CFLAGS"
          LIBS="$nss_LIBS $LIBS"])
    else
-     LIBS="-lnss3 -lnssutil3 -lnspr4 $LIBS"
+     AC_CHECK_HEADERS(
+       [nss.h],
+       [], [AC_MSG_FAILURE([can't find useable NSS headers])],
+       [AC_INCLUDES_DEFAULT])
+     AC_CHECK_LIB(
+       [nspr4], [PR_GetError],
+       [], [AC_MSG_WARN([can't find libnspr4])])
+     AC_CHECK_LIB(
+       [nss3], [NSS_NoDB_Init],
+       [], [AC_MSG_FAILURE([can't find useable libnss3])])
    fi
 
    AC_DEFINE([GCM], [1], [Define this to use AES-GCM.])

--- a/configure.ac
+++ b/configure.ac
@@ -301,21 +301,37 @@ elif test "$enable_nss" = "yes"; then
    AC_MSG_CHECKING([for user specified NSS directory])
    AC_ARG_WITH([nss-dir],
       [AS_HELP_STRING([--with-nss-dir], [Location of NSS installation])],
-      [if test -d $with_nss_dir/lib; then
-         CFLAGS="$CFLAGS -I$with_nss_dir/include/"
-         CFLAGS="$CFLAGS -I$with_nss_dir/../public/nss/"
+      [if test "x$PKG_CONFIG" != "x" && test -f $with_nss_dir/lib/pkgconfig/nss.pc; then
+         if test "x$PKG_CONFIG_PATH" = "x"; then
+           export PKG_CONFIG_PATH="$with_nss_dir/lib/pkgconfig"
+         else
+           export PKG_CONFIG_PATH="$with_nss_dir/lib/pkgconfig:$PKG_CONFIG_PATH"
+         fi
+         AC_MSG_RESULT([$with_nss_dir])
+       elif test -d $with_nss_dir/lib; then
+         CFLAGS="$CFLAGS -I$with_nss_dir/include"
+         CFLAGS="$CFLAGS -I$with_nss_dir/../public/nss"
          if test "x$LDFLAGS" = "x"; then
            LDFLAGS="-L$with_nss_dir/lib"
          else
            LDFLAGS="$LDFLAGS -L$with_nss_dir/lib"
          fi
-         LIBS="-lnss3 -lnssutil3 -lnspr4 $LIBS"
+         nss_skip_pkg_config=yes
          AC_MSG_RESULT([$with_nss_dir])
        else
          AC_MSG_RESULT([invalid])
          AC_MSG_FAILURE([Invalid NSS location: $with_nss_dir])
-      fi],
+       fi
+       AC_SUBST([CRYPTO_LIBDIR], [$with_nss_dir/lib])],
       [AC_MSG_RESULT([no])])
+
+   if test "x$PKG_CONFIG" != "x" && test "$nss_skip_pkg_config" != "yes"; then
+     PKG_CHECK_MODULES([nss], [nss],
+       [CFLAGS="$CFLAGS $nss_CFLAGS"
+         LIBS="$nss_LIBS $LIBS"])
+   else
+     LIBS="-lnss3 -lnssutil3 -lnspr4 $LIBS"
+   fi
 
    AC_DEFINE([GCM], [1], [Define this to use AES-GCM.])
    AC_DEFINE([NSS], [1], [Define this to use NSS crypto.])
@@ -327,7 +343,6 @@ elif test "$enable_nss" = "yes"; then
    # TODO(RLB): Use NSS for KDF
 
    AC_SUBST([USE_EXTERNAL_CRYPTO], [1])
-   AC_SUBST([CRYPTO_LIBDIR], [$with_nss_dir/lib])
 else
    AES_ICM_OBJS="crypto/cipher/aes_icm.o crypto/cipher/aes.o"
    HMAC_OBJS="crypto/hash/hmac.o crypto/hash/sha1.o"

--- a/crypto/Makefile.in
+++ b/crypto/Makefile.in
@@ -27,13 +27,15 @@ RANLIB	= @RANLIB@
 # not possible to pass this in from the outside; we have to specify
 # it for any subprocesses we call. No support for dynamic linked
 # tests on Windows.
-ifneq ($(OS),Windows_NT)
-	UNAME_S = $(shell uname -s)
-	ifeq ($(UNAME_S),Linux)
-		FIND_LIBRARIES = LD_LIBRARY_PATH=../$(CRYPTO_LIBDIR)
-	endif
-	ifeq ($(UNAME_S),Darwin)
-		FIND_LIBRARIES = DYLD_LIBRARY_PATH=../$(CRYPTO_LIBDIR)
+ifneq ($(strip $(CRYPTO_LIBDIR)),)
+	ifneq ($(OS),Windows_NT)
+		UNAME_S = $(shell uname -s)
+		ifeq ($(UNAME_S),Linux)
+			FIND_LIBRARIES = LD_LIBRARY_PATH=$(CRYPTO_LIBDIR)
+		endif
+		ifeq ($(UNAME_S),Darwin)
+			FIND_LIBRARIES = DYLD_LIBRARY_PATH=$(CRYPTO_LIBDIR)
+		endif
 	endif
 endif
 


### PR DESCRIPTION
Add nss build to traivs on linux & osx.
nss is version 3.38 and built locally using the `make nss_build_all` command.