### PR TITLE
cmake support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -25,6 +25,7 @@ matrix:
         - make
         - make runtest
         - make runtest-valgrind
+        - make distclean
         - mkdir build && cd build
         - cmake ..
         - make
@@ -46,6 +47,7 @@ matrix:
         - make
         - make runtest
         - make runtest-valgrind
+        - make distclean
         - mkdir build && cd build
         - cmake -DENABLE_OPENSSL=ON ..
         - make
@@ -90,6 +92,7 @@ matrix:
         - EXTRA_CFLAGS=-Werror ./configure
         - make
         - make runtest
+        - make distclean
         - mkdir build && cd build
         - cmake ..
         - make
@@ -105,6 +108,7 @@ matrix:
         - PKG_CONFIG_PATH=/usr/local/opt/openssl/lib/pkgconfig EXTRA_CFLAGS=-Werror ./configure --enable-openssl
         - make
         - make runtest
+        - make distclean
         - mkdir build && cd build
         - cmake -DOPENSSL_ROOT_DIR=/usr/local/opt/openssl -DENABLE_OPENSSL=ON ..
         - make

--- a/.travis.yml
+++ b/.travis.yml
@@ -168,3 +168,14 @@ matrix:
           branch_pattern: master
       script:
         - echo -n | openssl s_client -connect scan.coverity.com:443 | sed -ne '/-BEGIN CERTIFICATE-/,/-END CERTIFICATE-/p' | sudo tee -a /etc/ssl/certs/ca-
+
+    # windows build
+    - os: windows
+      env:
+        - TEST="windows"
+
+      script:
+        - export PATH="c:\Program Files (x86)\Microsoft Visual Studio\2017\BuildTools\MSBuild\15.0\Bin":$PATH
+        - mkdir build && cd build
+        - cmake -G "Visual Studio 15 2017" ..
+        - msbuild.exe srtp2.sln -p:Configuration=Release

--- a/.travis.yml
+++ b/.travis.yml
@@ -25,6 +25,10 @@ matrix:
         - make
         - make runtest
         - make runtest-valgrind
+        - mkdir build && cd build
+        - cmake ..
+        - make
+        - make test
 
     # linux build with openssl
     - os: linux
@@ -42,6 +46,10 @@ matrix:
         - make
         - make runtest
         - make runtest-valgrind
+        - mkdir build && cd build
+        - cmake -DENABLE_OPENSSL=ON ..
+        - make
+        - make test
 
     # linux build with openssl and clang
     - os: linux
@@ -82,6 +90,10 @@ matrix:
         - EXTRA_CFLAGS=-Werror ./configure
         - make
         - make runtest
+        - mkdir build && cd build
+        - cmake ..
+        - make
+        - make test
 
     # osx build with openssl
     - os: osx
@@ -93,6 +105,10 @@ matrix:
         - PKG_CONFIG_PATH=/usr/local/opt/openssl/lib/pkgconfig EXTRA_CFLAGS=-Werror ./configure --enable-openssl
         - make
         - make runtest
+        - mkdir build && cd build
+        - cmake -DOPENSSL_ROOT_DIR=/usr/local/opt/openssl -DENABLE_OPENSSL=ON ..
+        - make
+        - make test
 
     # osx build with nss
     - os: osx
@@ -178,4 +194,5 @@ matrix:
         - export PATH="c:\Program Files (x86)\Microsoft Visual Studio\2017\BuildTools\MSBuild\15.0\Bin":$PATH
         - mkdir build && cd build
         - cmake -G "Visual Studio 15 2017" ..
-        - msbuild.exe srtp2.sln -p:Configuration=Release
+        - msbuild.exe libsrtp2.sln -p:Configuration=Release
+        - msbuild.exe RUN_TESTS.vcxproj -p:Configuration=Release

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,9 +5,12 @@ project(libsrtp2 LANGUAGES C)
 set(PACKAGE_VERSION 2.3.0)
 set(PACKAGE_STRING "${CMAKE_PROJECT_NAME} ${PACKAGE_VERSION}")
 
+include(TestBigEndian)
 include(CheckIncludeFile)
 include(CheckFunctionExists)
 include(CheckTypeSize)
+
+test_big_endian(WORDS_BIGENDIAN)
 
 check_include_file(arpa/inet.h HAVE_ARPA_INET_H)
 check_include_file(byteswap.h HAVE_BYTESWAP_H)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -51,7 +51,10 @@ endif()
 set(OPENSSL ${ENABLE_OPENSSL} CACHE BOOL INTERNAL)
 set(GCM ${ENABLE_OPENSSL} CACHE BOOL INTERNAL)
 
-configure_file(config_in_cmake.h ${CMAKE_CURRENT_SOURCE_DIR}/crypto/include/config.h)
+set(CONFIG_FILE_DIR ${CMAKE_CURRENT_BINARY_DIR})
+include_directories(${CONFIG_FILE_DIR})
+
+configure_file(config_in_cmake.h ${CONFIG_FILE_DIR}/config.h)
 add_definitions(-DHAVE_CONFIG_H)
 
 set(SOURCES_C
@@ -117,7 +120,6 @@ set(SOURCES_H
   crypto/include/auth.h
   crypto/include/cipher.h
   crypto/include/cipher_types.h
-  crypto/include/config.h
   crypto/include/crypto_kernel.h
   crypto/include/crypto_types.h
   crypto/include/datatypes.h
@@ -134,6 +136,7 @@ set(SOURCES_H
   include/srtp.h
   include/srtp_priv.h
   include/ut_sim.h
+  ${CONFIG_FILE_DIR}/config.h
 )
 
 source_group("src" FILES ${SOURCES_C})

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,69 +1,136 @@
-cmake_minimum_required (VERSION 2.8)
+cmake_minimum_required(VERSION 2.8)
 
-project(srtp2)
+project(libsrtp2 LANGUAGES C)
+
+set(PACKAGE_VERSION 2.3.0)
+set(PACKAGE_STRING "${CMAKE_PROJECT_NAME} ${PACKAGE_VERSION}")
+
+include(CheckIncludeFile)
+include(CheckFunctionExists)
+include(CheckTypeSize)
+
+check_include_file(arpa/inet.h HAVE_ARPA_INET_H)
+check_include_file(byteswap.h HAVE_BYTESWAP_H)
+check_include_file(inttypes.h HAVE_INTTYPES_H)
+check_include_file(machine/types.h HAVE_MACHINE_TYPES_H)
+check_include_file(netinet/in.h HAVE_NETINET_IN_H)
+check_include_file(stdint.h HAVE_STDINT_H)
+check_include_file(stdlib.h HAVE_STDLIB_H)
+check_include_file(sys/int_types.h HAVE_SYS_INT_TYPES_H)
+check_include_file(sys/socket.h HAVE_SYS_SOCKET_H)
+check_include_file(sys/types.h HAVE_SYS_TYPES_H)
+check_include_file(unistd.h HAVE_UNISTD_H)
+check_include_file(windows.h HAVE_WINDOWS_H)
+check_include_file(winsock2.h HAVE_WINSOCK2_H)
+
+check_function_exists(sigaction HAVE_SIGACTION)
+check_function_exists(inet_aton HAVE_INET_ATON)
+check_function_exists(usleep HAVE_USLEEP)
+
+check_type_size(uint8_t UINT8_T)
+check_type_size(uint16_t UINT16_T)
+check_type_size(uint32_t UINT32_T)
+check_type_size(uint64_t UINT64_T)
+check_type_size(int32_t INT32_T)
+check_type_size("unsigned long" SIZEOF_UNSIGNED_LONG)
+check_type_size("unsigned long long" SIZEOF_UNSIGNED_LONG_LONG)
+
+set(ENABLE_DEBUG_LOGGING OFF CACHE BOOL "Enable debug logging in all modules")
+set(ERR_REPORTING_STDOUT OFF CACHE BOOL "Enable logging to stdout")
+set(ERR_REPORTING_FILE "" CACHE FILEPATH "Use file for logging")
+set(ENABLE_OPENSSL OFF CACHE BOOL "Enable OpenSSL crypto engine")
+set(TEST_APPS ON CACHE BOOL "Build test applications")
+
+if(ENABLE_OPENSSL)
+  find_package(OpenSSL REQUIRED)
+  include_directories(${OPENSSL_INCLUDE_DIR})
+endif()
+set(OPENSSL ${ENABLE_OPENSSL} CACHE BOOL INTERNAL)
+set(GCM ${ENABLE_OPENSSL} CACHE BOOL INTERNAL)
+
+configure_file(config_in_cmake.h ${CMAKE_CURRENT_SOURCE_DIR}/crypto/include/config.h)
+add_definitions(-DHAVE_CONFIG_H)
 
 set(SOURCES_C
-	srtp/ekt.c
-	srtp/srtp.c
+  srtp/ekt.c
+  srtp/srtp.c
 )
 
 set(CIPHERS_SOURCES_C
-	crypto/cipher/aes.c
-	crypto/cipher/aes_icm.c
-	crypto/cipher/cipher.c
-	crypto/cipher/null_cipher.c
+  crypto/cipher/cipher.c
+  crypto/cipher/null_cipher.c
 )
+
+if(ENABLE_OPENSSL)
+  list(APPEND CIPHERS_SOURCES_C
+    crypto/cipher/aes_icm_ossl.c
+    crypto/cipher/aes_gcm_ossl.c
+  )
+else()
+  list(APPEND  CIPHERS_SOURCES_C
+    crypto/cipher/aes.c
+    crypto/cipher/aes_icm.c
+  )
+endif()
 
 set(HASHES_SOURCES_C
-	crypto/hash/auth.c
-	crypto/hash/hmac.c
-	crypto/hash/null_auth.c
-	crypto/hash/sha1.c
+    crypto/hash/auth.c
+    crypto/hash/null_auth.c
 )
 
+if(ENABLE_OPENSSL)
+  list(APPEND HASHES_SOURCES_C
+    crypto/hash/hmac_ossl.c
+  )
+else()
+  list(APPEND  HASHES_SOURCES_C
+    crypto/hash/hmac.c
+    crypto/hash/sha1.c
+  )
+endif()
+
 set(KERNEL_SOURCES_C
-	crypto/kernel/alloc.c
-	crypto/kernel/crypto_kernel.c
-	crypto/kernel/err.c
-	crypto/kernel/key.c
+  crypto/kernel/alloc.c
+  crypto/kernel/crypto_kernel.c
+  crypto/kernel/err.c
+  crypto/kernel/key.c
 )
 
 set(MATH_SOURCES_C
-	crypto/math/datatypes.c
-	crypto/math/stat.c
+  crypto/math/datatypes.c
+  crypto/math/stat.c
 )
 
 set(REPLAY_SOURCES_C
-	crypto/replay/rdb.c
-	crypto/replay/rdbx.c
-	crypto/replay/ut_sim.c
+  crypto/replay/rdb.c
+  crypto/replay/rdbx.c
+  crypto/replay/ut_sim.c
 )
 
 set(SOURCES_H
-	crypto/include/aes.h
-	crypto/include/aes_icm.h
-	crypto/include/alloc.h
-	crypto/include/auth.h
-	crypto/include/cipher.h
-	crypto/include/cipher_types.h
-	crypto/include/config.h
-	crypto/include/crypto_kernel.h
-	crypto/include/crypto_types.h
-	crypto/include/datatypes.h
-	crypto/include/err.h
-	crypto/include/hmac.h
-	crypto/include/integers.h
-	crypto/include/key.h
-	crypto/include/null_auth.h
-	crypto/include/null_cipher.h
-	crypto/include/rdb.h
-	crypto/include/rdbx.h
-	crypto/include/sha1.h
-	crypto/include/stat.h
-	include/ekt.h
-	include/srtp.h
-	include/srtp_priv.h
-	include/ut_sim.h
+  crypto/include/aes.h
+  crypto/include/aes_icm.h
+  crypto/include/alloc.h
+  crypto/include/auth.h
+  crypto/include/cipher.h
+  crypto/include/cipher_types.h
+  crypto/include/config.h
+  crypto/include/crypto_kernel.h
+  crypto/include/crypto_types.h
+  crypto/include/datatypes.h
+  crypto/include/err.h
+  crypto/include/hmac.h
+  crypto/include/integers.h
+  crypto/include/key.h
+  crypto/include/null_auth.h
+  crypto/include/null_cipher.h
+  crypto/include/rdb.h
+  crypto/include/rdbx.h
+  crypto/include/sha1.h
+  crypto/include/stat.h
+  include/srtp.h
+  include/srtp_priv.h
+  include/ut_sim.h
 )
 
 source_group("src" FILES ${SOURCES_C})
@@ -75,15 +142,38 @@ source_group("src\\Replay" FILES ${REPLAY_SOURCES_C})
 source_group("include" FILES ${SOURCES_H})
 
 add_library(srtp2 STATIC
-	${SOURCES_C}
-	${CIPHERS_SOURCES_C}
-	${HASHES_SOURCES_C}
-	${KERNEL_SOURCES_C}
-	${MATH_SOURCES_C}
-	${REPLAY_SOURCES_C}
-	${SOURCES_H}
+  ${SOURCES_C}
+  ${CIPHERS_SOURCES_C}
+  ${HASHES_SOURCES_C}
+  ${KERNEL_SOURCES_C}
+  ${MATH_SOURCES_C}
+  ${REPLAY_SOURCES_C}
+  ${SOURCES_H}
 )
 
 target_include_directories(srtp2 PUBLIC crypto/include include)
-configure_file(config.hw ${CMAKE_CURRENT_SOURCE_DIR}/crypto/include/config.h COPYONLY)
-add_definitions(-D_LIB -DHAVE_CONFIG_H)
+if(ENABLE_OPENSSL)
+  target_link_libraries(srtp2 OpenSSL::Crypto)
+endif()
+if(WIN32)
+  target_link_libraries(srtp2 ws2_32)
+endif()
+
+install(TARGETS srtp2 DESTINATION lib)
+install(FILES include/srtp.h crypto/include/auth.h
+  crypto/include/cipher.h
+  crypto/include/cipher_types.h
+  DESTINATION include/srtp2)
+
+if(TEST_APPS)
+  enable_testing()
+
+  add_executable(test_srtp test/test_srtp.c)
+  target_link_libraries(test_srtp srtp2)
+  add_test(test_srtp test_srtp)
+
+  add_executable(srtp_driver test/srtp_driver.c
+    test/util.c test/getopt_s.c)
+  target_link_libraries(srtp_driver srtp2)
+  add_test(srtp_driver srtp_driver -v)
+endif()

--- a/config_in_cmake.h
+++ b/config_in_cmake.h
@@ -30,6 +30,10 @@
 /* Define to use X86 inlined assembly code */
 #define HAVE_X86 1
 
+/* Define WORDS_BIGENDIAN to 1 if your processor stores words with the most
+ significant byte first (like Motorola and SPARC, unlike Intel). */
+#cmakedefine WORDS_BIGENDIAN 1
+
 /* Define to 1 if you have the <arpa/inet.h> header file. */
 #cmakedefine HAVE_ARPA_INET_H 1
 

--- a/config_in_cmake.h
+++ b/config_in_cmake.h
@@ -1,0 +1,101 @@
+/* clang-format off */
+
+/* Define to the full name and version of this package. */
+#cmakedefine PACKAGE_VERSION "@PACKAGE_VERSION@"
+
+/* Define to the version of this package. */
+#cmakedefine PACKAGE_STRING "@PACKAGE_STRING@"
+
+/* Define to enabled debug logging for all mudules. */
+#cmakedefine ENABLE_DEBUG_LOGGING 1
+
+/* Logging statments will be writen to this file. */
+#cmakedefine ERR_REPORTING_FILE "@ERR_REPORTING_FILE@"
+
+/* Define to redirect logging to stdout. */
+#cmakedefine ERR_REPORTING_STDOUT 1
+
+/* Define this to use OpenSSL crypto. */
+#cmakedefine OPENSSL 1
+
+/* Define this to use AES-GCM. */
+#cmakedefine GCM 1
+
+/* Define if building for a CISC machine (e.g. Intel). */
+#define CPU_CISC 1
+
+/* Define if building for a RISC machine (assume slow byte access). */
+/* #undef CPU_RISC */
+
+/* Define to use X86 inlined assembly code */
+#define HAVE_X86 1
+
+/* Define to 1 if you have the <arpa/inet.h> header file. */
+#cmakedefine HAVE_ARPA_INET_H 1
+
+/* Define to 1 if you have the <byteswap.h> header file. */
+#cmakedefine HAVE_BYTESWAP_H 1
+
+/* Define to 1 if you have the <inttypes.h> header file. */
+#cmakedefine HAVE_INTTYPES_H 1
+
+/* Define to 1 if you have the <machine/types.h> header file. */
+#cmakedefine HAVE_MACHINE_TYPES_H 1
+
+/* Define to 1 if you have the <netinet/in.h> header file. */
+#cmakedefine HAVE_NETINET_IN_H 1
+
+/* Define to 1 if you have the <stdint.h> header file. */
+#cmakedefine HAVE_STDINT_H 1
+
+/* Define to 1 if you have the <stdlib.h> header file. */
+#cmakedefine HAVE_STDLIB_H 1
+
+/* Define to 1 if you have the <sys/int_types.h> header file. */
+#cmakedefine HAVE_SYS_INT_TYPES_H 1
+
+/* Define to 1 if you have the <sys/socket.h> header file. */
+#cmakedefine HAVE_SYS_SOCKET_H 1
+
+/* Define to 1 if you have the <sys/types.h> header file. */
+#cmakedefine HAVE_SYS_TYPES_H 1
+
+/* Define to 1 if you have the <unistd.h> header file. */
+#cmakedefine HAVE_UNISTD_H 1
+
+/* Define to 1 if you have the <windows.h> header file. */
+#cmakedefine HAVE_WINDOWS_H 1
+
+/* Define to 1 if you have the <winsock2.h> header file. */
+#cmakedefine HAVE_WINSOCK2_H 1
+
+/* Define to 1 if you have the `inet_aton' function. */
+#cmakedefine HAVE_INET_ATON 1
+
+/* Define to 1 if you have the `sigaction' function. */
+#cmakedefine HAVE_SIGACTION 1
+
+/* Define to 1 if you have the `usleep' function. */
+#cmakedefine HAVE_USLEEP 1
+
+/* Define to 1 if the system has the type `uint8_t'. */
+#cmakedefine HAVE_UINT8_T 1
+
+/* Define to 1 if the system has the type `uint16_t'. */
+#cmakedefine HAVE_UINT16_T 1
+
+/* Define to 1 if the system has the type `uint32_t'. */
+#cmakedefine HAVE_UINT32_T 1
+
+/* Define to 1 if the system has the type `uint64_t'. */
+#cmakedefine HAVE_UINT64_T 1
+
+/* Define to 1 if the system has the type `int32_t'. */
+#cmakedefine HAVE_INT32_T 1
+
+/* The size of `unsigned long', as computed by sizeof. */
+@SIZEOF_UNSIGNED_LONG_CODE@
+
+/* The size of `unsigned long long', as computed by sizeof. */
+@SIZEOF_UNSIGNED_LONG_LONG_CODE@
+

--- a/test/test_srtp.c
+++ b/test/test_srtp.c
@@ -44,14 +44,14 @@
  */
 
 /*
- * Test specific.
- */
-#include "cutest.h"
-
-/*
  * libSRTP specific.
  */
 #include "../srtp/srtp.c" // Get access to static functions
+
+/*
+ * Test specific.
+ */
+#include "cutest.h"
 
 /*
  * Standard library.


### PR DESCRIPTION
This extends the cmake support added in #449.
It now enables cmake to be used cross platform and supports openssl and debug config options.
The idea is to support cmake as a complete alternative build system, replacing the checked in windows project files (#450).

cmake builds have been added to travis, including on windows. The ENABLE_OPENSSL option is also supported on windows but I did not manage to get travis to install openssl.

I am not a cmake expert so I am sure there are better ways of handling things but this is a start.