### PR TITLE
Do not use pkg-config for NSS when a custom NSS directory is specified

### DIFF
--- a/config_in.h
+++ b/config_in.h
@@ -45,12 +45,6 @@
 /* Define to 1 if you have the `dl' library (-ldl). */
 #undef HAVE_LIBDL
 
-/* Define to 1 if you have the `nspr4' library (-lnspr4). */
-#undef HAVE_LIBNSPR4
-
-/* Define to 1 if you have the `nss3' library (-lnss3). */
-#undef HAVE_LIBNSS3
-
 /* Define to 1 if you have the `socket' library (-lsocket). */
 #undef HAVE_LIBSOCKET
 

--- a/configure
+++ b/configure
@@ -5479,38 +5479,27 @@ $as_echo_n "checking for user specified OpenSSL directory... " >&6; }
 
 # Check whether --with-openssl-dir was given.
 if test "${with_openssl_dir+set}" = set; then :
-  withval=$with_openssl_dir; if test "x$PKG_CONFIG" != "x" && test -f $with_openssl_dir/lib/pkgconfig/libcrypto.pc; then
-         if test "x$PKG_CONFIG_PATH" = "x"; then
-           export PKG_CONFIG_PATH="$with_openssl_dir/lib/pkgconfig"
-         else
-           export PKG_CONFIG_PATH="$with_openssl_dir/lib/pkgconfig:$PKG_CONFIG_PATH"
-         fi
-         { $as_echo "$as_me:${as_lineno-$LINENO}: result: $with_openssl_dir" >&5
+  withval=$with_openssl_dir; if test "x$(find "$with_openssl_dir/lib/." ! -name . -prune \( -type f -o -type l \) -name '*crypto.*' -print 2> /dev/null)" != "x"; then :
+  crypto_CFLAGS="-I$with_openssl_dir/include"
+          crypto_LIBS="-L$with_openssl_dir/lib -lcrypto"
+          { $as_echo "$as_me:${as_lineno-$LINENO}: result: $with_openssl_dir" >&5
 $as_echo "$with_openssl_dir" >&6; }
-       elif test -d $with_openssl_dir/lib; then
-         CFLAGS="$CFLAGS -I$with_openssl_dir/include"
-         if test "x$LDFLAGS" = "x"; then
-           LDFLAGS="-L$with_openssl_dir/lib"
-         else
-           LDFLAGS="$LDFLAGS -L$with_openssl_dir/lib"
-         fi
-         { $as_echo "$as_me:${as_lineno-$LINENO}: result: $with_openssl_dir" >&5
-$as_echo "$with_openssl_dir" >&6; }
-       else
-         { $as_echo "$as_me:${as_lineno-$LINENO}: result: invalid" >&5
-$as_echo "invalid" >&6; }
-         { { $as_echo "$as_me:${as_lineno-$LINENO}: error: in \`$ac_pwd':" >&5
-$as_echo "$as_me: error: in \`$ac_pwd':" >&2;}
-as_fn_error $? "Invalid OpenSSL location: $with_openssl_dir
-See \`config.log' for more details" "$LINENO" 5; }
-       fi
 else
-  { $as_echo "$as_me:${as_lineno-$LINENO}: result: no" >&5
+  { $as_echo "$as_me:${as_lineno-$LINENO}: result: invalid" >&5
+$as_echo "invalid" >&6; }
+          { { $as_echo "$as_me:${as_lineno-$LINENO}: error: in \`$ac_pwd':" >&5
+$as_echo "$as_me: error: in \`$ac_pwd':" >&2;}
+as_fn_error $? "Could not find a crypto library in \"$with_openssl_dir/lib\"
+See \`config.log' for more details" "$LINENO" 5; }
+fi
+else
+  with_openssl_dir="no"
+       { $as_echo "$as_me:${as_lineno-$LINENO}: result: no" >&5
 $as_echo "no" >&6; }
 fi
 
 
-   if test "x$PKG_CONFIG" != "x"; then
+   if test "$with_openssl_dir" = "no" && test "x$PKG_CONFIG" != "x"; then :
 
 pkg_failed=no
 { $as_echo "$as_me:${as_lineno-$LINENO}: checking for crypto" >&5
@@ -5600,11 +5589,10 @@ else
 	crypto_LIBS=$pkg_cv_crypto_LIBS
         { $as_echo "$as_me:${as_lineno-$LINENO}: result: yes" >&5
 $as_echo "yes" >&6; }
-	CFLAGS="$CFLAGS $crypto_CFLAGS"
-        LIBS="$crypto_LIBS $LIBS"
+
 fi
-   else
-     { $as_echo "$as_me:${as_lineno-$LINENO}: checking for dlopen in -ldl" >&5
+else
+  { $as_echo "$as_me:${as_lineno-$LINENO}: checking for dlopen in -ldl" >&5
 $as_echo_n "checking for dlopen in -ldl... " >&6; }
 if ${ac_cv_lib_dl_dlopen+:} false; then :
   $as_echo_n "(cached) " >&6
@@ -5648,11 +5636,11 @@ _ACEOF
   LIBS="-ldl $LIBS"
 
 else
-  { $as_echo "$as_me:${as_lineno-$LINENO}: WARNING: can't find libdl" >&5
-$as_echo "$as_me: WARNING: can't find libdl" >&2;}
+  { $as_echo "$as_me:${as_lineno-$LINENO}: WARNING: Can't find potential OpenSSL dependecny: libdl" >&5
+$as_echo "$as_me: WARNING: Can't find potential OpenSSL dependecny: libdl" >&2;}
 fi
 
-     { $as_echo "$as_me:${as_lineno-$LINENO}: checking for inflate in -lz" >&5
+      { $as_echo "$as_me:${as_lineno-$LINENO}: checking for inflate in -lz" >&5
 $as_echo_n "checking for inflate in -lz... " >&6; }
 if ${ac_cv_lib_z_inflate+:} false; then :
   $as_echo_n "(cached) " >&6
@@ -5696,11 +5684,16 @@ _ACEOF
   LIBS="-lz $LIBS"
 
 else
-  { $as_echo "$as_me:${as_lineno-$LINENO}: WARNING: can't find libz" >&5
-$as_echo "$as_me: WARNING: can't find libz" >&2;}
+  { $as_echo "$as_me:${as_lineno-$LINENO}: WARNING: Can't find potential OpenSSL dependency: libz" >&5
+$as_echo "$as_me: WARNING: Can't find potential OpenSSL dependency: libz" >&2;}
 fi
 
-   fi
+fi
+
+   if test "x$crypto_LIBS" != "x"; then :
+  CFLAGS="$CFLAGS $crypto_CFLAGS"
+      LIBS="$crypto_LIBS $LIBS"
+fi
 
    { $as_echo "$as_me:${as_lineno-$LINENO}: checking for library containing EVP_EncryptInit" >&5
 $as_echo_n "checking for library containing EVP_EncryptInit... " >&6; }

--- a/configure
+++ b/configure
@@ -6027,42 +6027,29 @@ $as_echo_n "checking for user specified NSS directory... " >&6; }
 
 # Check whether --with-nss-dir was given.
 if test "${with_nss_dir+set}" = set; then :
-  withval=$with_nss_dir; if test "x$PKG_CONFIG" != "x" && test -f $with_nss_dir/lib/pkgconfig/nss.pc; then
-         if test "x$PKG_CONFIG_PATH" = "x"; then
-           export PKG_CONFIG_PATH="$with_nss_dir/lib/pkgconfig"
-         else
-           export PKG_CONFIG_PATH="$with_nss_dir/lib/pkgconfig:$PKG_CONFIG_PATH"
-         fi
-         { $as_echo "$as_me:${as_lineno-$LINENO}: result: $with_nss_dir" >&5
-$as_echo "$with_nss_dir" >&6; }
-       elif test -d $with_nss_dir/lib; then
-         CFLAGS="$CFLAGS -I$with_nss_dir/include"
-         CFLAGS="$CFLAGS -I$with_nss_dir/../public/nss"
-         if test "x$LDFLAGS" = "x"; then
-           LDFLAGS="-L$with_nss_dir/lib"
-         else
-           LDFLAGS="$LDFLAGS -L$with_nss_dir/lib"
-         fi
-         nss_skip_pkg_config=yes
-         { $as_echo "$as_me:${as_lineno-$LINENO}: result: $with_nss_dir" >&5
-$as_echo "$with_nss_dir" >&6; }
-       else
-         { $as_echo "$as_me:${as_lineno-$LINENO}: result: invalid" >&5
-$as_echo "invalid" >&6; }
-         { { $as_echo "$as_me:${as_lineno-$LINENO}: error: in \`$ac_pwd':" >&5
-$as_echo "$as_me: error: in \`$ac_pwd':" >&2;}
-as_fn_error $? "Invalid NSS location: $with_nss_dir
-See \`config.log' for more details" "$LINENO" 5; }
-       fi
-       CRYPTO_LIBDIR=$with_nss_dir/lib
+  withval=$with_nss_dir; if test "x$(find "$with_nss_dir/lib/." ! -name . -prune \( -type f -o -type l \) -name '*nss3.*' -print 2> /dev/null)" != "x"; then :
+  nss_CFLAGS="-I$with_nss_dir/include -I$with_nss_dir/../public/nss"
+          nss_LIBS="-L$with_nss_dir/lib -lnss3 -lnspr4"
+          CRYPTO_LIBDIR=$with_nss_dir/lib
 
+          { $as_echo "$as_me:${as_lineno-$LINENO}: result: $with_nss_dir" >&5
+$as_echo "$with_nss_dir" >&6; }
 else
-  { $as_echo "$as_me:${as_lineno-$LINENO}: result: no" >&5
+  { $as_echo "$as_me:${as_lineno-$LINENO}: result: invalid" >&5
+$as_echo "invalid" >&6; }
+          { { $as_echo "$as_me:${as_lineno-$LINENO}: error: in \`$ac_pwd':" >&5
+$as_echo "$as_me: error: in \`$ac_pwd':" >&2;}
+as_fn_error $? "Could not find a NSS library in \"$with_nss_dir/lib\"
+See \`config.log' for more details" "$LINENO" 5; }
+fi
+else
+  with_nss_dir="no"
+       { $as_echo "$as_me:${as_lineno-$LINENO}: result: no" >&5
 $as_echo "no" >&6; }
 fi
 
 
-   if test "x$PKG_CONFIG" != "x" && test "$nss_skip_pkg_config" != "yes"; then
+   if test "$with_nss_dir" = "no" && test "x$PKG_CONFIG" != "x"; then :
 
 pkg_failed=no
 { $as_echo "$as_me:${as_lineno-$LINENO}: checking for nss" >&5
@@ -6152,11 +6139,16 @@ else
 	nss_LIBS=$pkg_cv_nss_LIBS
         { $as_echo "$as_me:${as_lineno-$LINENO}: result: yes" >&5
 $as_echo "yes" >&6; }
-	CFLAGS="$CFLAGS $nss_CFLAGS"
-         LIBS="$nss_LIBS $LIBS"
+
 fi
-   else
-     for ac_header in nss.h
+fi
+
+   if test "x$nss_LIBS" != "x"; then :
+  CFLAGS="$CFLAGS $nss_CFLAGS"
+      LIBS="$nss_LIBS $LIBS"
+fi
+
+   for ac_header in nss.h
 do :
   ac_fn_c_check_header_compile "$LINENO" "nss.h" "ac_cv_header_nss_h" "$ac_includes_default
 "
@@ -6174,13 +6166,13 @@ fi
 
 done
 
-     { $as_echo "$as_me:${as_lineno-$LINENO}: checking for PR_GetError in -lnspr4" >&5
-$as_echo_n "checking for PR_GetError in -lnspr4... " >&6; }
-if ${ac_cv_lib_nspr4_PR_GetError+:} false; then :
+
+   { $as_echo "$as_me:${as_lineno-$LINENO}: checking for library containing PR_GetError" >&5
+$as_echo_n "checking for library containing PR_GetError... " >&6; }
+if ${ac_cv_search_PR_GetError+:} false; then :
   $as_echo_n "(cached) " >&6
 else
-  ac_check_lib_save_LIBS=$LIBS
-LIBS="-lnspr4  $LIBS"
+  ac_func_search_save_LIBS=$LIBS
 cat confdefs.h - <<_ACEOF >conftest.$ac_ext
 /* end confdefs.h.  */
 
@@ -6199,36 +6191,47 @@ return PR_GetError ();
   return 0;
 }
 _ACEOF
-if ac_fn_c_try_link "$LINENO"; then :
-  ac_cv_lib_nspr4_PR_GetError=yes
-else
-  ac_cv_lib_nspr4_PR_GetError=no
+for ac_lib in '' nspr4; do
+  if test -z "$ac_lib"; then
+    ac_res="none required"
+  else
+    ac_res=-l$ac_lib
+    LIBS="-l$ac_lib  $ac_func_search_save_LIBS"
+  fi
+  if ac_fn_c_try_link "$LINENO"; then :
+  ac_cv_search_PR_GetError=$ac_res
 fi
 rm -f core conftest.err conftest.$ac_objext \
-    conftest$ac_exeext conftest.$ac_ext
-LIBS=$ac_check_lib_save_LIBS
+    conftest$ac_exeext
+  if ${ac_cv_search_PR_GetError+:} false; then :
+  break
 fi
-{ $as_echo "$as_me:${as_lineno-$LINENO}: result: $ac_cv_lib_nspr4_PR_GetError" >&5
-$as_echo "$ac_cv_lib_nspr4_PR_GetError" >&6; }
-if test "x$ac_cv_lib_nspr4_PR_GetError" = xyes; then :
-  cat >>confdefs.h <<_ACEOF
-#define HAVE_LIBNSPR4 1
-_ACEOF
-
-  LIBS="-lnspr4 $LIBS"
+done
+if ${ac_cv_search_PR_GetError+:} false; then :
 
 else
-  { $as_echo "$as_me:${as_lineno-$LINENO}: WARNING: can't find libnspr4" >&5
-$as_echo "$as_me: WARNING: can't find libnspr4" >&2;}
+  ac_cv_search_PR_GetError=no
+fi
+rm conftest.$ac_ext
+LIBS=$ac_func_search_save_LIBS
+fi
+{ $as_echo "$as_me:${as_lineno-$LINENO}: result: $ac_cv_search_PR_GetError" >&5
+$as_echo "$ac_cv_search_PR_GetError" >&6; }
+ac_res=$ac_cv_search_PR_GetError
+if test "$ac_res" != no; then :
+  test "$ac_res" = "none required" || LIBS="$ac_res $LIBS"
+
+else
+  { $as_echo "$as_me:${as_lineno-$LINENO}: WARNING: can't find useable libnsrp4" >&5
+$as_echo "$as_me: WARNING: can't find useable libnsrp4" >&2;}
 fi
 
-     { $as_echo "$as_me:${as_lineno-$LINENO}: checking for NSS_NoDB_Init in -lnss3" >&5
-$as_echo_n "checking for NSS_NoDB_Init in -lnss3... " >&6; }
-if ${ac_cv_lib_nss3_NSS_NoDB_Init+:} false; then :
+   { $as_echo "$as_me:${as_lineno-$LINENO}: checking for library containing NSS_NoDB_Init" >&5
+$as_echo_n "checking for library containing NSS_NoDB_Init... " >&6; }
+if ${ac_cv_search_NSS_NoDB_Init+:} false; then :
   $as_echo_n "(cached) " >&6
 else
-  ac_check_lib_save_LIBS=$LIBS
-LIBS="-lnss3  $LIBS"
+  ac_func_search_save_LIBS=$LIBS
 cat confdefs.h - <<_ACEOF >conftest.$ac_ext
 /* end confdefs.h.  */
 
@@ -6247,23 +6250,35 @@ return NSS_NoDB_Init ();
   return 0;
 }
 _ACEOF
-if ac_fn_c_try_link "$LINENO"; then :
-  ac_cv_lib_nss3_NSS_NoDB_Init=yes
-else
-  ac_cv_lib_nss3_NSS_NoDB_Init=no
+for ac_lib in '' nss3; do
+  if test -z "$ac_lib"; then
+    ac_res="none required"
+  else
+    ac_res=-l$ac_lib
+    LIBS="-l$ac_lib  $ac_func_search_save_LIBS"
+  fi
+  if ac_fn_c_try_link "$LINENO"; then :
+  ac_cv_search_NSS_NoDB_Init=$ac_res
 fi
 rm -f core conftest.err conftest.$ac_objext \
-    conftest$ac_exeext conftest.$ac_ext
-LIBS=$ac_check_lib_save_LIBS
+    conftest$ac_exeext
+  if ${ac_cv_search_NSS_NoDB_Init+:} false; then :
+  break
 fi
-{ $as_echo "$as_me:${as_lineno-$LINENO}: result: $ac_cv_lib_nss3_NSS_NoDB_Init" >&5
-$as_echo "$ac_cv_lib_nss3_NSS_NoDB_Init" >&6; }
-if test "x$ac_cv_lib_nss3_NSS_NoDB_Init" = xyes; then :
-  cat >>confdefs.h <<_ACEOF
-#define HAVE_LIBNSS3 1
-_ACEOF
+done
+if ${ac_cv_search_NSS_NoDB_Init+:} false; then :
 
-  LIBS="-lnss3 $LIBS"
+else
+  ac_cv_search_NSS_NoDB_Init=no
+fi
+rm conftest.$ac_ext
+LIBS=$ac_func_search_save_LIBS
+fi
+{ $as_echo "$as_me:${as_lineno-$LINENO}: result: $ac_cv_search_NSS_NoDB_Init" >&5
+$as_echo "$ac_cv_search_NSS_NoDB_Init" >&6; }
+ac_res=$ac_cv_search_NSS_NoDB_Init
+if test "$ac_res" != no; then :
+  test "$ac_res" = "none required" || LIBS="$ac_res $LIBS"
 
 else
   { { $as_echo "$as_me:${as_lineno-$LINENO}: error: in \`$ac_pwd':" >&5
@@ -6272,7 +6287,6 @@ as_fn_error $? "can't find useable libnss3
 See \`config.log' for more details" "$LINENO" 5; }
 fi
 
-   fi
 
 
 $as_echo "#define GCM 1" >>confdefs.h

--- a/configure.ac
+++ b/configure.ac
@@ -291,46 +291,34 @@ elif test "$enable_nss" = "yes"; then
    AC_MSG_CHECKING([for user specified NSS directory])
    AC_ARG_WITH([nss-dir],
       [AS_HELP_STRING([--with-nss-dir], [Location of NSS installation])],
-      [if test "x$PKG_CONFIG" != "x" && test -f $with_nss_dir/lib/pkgconfig/nss.pc; then
-         if test "x$PKG_CONFIG_PATH" = "x"; then
-           export PKG_CONFIG_PATH="$with_nss_dir/lib/pkgconfig"
-         else
-           export PKG_CONFIG_PATH="$with_nss_dir/lib/pkgconfig:$PKG_CONFIG_PATH"
-         fi
-         AC_MSG_RESULT([$with_nss_dir])
-       elif test -d $with_nss_dir/lib; then
-         CFLAGS="$CFLAGS -I$with_nss_dir/include"
-         CFLAGS="$CFLAGS -I$with_nss_dir/../public/nss"
-         if test "x$LDFLAGS" = "x"; then
-           LDFLAGS="-L$with_nss_dir/lib"
-         else
-           LDFLAGS="$LDFLAGS -L$with_nss_dir/lib"
-         fi
-         nss_skip_pkg_config=yes
-         AC_MSG_RESULT([$with_nss_dir])
-       else
-         AC_MSG_RESULT([invalid])
-         AC_MSG_FAILURE([Invalid NSS location: $with_nss_dir])
-       fi
-       AC_SUBST([CRYPTO_LIBDIR], [$with_nss_dir/lib])],
-      [AC_MSG_RESULT([no])])
+      [AS_IF(
+         [test "x$(find "$with_nss_dir/lib/." ! -name . -prune \( -type f -o -type l \) -name '*nss3.*' -print 2> /dev/null)" != "x"],
+         [nss_CFLAGS="-I$with_nss_dir/include -I$with_nss_dir/../public/nss"
+          nss_LIBS="-L$with_nss_dir/lib -lnss3 -lnspr4"
+          AC_SUBST([CRYPTO_LIBDIR], [$with_nss_dir/lib])
+          AC_MSG_RESULT([$with_nss_dir])],
+         [AC_MSG_RESULT([invalid])
+          AC_MSG_FAILURE([Could not find a NSS library in "$with_nss_dir/lib"])])],
+      [with_nss_dir="no"
+       AC_MSG_RESULT([no])])
 
-   if test "x$PKG_CONFIG" != "x" && test "$nss_skip_pkg_config" != "yes"; then
-     PKG_CHECK_MODULES([nss], [nss],
-       [CFLAGS="$CFLAGS $nss_CFLAGS"
-         LIBS="$nss_LIBS $LIBS"])
-   else
-     AC_CHECK_HEADERS(
-       [nss.h],
-       [], [AC_MSG_FAILURE([can't find useable NSS headers])],
-       [AC_INCLUDES_DEFAULT])
-     AC_CHECK_LIB(
-       [nspr4], [PR_GetError],
-       [], [AC_MSG_WARN([can't find libnspr4])])
-     AC_CHECK_LIB(
-       [nss3], [NSS_NoDB_Init],
-       [], [AC_MSG_FAILURE([can't find useable libnss3])])
-   fi
+   AS_IF(
+     [test "$with_nss_dir" = "no" && test "x$PKG_CONFIG" != "x"],
+     [PKG_CHECK_MODULES([nss], [nss])])
+
+   AS_IF([test "x$nss_LIBS" != "x"],
+     [CFLAGS="$CFLAGS $nss_CFLAGS"
+      LIBS="$nss_LIBS $LIBS"])
+
+   AC_CHECK_HEADERS(
+     [nss.h],
+     [], [AC_MSG_FAILURE([can't find useable NSS headers])],
+     [AC_INCLUDES_DEFAULT])
+
+   AC_SEARCH_LIBS([PR_GetError], [nspr4],
+     [], [AC_MSG_WARN([can't find useable libnsrp4])])
+   AC_SEARCH_LIBS([NSS_NoDB_Init], [nss3],
+     [], [AC_MSG_FAILURE([can't find useable libnss3])])
 
    AC_DEFINE([GCM], [1], [Define this to use AES-GCM.])
    AC_DEFINE([NSS], [1], [Define this to use NSS crypto.])

--- a/configure.ac
+++ b/configure.ac
@@ -220,35 +220,24 @@ if test "$enable_openssl" = "yes"; then
    AC_MSG_CHECKING([for user specified OpenSSL directory])
    AC_ARG_WITH([openssl-dir],
       [AS_HELP_STRING([--with-openssl-dir], [Location of OpenSSL installation])],
-      [if test "x$PKG_CONFIG" != "x" && test -f $with_openssl_dir/lib/pkgconfig/libcrypto.pc; then
-         if test "x$PKG_CONFIG_PATH" = "x"; then
-           export PKG_CONFIG_PATH="$with_openssl_dir/lib/pkgconfig"
-         else
-           export PKG_CONFIG_PATH="$with_openssl_dir/lib/pkgconfig:$PKG_CONFIG_PATH"
-         fi
-         AC_MSG_RESULT([$with_openssl_dir])
-       elif test -d $with_openssl_dir/lib; then
-         CFLAGS="$CFLAGS -I$with_openssl_dir/include"
-         if test "x$LDFLAGS" = "x"; then
-           LDFLAGS="-L$with_openssl_dir/lib"
-         else
-           LDFLAGS="$LDFLAGS -L$with_openssl_dir/lib"
-         fi
-         AC_MSG_RESULT([$with_openssl_dir])
-       else
-         AC_MSG_RESULT([invalid])
-         AC_MSG_FAILURE([Invalid OpenSSL location: $with_openssl_dir])
-       fi],
-      [AC_MSG_RESULT([no])])
+      [AS_IF(
+         [test "x$(find "$with_openssl_dir/lib/." ! -name . -prune \( -type f -o -type l \) -name '*crypto.*' -print 2> /dev/null)" != "x"],
+         [crypto_CFLAGS="-I$with_openssl_dir/include"
+          crypto_LIBS="-L$with_openssl_dir/lib -lcrypto"
+          AC_MSG_RESULT([$with_openssl_dir])],
+         [AC_MSG_RESULT([invalid])
+          AC_MSG_FAILURE([Could not find a crypto library in "$with_openssl_dir/lib"])])],
+      [with_openssl_dir="no"
+       AC_MSG_RESULT([no])])
 
-   if test "x$PKG_CONFIG" != "x"; then
-     PKG_CHECK_MODULES([crypto], [libcrypto >= 1.0.1],
-       [CFLAGS="$CFLAGS $crypto_CFLAGS"
-        LIBS="$crypto_LIBS $LIBS"])
-   else
-     AC_CHECK_LIB([dl], [dlopen], [], [AC_MSG_WARN([can't find libdl])])
-     AC_CHECK_LIB([z], [inflate], [], [AC_MSG_WARN([can't find libz])])
-   fi
+   AS_IF([test "$with_openssl_dir" = "no" && test "x$PKG_CONFIG" != "x"],
+     [PKG_CHECK_MODULES([crypto], [libcrypto >= 1.0.1])],
+     [AC_CHECK_LIB([dl], [dlopen], [], [AC_MSG_WARN([Can't find potential OpenSSL dependecny: libdl])])
+      AC_CHECK_LIB([z], [inflate], [], [AC_MSG_WARN([Can't find potential OpenSSL dependency: libz])])])
+
+   AS_IF([test "x$crypto_LIBS" != "x"],
+     [CFLAGS="$CFLAGS $crypto_CFLAGS"
+      LIBS="$crypto_LIBS $LIBS"])
 
    AC_SEARCH_LIBS([EVP_EncryptInit], [crypto],
      [], [AC_MSG_FAILURE([can't find openssl >= 1.0.1 crypto lib])])


### PR DESCRIPTION
When installing NSS (using `make install`), it's possible to specify a `DESTDIR` which will install it to that location instead of the location specified with --prefix during configuration.

However, package config files are generated based on the `--prefix` location, so even if installed to somewhere else, the package config file will still point to the final destination provided during configuration.

This configure script would call `pkg-config`, if available, also when `--with-nss-dir` was used. This is primarily because the `--with-nss-dir` handling is a copy-and-paste of the `--with-openssl-dir` handling, which also used to do this. That was changed in PR #481. This builds off that and essentially does the same thing for the `--with-nss-dir` flags.

If `DESTDIR` was used to install NSS, `pkg-config` would add flags pointing to the `--prefix` location used when building NSS, not the provided `--with-nss-dir`.

This could end up picking up a system library instead, or, if there happened to be a NSS library already at the given `--prefix`, that would be used.

Both of those scenarios are probably not what you'd expect to happen.

To fix this, this removes the use of `pkg-config` when `--with-nss-dir` is specified.

To further make sure that `--with-nss-dir` functions as the override it was meant to be, the check for a `lib` directory under the specified location is changed to a more comprehensive check for the library itself.

It uses the `find` utility to look for `*nss3.*`, which should find it for most naming schemes (it will find `libnss3.a`, `libnns3.so`, `nss3.dll`, etc.).

The `find` syntax used should be POSIX compliant. It has been tested with GNU, BSD and Solaris versions of `find`.

Note that this could break existing build configurations that uses `--with-nss-dir` to point to non-system package install location.

For instance, MacPorts installs NSS and NSPR to `/opt/local`, but in sub directories. So include files go in `/opt/local/include/[nss|nspr]` and libraries go in `/opt/local/lib/[nss|nspr]`.

If you tried to use `--with-nss-dir=/opt/local`, this would fail to find a NSS library in `/opt/local/lib`, whereas the old method would find the `nss.pc` file in `/opt/local/lib/pkgconfig` and pick up the correct flags from running `pkg-config`.

If you're in this situation, with this change, you would have to set `PKG_CONFIG_PATH` before running configure instead of `--with-nss-dir`.
