### PR TITLE
Fixed compatibility with Visual Studio 2010

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -46,3 +46,13 @@ test/rtp_decoder
 test/rtpw
 test/srtp_driver
 test/test_srtp
+
+# Visual C++ intermediary and output directories and files
+Debug Dll/*
+Release Dll/*
+Debug/*
+Release/*
+ipch/*
+*.sdf
+*.suo
+*.user

--- a/.gitignore
+++ b/.gitignore
@@ -47,7 +47,7 @@ test/rtpw
 test/srtp_driver
 test/test_srtp
 
-# Visual C++ intermediary and output directories and files
+# Visual Studio intermediary and output directories and files
 Debug Dll/*
 Release Dll/*
 Debug/*
@@ -56,3 +56,4 @@ ipch/*
 *.sdf
 *.suo
 *.user
+*.opensdf

--- a/crypto/cipher/cipher.c
+++ b/crypto/cipher/cipher.c
@@ -171,7 +171,7 @@ int srtp_cipher_get_key_length(const srtp_cipher_t *c)
  */
 void srtp_cipher_rand_for_tests(void *dest, uint32_t len)
 {
-#if 0 //defined(HAVE_RAND_S) 
+#if 0 // defined(HAVE_RAND_S) 
     uint8_t *dst = (uint8_t *)dest;
     while (len) {
         unsigned int val;

--- a/crypto/cipher/cipher.c
+++ b/crypto/cipher/cipher.c
@@ -171,7 +171,7 @@ int srtp_cipher_get_key_length(const srtp_cipher_t *c)
  */
 void srtp_cipher_rand_for_tests(void *dest, uint32_t len)
 {
-#if defined(HAVE_RAND_S)
+#if 0 //defined(HAVE_RAND_S) 
     uint8_t *dst = (uint8_t *)dest;
     while (len) {
         unsigned int val;

--- a/crypto/kernel/err.c
+++ b/crypto/kernel/err.c
@@ -87,8 +87,10 @@ void srtp_err_report(srtp_err_reporting_level_t level, const char *format, ...)
         va_end(args);
     }
     if (srtp_err_report_handler != NULL) {
-        va_start(args, format);
         char msg[512];
+
+        va_start(args, format);
+
         if (vsnprintf(msg, sizeof(msg), format, args) > 0) {
             /* strip trailing \n, callback should not have one */
             size_t l = strlen(msg);

--- a/srtp/srtp.c
+++ b/srtp/srtp.c
@@ -696,9 +696,7 @@ static srtp_err_status_t srtp_kdf_init(srtp_kdf_t *kdf,
 
     {
         srtp_err_status_t stat;
-        stat = srtp_crypto_kernel_alloc_cipher(cipher_id,
-                                               &kdf->cipher,
-                                               key_len,
+        stat = srtp_crypto_kernel_alloc_cipher(cipher_id, &kdf->cipher, key_len,
                                                0);
         if (stat)
             return stat;

--- a/srtp/srtp.c
+++ b/srtp/srtp.c
@@ -88,7 +88,7 @@ static srtp_err_status_t srtp_validate_rtp_header(void *rtp_hdr,
     int rtp_header_len = octets_in_rtp_header + 4 * hdr->cc;
 
     if (*pkt_octet_len < octets_in_rtp_header)
-      return srtp_err_status_bad_param;
+        return srtp_err_status_bad_param;
 
     if (hdr->x == 1)
         rtp_header_len += octets_in_rtp_extn_hdr;
@@ -696,7 +696,10 @@ static srtp_err_status_t srtp_kdf_init(srtp_kdf_t *kdf,
 
     {
         srtp_err_status_t stat;
-        stat = srtp_crypto_kernel_alloc_cipher(cipher_id, &kdf->cipher, key_len, 0);
+        stat = srtp_crypto_kernel_alloc_cipher(cipher_id,
+                                               &kdf->cipher,
+                                               key_len,
+                                               0);
         if (stat)
             return stat;
 

--- a/srtp/srtp.c
+++ b/srtp/srtp.c
@@ -82,13 +82,14 @@ srtp_debug_module_t mod_srtp = {
 static srtp_err_status_t srtp_validate_rtp_header(void *rtp_hdr,
                                                   int *pkt_octet_len)
 {
-    if (*pkt_octet_len < octets_in_rtp_header)
-        return srtp_err_status_bad_param;
-
     srtp_hdr_t *hdr = (srtp_hdr_t *)rtp_hdr;
 
     /* Check RTP header length */
     int rtp_header_len = octets_in_rtp_header + 4 * hdr->cc;
+
+    if (*pkt_octet_len < octets_in_rtp_header)
+      return srtp_err_status_bad_param;
+
     if (hdr->x == 1)
         rtp_header_len += octets_in_rtp_extn_hdr;
 
@@ -693,16 +694,19 @@ static srtp_err_status_t srtp_kdf_init(srtp_kdf_t *kdf,
         break;
     }
 
-    srtp_err_status_t stat;
-    stat = srtp_crypto_kernel_alloc_cipher(cipher_id, &kdf->cipher, key_len, 0);
-    if (stat)
-        return stat;
+    {
+        srtp_err_status_t stat;
+        stat = srtp_crypto_kernel_alloc_cipher(cipher_id, &kdf->cipher, key_len, 0);
+        if (stat)
+            return stat;
 
-    stat = srtp_cipher_init(kdf->cipher, key);
-    if (stat) {
-        srtp_cipher_dealloc(kdf->cipher);
-        return stat;
+        stat = srtp_cipher_init(kdf->cipher, key);
+        if (stat) {
+            srtp_cipher_dealloc(kdf->cipher);
+            return stat;
+        }
     }
+
     return srtp_err_status_ok;
 }
 
@@ -4551,9 +4555,9 @@ srtp_err_status_t stream_get_protect_trailer_length(srtp_stream_ctx_t *stream,
                                                     uint32_t mki_index,
                                                     uint32_t *length)
 {
-    *length = 0;
-
     srtp_session_keys_t *session_key;
+
+    *length = 0;
 
     if (use_mki) {
         if (mki_index >= stream->num_master_keys) {

--- a/srtp/srtp.c
+++ b/srtp/srtp.c
@@ -83,12 +83,13 @@ static srtp_err_status_t srtp_validate_rtp_header(void *rtp_hdr,
                                                   int *pkt_octet_len)
 {
     srtp_hdr_t *hdr = (srtp_hdr_t *)rtp_hdr;
-
-    /* Check RTP header length */
-    int rtp_header_len = octets_in_rtp_header + 4 * hdr->cc;
+    int rtp_header_len;
 
     if (*pkt_octet_len < octets_in_rtp_header)
         return srtp_err_status_bad_param;
+
+    /* Check RTP header length */
+    rtp_header_len = octets_in_rtp_header + 4 * hdr->cc;
 
     if (hdr->x == 1)
         rtp_header_len += octets_in_rtp_extn_hdr;
@@ -679,6 +680,8 @@ static srtp_err_status_t srtp_kdf_init(srtp_kdf_t *kdf,
                                        int key_len)
 {
     srtp_cipher_type_id_t cipher_id;
+    srtp_err_status_t stat;
+
     switch (key_len) {
     case SRTP_AES_ICM_256_KEY_LEN_WSALT:
         cipher_id = SRTP_AES_ICM_256;
@@ -694,18 +697,14 @@ static srtp_err_status_t srtp_kdf_init(srtp_kdf_t *kdf,
         break;
     }
 
-    {
-        srtp_err_status_t stat;
-        stat = srtp_crypto_kernel_alloc_cipher(cipher_id, &kdf->cipher, key_len,
-                                               0);
-        if (stat)
-            return stat;
+    stat = srtp_crypto_kernel_alloc_cipher(cipher_id, &kdf->cipher, key_len, 0);
+    if (stat)
+        return stat;
 
-        stat = srtp_cipher_init(kdf->cipher, key);
-        if (stat) {
-            srtp_cipher_dealloc(kdf->cipher);
-            return stat;
-        }
+    stat = srtp_cipher_init(kdf->cipher, key);
+    if (stat) {
+        srtp_cipher_dealloc(kdf->cipher);
+        return stat;
     }
 
     return srtp_err_status_ok;

--- a/srtp2.vcxproj
+++ b/srtp2.vcxproj
@@ -42,46 +42,38 @@
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release Dll|Win32'" Label="Configuration">
     <ConfigurationType>DynamicLibrary</ConfigurationType>
-    <PlatformToolset>v140</PlatformToolset>
     <CharacterSet>Unicode</CharacterSet>
     <WholeProgramOptimization>true</WholeProgramOptimization>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release Dll|x64'" Label="Configuration">
     <ConfigurationType>DynamicLibrary</ConfigurationType>
-    <PlatformToolset>v140</PlatformToolset>
     <CharacterSet>Unicode</CharacterSet>
     <WholeProgramOptimization>true</WholeProgramOptimization>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug Dll|Win32'" Label="Configuration">
     <ConfigurationType>DynamicLibrary</ConfigurationType>
-    <PlatformToolset>v140</PlatformToolset>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug Dll|x64'" Label="Configuration">
     <ConfigurationType>DynamicLibrary</ConfigurationType>
-    <PlatformToolset>v140</PlatformToolset>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="Configuration">
     <ConfigurationType>StaticLibrary</ConfigurationType>
-    <PlatformToolset>v140</PlatformToolset>
     <CharacterSet>Unicode</CharacterSet>
     <WholeProgramOptimization>true</WholeProgramOptimization>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="Configuration">
     <ConfigurationType>StaticLibrary</ConfigurationType>
-    <PlatformToolset>v140</PlatformToolset>
     <CharacterSet>Unicode</CharacterSet>
     <WholeProgramOptimization>true</WholeProgramOptimization>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">
     <ConfigurationType>StaticLibrary</ConfigurationType>
-    <PlatformToolset>v140</PlatformToolset>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">
     <ConfigurationType>StaticLibrary</ConfigurationType>
-    <PlatformToolset>v140</PlatformToolset>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />


### PR DESCRIPTION
From the history of the Visual Studio project files, it looks like compatibility with VS2010 was intended since they were added in 701bb796bfb8a512859f7147649e2b835a321ff2. This change accomplishes that Visual Studio 2010 or higher can be used to build libsrtp with no other changes.

- Removed the specified platform toolset "v140" from the project file because it's probably irrelevant anyway. The Platform Toolset determines which compiler etc. to use for building, and each version of Visual Studio has its own default. There is no reason to override the default, unless there is a known security bug that I'm not aware of.
- Modified the err.c and srtp.c files so that all declarations of variables appear before any executable code. VS2010 doesn't support this. No functional changes were made to the code.
- Modified the srtp_cipher_rand_for_tests( ) function so it doesn't try to return an error from a function that returns void.
- Modified .gitignore to ignore Visual Studio related files