### PR TITLE
Rtp decoder update

### DIFF
--- a/test/rtp_decoder.c
+++ b/test/rtp_decoder.c
@@ -130,6 +130,28 @@ static struct srtp_crypto_suite srtp_crypto_suites[] = {
     {.can_name = NULL }
 };
 
+void rtp_decoder_srtp_log_handler(srtp_log_level_t level,
+                                  const char *msg,
+                                  void *data)
+{
+    char level_char = '?';
+    switch (level) {
+    case srtp_log_level_error:
+        level_char = 'e';
+        break;
+    case srtp_log_level_warning:
+        level_char = 'w';
+        break;
+    case srtp_log_level_info:
+        level_char = 'i';
+        break;
+    case srtp_log_level_debug:
+        level_char = 'd';
+        break;
+    }
+    fprintf(stderr, "SRTP-LOG [%c]: %s\n", level_char, msg);
+}
+
 int main(int argc, char *argv[])
 {
     char errbuf[PCAP_ERRBUF_SIZE];
@@ -165,6 +187,12 @@ int main(int argc, char *argv[])
         fprintf(stderr,
                 "error: srtp initialization failed with error code %d\n",
                 status);
+        exit(1);
+    }
+
+    status = srtp_install_log_handler(rtp_decoder_srtp_log_handler, NULL);
+    if (status) {
+        fprintf(stderr, "error: install log handler failed\n");
         exit(1);
     }
 
@@ -205,7 +233,7 @@ int main(int argc, char *argv[])
             sec_servs |= sec_serv_auth;
             break;
         case 'd':
-            status = srtp_crypto_kernel_set_debug_module(optarg_s, 1);
+            status = srtp_set_debug_module(optarg_s, 1);
             if (status) {
                 fprintf(stderr, "error: set debug module (%s) failed\n",
                         optarg_s);
@@ -267,7 +295,7 @@ int main(int argc, char *argv[])
     }
 
     if (do_list_mods) {
-        status = srtp_crypto_kernel_list_debug_modules();
+        status = srtp_list_debug_modules();
         if (status) {
             fprintf(stderr, "error: list of debug modules failed\n");
             exit(1);

--- a/test/rtp_decoder.c
+++ b/test/rtp_decoder.c
@@ -365,11 +365,7 @@ int main(int argc, char *argv[])
             int pad;
             expected_len = policy.rtp.cipher_key_len * 4 / 3;
             len = base64_string_to_octet_string(key, &pad, input_key,
-                                                expected_len);
-            if (pad != 0) {
-                fprintf(stderr, "error: padding in base64 unexpected\n");
-                exit(1);
-            }
+                                                strlen(input_key));
         } else {
             expected_len = policy.rtp.cipher_key_len * 2;
             len = hex_string_to_octet_string(key, input_key, expected_len);

--- a/test/rtp_decoder.c
+++ b/test/rtp_decoder.c
@@ -86,17 +86,31 @@
 
 struct srtp_crypto_suite {
     const char *can_name;
+    int gcm_on;
     int key_size;
     int tag_size;
 };
 
 static struct srtp_crypto_suite srtp_crypto_suites[] = {
-    {.can_name = "AES_CM_128_HMAC_SHA1_32", .key_size = 128, .tag_size = 4 },
 #if 0
-  {.can_name = "F8_128_HMAC_SHA1_32", .key_size = 128, .tag_size = 4},
+  {.can_name = "F8_128_HMAC_SHA1_32", .gcm_on = 0, .key_size = 128, .tag_size = 4},
 #endif
-    {.can_name = "AES_CM_128_HMAC_SHA1_32", .key_size = 128, .tag_size = 4 },
-    {.can_name = "AES_CM_128_HMAC_SHA1_80", .key_size = 128, .tag_size = 10 },
+    {.can_name = "AES_CM_128_HMAC_SHA1_32",
+     .gcm_on = 0,
+     .key_size = 128,
+     .tag_size = 4 },
+    {.can_name = "AES_CM_128_HMAC_SHA1_80",
+     .gcm_on = 0,
+     .key_size = 128,
+     .tag_size = 10 },
+    {.can_name = "AEAD_AES_128_GCM",
+     .gcm_on = 1,
+     .key_size = 128,
+     .tag_size = 16 },
+    {.can_name = "AEAD_AES_256_GCM",
+     .gcm_on = 1,
+     .key_size = 256,
+     .tag_size = 16 },
     {.can_name = NULL }
 };
 
@@ -207,6 +221,7 @@ int main(int argc, char *argv[])
             scs = *i_scsp;
             input_key = malloc(scs.key_size);
             sec_servs |= sec_serv_conf | sec_serv_auth;
+            gcm_on = scs.gcm_on;
             break;
         default:
             usage(argv[0]);
@@ -266,12 +281,12 @@ int main(int argc, char *argv[])
 #ifdef OPENSSL
                 switch (scs.key_size) {
                 case 128:
-                    srtp_crypto_policy_set_aes_gcm_128_8_auth(&policy.rtp);
-                    srtp_crypto_policy_set_aes_gcm_128_8_auth(&policy.rtcp);
+                    srtp_crypto_policy_set_aes_gcm_128_16_auth(&policy.rtp);
+                    srtp_crypto_policy_set_aes_gcm_128_16_auth(&policy.rtcp);
                     break;
                 case 256:
-                    srtp_crypto_policy_set_aes_gcm_256_8_auth(&policy.rtp);
-                    srtp_crypto_policy_set_aes_gcm_256_8_auth(&policy.rtcp);
+                    srtp_crypto_policy_set_aes_gcm_256_16_auth(&policy.rtp);
+                    srtp_crypto_policy_set_aes_gcm_256_16_auth(&policy.rtcp);
                     break;
                 }
 #else

--- a/test/rtp_decoder.c
+++ b/test/rtp_decoder.c
@@ -579,7 +579,7 @@ void usage(char *string)
 {
     fprintf(
         stderr,
-        "usage: %s [-d <debug>]* [[-k][-b] <key> [-a][-e]]\n"
+        "usage: %s [-d <debug>]* [[-k][-b] <key> [-a][-t][-e]]\n"
         "or     %s -l\n"
         "where  -a use message authentication\n"
         "       -e <key size> use encryption (use 128 or 256 for key size)\n"

--- a/test/rtp_decoder.h
+++ b/test/rtp_decoder.h
@@ -102,4 +102,8 @@ srtp_err_status_t rtp_decoder_init_srtp(rtp_decoder_t decoder,
 
 int rtp_decoder_deinit_srtp(rtp_decoder_t decoder);
 
+void rtp_decoder_srtp_log_handler(srtp_log_level_t level,
+                                  const char *msg,
+                                  void *data);
+
 #endif /* RTP_DECODER_H */


### PR DESCRIPTION
Update the rtp_decoder to changes in libsrtp from the last few years.
Includes better support for AES_GCM ciphers and AES_CM 192/256 ciphers.