### PR TITLE
Fix building with gcc-10

### DIFF
--- a/crypto/math/datatypes.c
+++ b/crypto/math/datatypes.c
@@ -79,7 +79,7 @@ int octet_get_weight(uint8_t octet)
 
 /* the value MAX_PRINT_STRING_LEN is defined in datatypes.h */
 
-char bit_string[MAX_PRINT_STRING_LEN];
+static char bit_string[MAX_PRINT_STRING_LEN];
 
 uint8_t srtp_nibble_to_hex_char(uint8_t nibble)
 {

--- a/test/util.c
+++ b/test/util.c
@@ -49,7 +49,7 @@
 #include <stdint.h>
 
 /* include space for null terminator */
-char bit_string[MAX_PRINT_STRING_LEN + 1];
+static char bit_string[MAX_PRINT_STRING_LEN + 1];
 
 static inline int hex_char_to_nibble(uint8_t c)
 {


### PR DESCRIPTION
gcc-10 defaults to -fno-common which reveals a symbol conflict with
bit_string. See https://gcc.gnu.org/bugzilla/show_bug.cgi?id=85678