### PR TITLE
Do not use pkg-config for libcrypto when a custom OpenSSL directory is specified

### DIFF
--- a/configure
+++ b/configure
@@ -5479,38 +5479,27 @@ $as_echo_n "checking for user specified OpenSSL directory... " >&6; }
 
 # Check whether --with-openssl-dir was given.
 if test "${with_openssl_dir+set}" = set; then :
-  withval=$with_openssl_dir; if test "x$PKG_CONFIG" != "x" && test -f $with_openssl_dir/lib/pkgconfig/libcrypto.pc; then
-         if test "x$PKG_CONFIG_PATH" = "x"; then
-           export PKG_CONFIG_PATH="$with_openssl_dir/lib/pkgconfig"
-         else
-           export PKG_CONFIG_PATH="$with_openssl_dir/lib/pkgconfig:$PKG_CONFIG_PATH"
-         fi
-         { $as_echo "$as_me:${as_lineno-$LINENO}: result: $with_openssl_dir" >&5
+  withval=$with_openssl_dir; if test "x$(find "$with_openssl_dir/lib/." ! -name . -prune \( -type f -o -type l \) -name '*crypto.*' -print 2> /dev/null)" != "x"; then :
+  crypto_CFLAGS="-I$with_openssl_dir/include"
+          crypto_LIBS="-L$with_openssl_dir/lib -lcrypto"
+          { $as_echo "$as_me:${as_lineno-$LINENO}: result: $with_openssl_dir" >&5
 $as_echo "$with_openssl_dir" >&6; }
-       elif test -d $with_openssl_dir/lib; then
-         CFLAGS="$CFLAGS -I$with_openssl_dir/include"
-         if test "x$LDFLAGS" = "x"; then
-           LDFLAGS="-L$with_openssl_dir/lib"
-         else
-           LDFLAGS="$LDFLAGS -L$with_openssl_dir/lib"
-         fi
-         { $as_echo "$as_me:${as_lineno-$LINENO}: result: $with_openssl_dir" >&5
-$as_echo "$with_openssl_dir" >&6; }
-       else
-         { $as_echo "$as_me:${as_lineno-$LINENO}: result: invalid" >&5
-$as_echo "invalid" >&6; }
-         { { $as_echo "$as_me:${as_lineno-$LINENO}: error: in \`$ac_pwd':" >&5
-$as_echo "$as_me: error: in \`$ac_pwd':" >&2;}
-as_fn_error $? "Invalid OpenSSL location: $with_openssl_dir
-See \`config.log' for more details" "$LINENO" 5; }
-       fi
 else
-  { $as_echo "$as_me:${as_lineno-$LINENO}: result: no" >&5
+  { $as_echo "$as_me:${as_lineno-$LINENO}: result: invalid" >&5
+$as_echo "invalid" >&6; }
+          { { $as_echo "$as_me:${as_lineno-$LINENO}: error: in \`$ac_pwd':" >&5
+$as_echo "$as_me: error: in \`$ac_pwd':" >&2;}
+as_fn_error $? "Could not find a crypto library in \"$with_openssl_dir/lib\"
+See \`config.log' for more details" "$LINENO" 5; }
+fi
+else
+  with_openssl_dir="no"
+       { $as_echo "$as_me:${as_lineno-$LINENO}: result: no" >&5
 $as_echo "no" >&6; }
 fi
 
 
-   if test "x$PKG_CONFIG" != "x"; then
+   if test "$with_openssl_dir" = "no" && test "x$PKG_CONFIG" != "x"; then :
 
 pkg_failed=no
 { $as_echo "$as_me:${as_lineno-$LINENO}: checking for crypto" >&5
@@ -5600,11 +5589,10 @@ else
 	crypto_LIBS=$pkg_cv_crypto_LIBS
         { $as_echo "$as_me:${as_lineno-$LINENO}: result: yes" >&5
 $as_echo "yes" >&6; }
-	CFLAGS="$CFLAGS $crypto_CFLAGS"
-        LIBS="$crypto_LIBS $LIBS"
+
 fi
-   else
-     { $as_echo "$as_me:${as_lineno-$LINENO}: checking for dlopen in -ldl" >&5
+else
+  { $as_echo "$as_me:${as_lineno-$LINENO}: checking for dlopen in -ldl" >&5
 $as_echo_n "checking for dlopen in -ldl... " >&6; }
 if ${ac_cv_lib_dl_dlopen+:} false; then :
   $as_echo_n "(cached) " >&6
@@ -5648,11 +5636,11 @@ _ACEOF
   LIBS="-ldl $LIBS"
 
 else
-  { $as_echo "$as_me:${as_lineno-$LINENO}: WARNING: can't find libdl" >&5
-$as_echo "$as_me: WARNING: can't find libdl" >&2;}
+  { $as_echo "$as_me:${as_lineno-$LINENO}: WARNING: Can't find potential OpenSSL dependecny: libdl" >&5
+$as_echo "$as_me: WARNING: Can't find potential OpenSSL dependecny: libdl" >&2;}
 fi
 
-     { $as_echo "$as_me:${as_lineno-$LINENO}: checking for inflate in -lz" >&5
+      { $as_echo "$as_me:${as_lineno-$LINENO}: checking for inflate in -lz" >&5
 $as_echo_n "checking for inflate in -lz... " >&6; }
 if ${ac_cv_lib_z_inflate+:} false; then :
   $as_echo_n "(cached) " >&6
@@ -5696,11 +5684,16 @@ _ACEOF
   LIBS="-lz $LIBS"
 
 else
-  { $as_echo "$as_me:${as_lineno-$LINENO}: WARNING: can't find libz" >&5
-$as_echo "$as_me: WARNING: can't find libz" >&2;}
+  { $as_echo "$as_me:${as_lineno-$LINENO}: WARNING: Can't find potential OpenSSL dependency: libz" >&5
+$as_echo "$as_me: WARNING: Can't find potential OpenSSL dependency: libz" >&2;}
 fi
 
-   fi
+fi
+
+   if test "x$crypto_LIBS" != "x"; then :
+  CFLAGS="$CFLAGS $crypto_CFLAGS"
+      LIBS="$crypto_LIBS $LIBS"
+fi
 
    { $as_echo "$as_me:${as_lineno-$LINENO}: checking for library containing EVP_EncryptInit" >&5
 $as_echo_n "checking for library containing EVP_EncryptInit... " >&6; }

--- a/configure.ac
+++ b/configure.ac
@@ -220,35 +220,24 @@ if test "$enable_openssl" = "yes"; then
    AC_MSG_CHECKING([for user specified OpenSSL directory])
    AC_ARG_WITH([openssl-dir],
       [AS_HELP_STRING([--with-openssl-dir], [Location of OpenSSL installation])],
-      [if test "x$PKG_CONFIG" != "x" && test -f $with_openssl_dir/lib/pkgconfig/libcrypto.pc; then
-         if test "x$PKG_CONFIG_PATH" = "x"; then
-           export PKG_CONFIG_PATH="$with_openssl_dir/lib/pkgconfig"
-         else
-           export PKG_CONFIG_PATH="$with_openssl_dir/lib/pkgconfig:$PKG_CONFIG_PATH"
-         fi
-         AC_MSG_RESULT([$with_openssl_dir])
-       elif test -d $with_openssl_dir/lib; then
-         CFLAGS="$CFLAGS -I$with_openssl_dir/include"
-         if test "x$LDFLAGS" = "x"; then
-           LDFLAGS="-L$with_openssl_dir/lib"
-         else
-           LDFLAGS="$LDFLAGS -L$with_openssl_dir/lib"
-         fi
-         AC_MSG_RESULT([$with_openssl_dir])
-       else
-         AC_MSG_RESULT([invalid])
-         AC_MSG_FAILURE([Invalid OpenSSL location: $with_openssl_dir])
-       fi],
-      [AC_MSG_RESULT([no])])
+      [AS_IF(
+         [test "x$(find "$with_openssl_dir/lib/." ! -name . -prune \( -type f -o -type l \) -name '*crypto.*' -print 2> /dev/null)" != "x"],
+         [crypto_CFLAGS="-I$with_openssl_dir/include"
+          crypto_LIBS="-L$with_openssl_dir/lib -lcrypto"
+          AC_MSG_RESULT([$with_openssl_dir])],
+         [AC_MSG_RESULT([invalid])
+          AC_MSG_FAILURE([Could not find a crypto library in "$with_openssl_dir/lib"])])],
+      [with_openssl_dir="no"
+       AC_MSG_RESULT([no])])
 
-   if test "x$PKG_CONFIG" != "x"; then
-     PKG_CHECK_MODULES([crypto], [libcrypto >= 1.0.1],
-       [CFLAGS="$CFLAGS $crypto_CFLAGS"
-        LIBS="$crypto_LIBS $LIBS"])
-   else
-     AC_CHECK_LIB([dl], [dlopen], [], [AC_MSG_WARN([can't find libdl])])
-     AC_CHECK_LIB([z], [inflate], [], [AC_MSG_WARN([can't find libz])])
-   fi
+   AS_IF([test "$with_openssl_dir" = "no" && test "x$PKG_CONFIG" != "x"],
+     [PKG_CHECK_MODULES([crypto], [libcrypto >= 1.0.1])],
+     [AC_CHECK_LIB([dl], [dlopen], [], [AC_MSG_WARN([Can't find potential OpenSSL dependecny: libdl])])
+      AC_CHECK_LIB([z], [inflate], [], [AC_MSG_WARN([Can't find potential OpenSSL dependency: libz])])])
+
+   AS_IF([test "x$crypto_LIBS" != "x"],
+     [CFLAGS="$CFLAGS $crypto_CFLAGS"
+      LIBS="$crypto_LIBS $LIBS"])
 
    AC_SEARCH_LIBS([EVP_EncryptInit], [crypto],
      [], [AC_MSG_FAILURE([can't find openssl >= 1.0.1 crypto lib])])


### PR DESCRIPTION
When installing OpenSSL (using `make install`), it's possible to specify a `INSTALL_PREFIX` (this can also be set during configuration). This is similar to the customary `DESTDIR` mechanism, but not quite.

`DESTDIR` will not duplicate the entire `--prefix` hierarchy, but OpenSSL's `INSTALL_PREFIX` will..

Given a package "foo" configured with `configure --prefix=/opt/local`:
- The customary `make DESTDIR=/tmp/foo install` will install it to  `/tmp/foo/bin`, `/tmp/foo/lib`, etc.
- OpenSSL's `make INSTALL_PREFIX=/tmp/foo install` will install it to  `/tmp/foo/opt/local/bin`, `/tmp/foo/opt/local/lib`, etc.

Package config files are generated based on the provided `--prefix`. So even if installed to somewhere else, the package config file will still point to the final destination provided during configuration.

This configure script would call `pkg-config`, if available, also when `--with-openssl-dir` was used.

There are old and pedantic reasons for that, primarily relating to finding the correct dependencies and avoiding specifying the library multiple times (event though that doesn't hurt).

However, if the mentioned `INSTALL_PREFIX` mechanism was used to install OpenSSL, `pkg-config` would add flags pointing to the `--prefix` location used when building OpenSSL, not the provided `--with-openssl-dir`.

Since the crypto library is so ubiquitous, this would most likely end up using the system library instead, if the rest of the configure checks found the functions it's looking for in the system library.

If there happened to be a crypto library already at the given `--prefix`, that would be used (again provided the configure checks passed).

Both of those scenarios are probably not what you'd expect to happen.

To fix this, this removes the use of `pkg-config` when `--with-openssl-dir` is specified.

To further make sure that `--with-openssl-dir` functions as the override it was meant to be, the check for a `lib` directory under the specified location is changed to a more comprehensive check for the library itself.

It uses the `find` utility to look for `*crypto.*`, which should find it for most naming schemes (it will find `libcrypto.a`, `libcrypto.so`, `crypto.dll`, etc.).

The `find` syntax used should be POSIX compliant. It has been tested with GNU, BSD and Solaris versions of `find`.

Since OpenSSL dependencies were handled by `pkg-config`, those have to now be added unconditionally when `--with-openssl-dir` is specified (in addition to when `pkg-config` isn't available).

This may result in a extraneous zlib (if OpenSSL was built without it) appearing on the link line (ref. "pedantic reasons" above). Modern linkers will not record a dependency on this unless explicitly told to do so.
