### PR TITLE
Don't set LD_LIBRARY_PATH if CRYPTO_LIBDIR is not set

### DIFF
--- a/test/rtpw_test.sh
+++ b/test/rtpw_test.sh
@@ -43,11 +43,17 @@ case $(uname -s) in
         ;;
     *Linux*)
         EXE=""
-        export LD_LIBRARY_PATH=$CRYPTO_LIBDIR
+        if [ -n "$CRYPTO_LIBDIR" ]
+        then
+            export LD_LIBRARY_PATH="$CRYPTO_LIBDIR"
+        fi
         ;;
     *Darwin*)
         EXE=""
-        export DYLD_LIBRARY_PATH=$CRYPTO_LIBDIR
+        if [ -n "$CRYPTO_LIBDIR" ]
+        then
+            export DYLD_LIBRARY_PATH="$CRYPTO_LIBDIR"
+        fi
         ;;
 esac
 

--- a/test/rtpw_test_gcm.sh
+++ b/test/rtpw_test_gcm.sh
@@ -43,11 +43,17 @@ case $(uname -s) in
         ;;
     *Linux*)
         EXE=""
-        export LD_LIBRARY_PATH=$CRYPTO_LIBDIR
+        if [ -n "$CRYPTO_LIBDIR" ]
+        then
+            export LD_LIBRARY_PATH="$CRYPTO_LIBDIR"
+        fi
         ;;
     *Darwin*)
         EXE=""
-        export DYLD_LIBRARY_PATH=$CRYPTO_LIBDIR
+        if [ -n "$CRYPTO_LIBDIR" ]
+        then
+            export DYLD_LIBRARY_PATH="$CRYPTO_LIBDIR"
+        fi
         ;;
 esac
 


### PR DESCRIPTION
This avoids overriding `LD_LIBRARY_PATH` that may be set by the user who invokes the building/testing process when not necessary.

In my case, `LD_LIBRARY_PATH` needs to be set in package building scripts, which invoke tests during the build process. `LD_LIBRARY_PATH` contains the local path where the built libsrtp binaries are located.
