### PR TITLE
Add extra command line options for more flexibility

### DIFF
--- a/include/srtp_priv.h
+++ b/include/srtp_priv.h
@@ -215,7 +215,7 @@ typedef struct {
  * srtcp_hdr_t represents a secure rtcp header
  *
  * in this implementation, an srtcp header is assumed to be 32-bit
- * alinged
+ * aligned
  */
 
 #ifndef WORDS_BIGENDIAN

--- a/test/rtp_decoder.h
+++ b/test/rtp_decoder.h
@@ -106,7 +106,8 @@ void rtp_decoder_dealloc(rtp_decoder_t rtp_ctx);
 
 int rtp_decoder_init(rtp_decoder_t dcdr,
                      srtp_policy_t policy,
-                     rtp_decoder_mode_t mode);
+                     rtp_decoder_mode_t mode,
+                     int rtp_packet_offset);
 
 int rtp_decoder_deinit(rtp_decoder_t decoder);
 


### PR DESCRIPTION
Allow the pcap file to be read from a physical file, but maintain
default stdin behaviour.

Allow the byte offset of the RTP packet to be specified such that if a
non-tcp transport is used (e.g. UDP) the RTP packet can still be read
correctly.