### PR TITLE
crypto/cipher: Reset the EVP_CIPHER_CTX structure before each test

### DIFF
--- a/crypto/cipher/aes_gcm_ossl.c
+++ b/crypto/cipher/aes_gcm_ossl.c
@@ -192,6 +192,7 @@ static srtp_err_status_t srtp_aes_gcm_openssl_context_init(void *cv,
         break;
     }
 
+    EVP_CIPHER_CTX_reset(c->ctx);
     if (!EVP_CipherInit_ex(c->ctx, evp, NULL, key, NULL, 0)) {
         return (srtp_err_status_init_fail);
     }

--- a/crypto/cipher/aes_icm_ossl.c
+++ b/crypto/cipher/aes_icm_ossl.c
@@ -248,6 +248,7 @@ static srtp_err_status_t srtp_aes_icm_openssl_context_init(void *cv,
         break;
     }
 
+    EVP_CIPHER_CTX_reset(c->ctx);
     if (!EVP_EncryptInit_ex(c->ctx, evp, NULL, key, NULL)) {
         return srtp_err_status_fail;
     } else {


### PR DESCRIPTION
Reusing a EVP_CIPHER_CTX between EVP_*Init_ex() calls is not allowed
unless one calls EVP_CIPHER_CTX_reset() first.

EVP_EncryptInit_ex() expects the cipher context to be initialized, which
isn't done by EVP_CIPHER_CTX_new() in OpenSSL-1.1.x.