### PR TITLE
enable valgrind in nss builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,40 +9,44 @@ env:
 matrix:
   include:
 
-    # default linux build with gcc
+    # linux build
     - os: linux
       env:
-        - TEST="linux gcc"
-      addons:
-        apt:
-          sources:
-            - ubuntu-toolchain-r-test
-          packages:
-          - gcc-6
-      script:
-        - CC=gcc-6 EXTRA_CFLAGS=-Werror ./configure
-        - make
-        - make runtest
-
-    # linux build with openssl and gcc
-    - os: linux
-      env:
-        - TEST="linux gcc (openssl)"
+        - TEST="linux (gcc / valgrind)"
       addons:
         apt:
           sources:
             - ubuntu-toolchain-r-test
           packages:
             - gcc-6
+            - valgrind
+      script:
+        - CC=gcc-6 EXTRA_CFLAGS=-Werror ./configure
+        - make
+        - make runtest
+        - make runtest-valgrind
+
+    # linux build with openssl
+    - os: linux
+      env:
+        - TEST="linux openssl (gcc / valgrind)"
+      addons:
+        apt:
+          sources:
+            - ubuntu-toolchain-r-test
+          packages:
+            - gcc-6
+            - valgrind
       script:
         - CC=gcc-6 EXTRA_CFLAGS=-Werror ./configure --enable-openssl
         - make
         - make runtest
+        - make runtest-valgrind
 
     # linux build with openssl and clang
     - os: linux
       env:
-        - TEST="linux clang (openssl)"
+        - TEST="linux openssl (clang)"
       addons:
         apt:
           packages:
@@ -55,18 +59,20 @@ matrix:
     # linux build with nss
     - os: linux
       env:
-        - TEST="linux gcc (nss)"
+        - TEST="linux nss (gcc / valgrind)"
       addons:
         apt:
           sources:
             - ubuntu-toolchain-r-test
           packages:
             - gcc-6
+            - valgrind
             - libnss3-dev
       script:
         - CC=gcc-6 EXTRA_CFLAGS=-Werror ./configure --enable-nss
         - make
         - make runtest
+        - make runtest-valgrind
 
     # default osx build with xcode (clang)
     - os: osx
@@ -100,22 +106,6 @@ matrix:
             - clang-format-3.9
       script:
         - CLANG_FORMAT=clang-format-3.9 ./format.sh -d
-
-    # valgrind
-    - os: linux
-      env:
-        - TEST="valgrind (openssl)"
-      addons:
-        apt:
-          sources:
-            - ubuntu-toolchain-r-test
-          packages:
-            - gcc-6
-            - valgrind
-      script:
-        - CC=gcc-6 ./configure --enable-openssl
-        - make
-        - make runtest-valgrind
 
     # big-endian
     - os: linux

--- a/crypto/include/aes_gcm.h
+++ b/crypto/include/aes_gcm.h
@@ -66,6 +66,7 @@ typedef struct {
 
 #ifdef NSS
 
+#include <nss.h>
 #include <pk11pub.h>
 
 #define MAX_AD_SIZE 2048
@@ -74,6 +75,7 @@ typedef struct {
     int key_size;
     int tag_size;
     srtp_cipher_direction_t dir;
+    NSSInitContext *nss;
     PK11SymKey *key;
     uint8_t iv[12];
     uint8_t aad[MAX_AD_SIZE];

--- a/crypto/include/aes_icm_ext.h
+++ b/crypto/include/aes_icm_ext.h
@@ -65,6 +65,7 @@ typedef struct {
 
 #ifdef NSS
 
+#include <nss.h>
 #include <pk11pub.h>
 
 typedef struct {
@@ -72,6 +73,7 @@ typedef struct {
     v128_t offset;
     int key_size;
     uint8_t iv[16];
+    NSSInitContext *nss;
     PK11SymKey *key;
     PK11Context *ctx;
 } srtp_aes_icm_ctx_t;


### PR DESCRIPTION
After enabling valgrind with nss , static leaks where reported from NSS_NoDB_Init().
According to https://wiki.mozilla.org/NSS_Library_Init the correct solution for libsrtp was to change to NSS_InitContext().

@bifurcation what do you think?