### PR TITLE
Fix rtp_decoder policy init on Raspbian OS

### DIFF
--- a/test/rtp_decoder.c
+++ b/test/rtp_decoder.c
@@ -120,7 +120,7 @@ int main(int argc, char *argv[])
     struct bpf_program fp;
     char filter_exp[MAX_FILTER] = "";
     rtp_decoder_t dec;
-    srtp_policy_t policy = {0};
+    srtp_policy_t policy = { 0 };
     srtp_err_status_t status;
     int len;
     int expected_len;

--- a/test/rtp_decoder.c
+++ b/test/rtp_decoder.c
@@ -120,7 +120,7 @@ int main(int argc, char *argv[])
     struct bpf_program fp;
     char filter_exp[MAX_FILTER] = "";
     rtp_decoder_t dec;
-    srtp_policy_t policy;
+    srtp_policy_t policy = {0};
     srtp_err_status_t status;
     int len;
     int expected_len;

--- a/test/rtp_decoder.c
+++ b/test/rtp_decoder.c
@@ -120,7 +120,7 @@ int main(int argc, char *argv[])
     struct bpf_program fp;
     char filter_exp[MAX_FILTER] = "";
     rtp_decoder_t dec;
-    srtp_policy_t policy = { 0 };
+    srtp_policy_t policy = { { 0 } };
     srtp_err_status_t status;
     int len;
     int expected_len;


### PR DESCRIPTION
Fix for issue #437