### PR TITLE
set xcode version in travis for some osx builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -105,6 +105,7 @@ matrix:
 
     # osx build with openssl
     - os: osx
+      osx_image: xcode11.2
       env:
         - TEST="osx openssl"
       before_install:
@@ -121,10 +122,9 @@ matrix:
 
     # osx build with nss
     - os: osx
+      osx_image: xcode11.2
       env:
         - TEST="osx nss"
-      before_install:
-            - brew install nss
       script:
         - PKG_CONFIG_PATH=/usr/local/opt/nss/lib/pkgconfig EXTRA_CFLAGS=-Werror ./configure --enable-nss
         - make


### PR DESCRIPTION
travis osx builds that use brew seam to need a
newer version of xcode in order to have a ruby
version that works. This really should have been
automatic on the travis side.
Nss is now pre installed.