### PR TITLE
Add support for the Meson build system

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -263,7 +263,8 @@ matrix:
     - os: windows
       before_install:
         - choco install python --version 3.8.0
-        - pip3 install meson ninja
+        - choco install ninja
+        - pip3 install meson
       env:
         - TEST="windows"
         - PATH=/c/Python38:/c/Python38/Scripts:$PATH

--- a/.travis.yml
+++ b/.travis.yml
@@ -284,10 +284,12 @@ matrix:
         - meson compile -C builddir-gcc
         - meson test -v -C builddir-gcc
         # Test MSVC 64-bit build
-        - cmd.exe //C 'C:\Program Files (x86)\Microsoft Visual Studio\2017\BuildTools\VC\Auxiliary\Build\vcvarsall.bat' x86_amd64 \& set CC=cl \& meson setup --werror builddir-msvc \& meson compile -C builddir-msvc \& meson test -v -C builddir-msvc
+        - cmd.exe //C 'C:\Program Files (x86)\Microsoft Visual Studio\2017\BuildTools\VC\Auxiliary\Build\vcvarsall.bat' amd64 \& set CC=cl \& meson setup --werror builddir-msvc-amd64 \& meson compile -C builddir-msvc-amd64 \& meson test -v -C builddir-msvc-amd64
+        # Test MSVC 32-bit build
+        - cmd.exe //C 'C:\Program Files (x86)\Microsoft Visual Studio\2017\BuildTools\VC\Auxiliary\Build\vcvarsall.bat' x86 \& set CC=cl \& meson setup --werror builddir-msvc-x86 \& meson compile -C builddir-msvc-x86 \& meson test -v -C builddir-msvc-x86
         # Test MSVC 64-bit UWP build. This is a cross build because we cannot run UWP binaries natively.
         - |
-          cat > uwp-cross-file.txt <<EOF
+          cat > uwp-amd64-cross-file.txt <<EOF
           [host_machine]
           system = 'windows'
           cpu_family = 'x86_64'
@@ -305,7 +307,7 @@ matrix:
           cpp       = 'cl'
           pkgconfig = 'false'
           EOF
-        - cmd.exe //C 'C:\Program Files (x86)\Microsoft Visual Studio\2017\BuildTools\VC\Auxiliary\Build\vcvarsall.bat' x86_amd64 uwp \& meson setup --werror --cross-file uwp-cross-file.txt builddir-uwp \& meson compile -C builddir-uwp
+        - cmd.exe //C 'C:\Program Files (x86)\Microsoft Visual Studio\2017\BuildTools\VC\Auxiliary\Build\vcvarsall.bat' amd64 uwp \& meson setup --werror --cross-file uwp-amd64-cross-file.txt builddir-uwp-amd64 \& meson compile -C builddir-uwp-amd64
 
     # android build
     - os: linux

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,4 @@
 dist: xenial
-sudo: false
 language: c
 
 env:
@@ -185,7 +184,6 @@ matrix:
 
     # big-endian
     - os: linux
-      sudo: true
       env:
         - TEST="big-endian"
       services:

--- a/.travis.yml
+++ b/.travis.yml
@@ -308,6 +308,27 @@ matrix:
           pkgconfig = 'false'
           EOF
         - cmd.exe //C 'C:\Program Files (x86)\Microsoft Visual Studio\2017\BuildTools\VC\Auxiliary\Build\vcvarsall.bat' amd64 uwp \& meson setup --werror --cross-file uwp-amd64-cross-file.txt builddir-uwp-amd64 \& meson compile -C builddir-uwp-amd64
+        # Test MSVC ARM64 UWP build. This is a cross build.
+        - |
+          cat > uwp-arm64-cross-file.txt <<EOF
+          [host_machine]
+          system = 'windows'
+          cpu_family = 'aarch64'
+          cpu = 'aarch64'
+          endian = 'little'
+
+          [properties]
+          c_args = ['-DWINAPI_FAMILY=WINAPI_FAMILY_APP']
+          c_link_args = ['-APPCONTAINER', 'WindowsApp.lib']
+          needs_exe_wrapper = true
+
+          [binaries]
+          ar        = 'lib'
+          c         = 'cl'
+          cpp       = 'cl'
+          pkgconfig = 'false'
+          EOF
+        - cmd.exe //C 'C:\Program Files (x86)\Microsoft Visual Studio\2017\BuildTools\VC\Auxiliary\Build\vcvarsall.bat' amd64_arm64 uwp \& meson setup --werror --cross-file uwp-arm64-cross-file.txt builddir-uwp-arm64 \& meson compile -C builddir-uwp-arm64
 
     # android build
     - os: linux

--- a/.travis.yml
+++ b/.travis.yml
@@ -20,6 +20,9 @@ matrix:
           packages:
             - gcc-6
             - valgrind
+      install:
+        - pyenv global 3.7.1
+        - pip3 install meson ninja
       script:
         - CC=gcc-6 EXTRA_CFLAGS=-Werror ./configure
         - make
@@ -30,6 +33,10 @@ matrix:
         - cmake ..
         - make
         - make test
+        - cd ..
+        - CC=gcc-6 meson setup --werror builddir
+        - meson compile -C builddir
+        - meson test -v -C builddir
 
     # linux build with openssl
     - os: linux
@@ -42,6 +49,9 @@ matrix:
           packages:
             - gcc-6
             - valgrind
+      install:
+        - pyenv global 3.7.1
+        - pip3 install meson ninja
       script:
         - CC=gcc-6 EXTRA_CFLAGS=-Werror ./configure --enable-openssl
         - make
@@ -57,6 +67,10 @@ matrix:
         - cmake -DENABLE_OPENSSL=ON -DBUILD_SHARED_LIBS=ON ..
         - make
         - make test
+        - cd ..
+        - meson setup --werror -Dcrypto-library=openssl builddir
+        - meson compile -C builddir
+        - meson test -v -C builddir
 
     # linux build with openssl and clang
     - os: linux
@@ -66,10 +80,16 @@ matrix:
         apt:
           packages:
             - clang
+      install:
+        - pyenv global 3.7.1
+        - pip3 install meson ninja
       script:
         - CC=clang EXTRA_CFLAGS=-Werror ./configure --enable-openssl
         - make
         - make runtest
+        - CC=clang meson setup --werror -Dcrypto-library=openssl builddir
+        - meson compile -C builddir
+        - meson test -v -C builddir
 
     # linux build with nss
     - os: linux
@@ -83,16 +103,24 @@ matrix:
             - gcc-6
             - valgrind
             - libnss3-dev
+      install:
+        - pyenv global 3.7.1
+        - pip3 install meson ninja
       script:
         - CC=gcc-6 EXTRA_CFLAGS=-Werror ./configure --enable-nss
         - make
         - make runtest
         - make runtest-valgrind
+        - CC=gcc-6 meson setup --werror -Dcrypto-library=nss builddir
+        - meson compile -C builddir
+        - meson test -v -C builddir
 
     # default osx build
     - os: osx
       env:
         - TEST="osx"
+      before_install:
+        - pip3 install meson ninja
       script:
         - EXTRA_CFLAGS=-Werror ./configure
         - make
@@ -102,6 +130,10 @@ matrix:
         - cmake ..
         - make
         - make test
+        - cd ..
+        - meson setup --werror builddir
+        - meson compile -C builddir
+        - meson test -v -C builddir
 
     # osx build with openssl
     - os: osx
@@ -109,7 +141,8 @@ matrix:
       env:
         - TEST="osx openssl"
       before_install:
-            - brew install openssl@1.1
+        - pip3 install meson ninja
+        - brew install openssl@1.1
       script:
         - PKG_CONFIG_PATH=$(brew --prefix openssl@1.1)/lib/pkgconfig EXTRA_CFLAGS=-Werror ./configure --enable-openssl
         - make
@@ -119,16 +152,25 @@ matrix:
         - cmake -DOPENSSL_ROOT_DIR=$(brew --prefix openssl@1.1) -DENABLE_OPENSSL=ON ..
         - make
         - make test
+        - cd ..
+        - PKG_CONFIG_PATH=$(brew --prefix openssl@1.1)/lib/pkgconfig meson setup --werror -Dcrypto-library=openssl builddir
+        - meson compile -C builddir
+        - meson test -v -C builddir
 
     # osx build with nss
     - os: osx
       osx_image: xcode11.2
       env:
         - TEST="osx nss"
+      before_install:
+        - pip3 install meson ninja
       script:
         - PKG_CONFIG_PATH=$(brew --prefix nss)/lib/pkgconfig EXTRA_CFLAGS=-Werror ./configure --enable-nss
         - make
         - make runtest
+        - PKG_CONFIG_PATH=$(brew --prefix nss)/lib/pkgconfig meson setup --werror -Dcrypto-library=nss builddir
+        - meson compile -C builddir
+        - meson test -v -C builddir
 
     # code format check
     - os: linux
@@ -157,13 +199,36 @@ matrix:
         - sudo docker run --volume $(pwd):/src --workdir /src --name mipsX --tty --detach ubuntu:16.04 tail
         - sudo docker exec --tty mipsX apt-get update
         - sudo docker exec --tty mipsX apt-get install build-essential -y
-        - sudo docker exec --tty mipsX apt-get install gcc-mips-linux-gnu -y
+        - sudo docker exec --tty mipsX apt-get install qemu-user-static qemu-system-mips gcc-mips-linux-gnu python3-pip -y
+        - sudo docker exec --tty mipsX pip3 install meson ninja
       script:
         - sudo docker exec --tty mipsX bash -c 'EXTRA_CFLAGS=-static CC=mips-linux-gnu-gcc ./configure --host=mips-linux-gnu'
         - sudo docker exec --tty mipsX make
-        - sudo docker kill mipsX
         - file test/srtp_driver
         - make runtest
+        - |
+          cat > mips-cross-file.txt <<EOF
+          [host_machine]
+          system = 'linux'
+          cpu_family = 'mips'
+          cpu = 'mips'
+          endian = 'big'
+
+          [properties]
+          c_args = ['-static', '-static-libgcc']
+          c_link_args = ['-static', '-static-libgcc']
+
+          [binaries]
+          ar          = 'mips-linux-gnu-gcc-ar'
+          c           = 'mips-linux-gnu-gcc'
+          ranlib      = 'mips-linux-gnu-gcc-ranlib'
+          exe_wrapper = 'qemu-mips-static'
+          pkgconfig   = 'false'
+          EOF
+        - sudo docker exec --tty mipsX meson setup --cross-file mips-cross-file.txt -Ddefault_library=static -Db_staticpic=false builddir
+        - sudo docker exec --tty mipsX meson compile -C builddir
+        - sudo docker exec --tty mipsX meson test -v --timeout-multiplier 10 -C builddir
+        - sudo docker kill mipsX
 
     # linux build of fuzzer
     - os: linux
@@ -196,8 +261,12 @@ matrix:
 
     # windows build
     - os: windows
+      before_install:
+        - choco install python --version 3.8.0
+        - pip3 install meson ninja
       env:
         - TEST="windows"
+        - PATH=/c/Python38:/c/Python38/Scripts:$PATH
       script:
         - export PATH="c:\Program Files (x86)\Microsoft Visual Studio\2017\BuildTools\MSBuild\15.0\Bin":$PATH
         - mkdir build && cd build
@@ -209,11 +278,42 @@ matrix:
         - cmake -G "Visual Studio 15 2017" -DBUILD_SHARED_LIBS=ON ..
         - msbuild.exe libsrtp2.sln -p:Configuration=Release
         - msbuild.exe RUN_TESTS.vcxproj -p:Configuration=Release
+        # Test mingw build
+        - cd ..
+        - meson setup builddir-gcc
+        - meson compile -C builddir-gcc
+        - meson test -v -C builddir-gcc
+        # Test MSVC 64-bit build
+        - cmd.exe //C 'C:\Program Files (x86)\Microsoft Visual Studio\2017\BuildTools\VC\Auxiliary\Build\vcvarsall.bat' x86_amd64 \& set CC=cl \& meson setup --werror builddir-msvc \& meson compile -C builddir-msvc \& meson test -v -C builddir-msvc
+        # Test MSVC 64-bit UWP build. This is a cross build because we cannot run UWP binaries natively.
+        - |
+          cat > uwp-cross-file.txt <<EOF
+          [host_machine]
+          system = 'windows'
+          cpu_family = 'x86_64'
+          cpu = 'x86_64'
+          endian = 'little'
+
+          [properties]
+          c_args = ['-DWINAPI_FAMILY=WINAPI_FAMILY_APP']
+          c_link_args = ['-APPCONTAINER', 'WindowsApp.lib']
+          needs_exe_wrapper = true
+
+          [binaries]
+          ar        = 'lib'
+          c         = 'cl'
+          cpp       = 'cl'
+          pkgconfig = 'false'
+          EOF
+        - cmd.exe //C 'C:\Program Files (x86)\Microsoft Visual Studio\2017\BuildTools\VC\Auxiliary\Build\vcvarsall.bat' x86_amd64 uwp \& meson setup --werror --cross-file uwp-cross-file.txt builddir-uwp \& meson compile -C builddir-uwp
 
     # android build
     - os: linux
       env:
         - TEST="android"
+      install:
+        - pyenv global 3.7.1
+        - pip3 install meson ninja
       script:
         - wget -q https://dl.google.com/android/repository/android-ndk-r20b-linux-x86_64.zip
         - unzip -qq android-ndk-r20b-linux-x86_64.zip
@@ -224,7 +324,7 @@ matrix:
         - make
         - cd ..
         - TOOLCHAIN=$ANDROID_NDK/toolchains/llvm/prebuilt/linux-x86_64
-          AR=$TOOLCHAIN/bin/aarch64-linux-android-ar
+        - AR=$TOOLCHAIN/bin/aarch64-linux-android-ar
           AS=$TOOLCHAIN/bin/aarch64-linux-android-as
           CC=$TOOLCHAIN/bin/aarch64-linux-android21-clang
           CXX=$TOOLCHAIN/bin/aarch64-linux-android21-clang++
@@ -233,12 +333,35 @@ matrix:
           STRIP=$TOOLCHAIN/bin/aarch64-linux-android-strip
           ./configure --host aarch64-linux-android
         - make
+        - |
+          cat > android-cross-file.txt <<EOF
+          [host_machine]
+          system = 'android'
+          cpu_family = 'aarch64'
+          cpu = 'aarch64'
+          endian = 'little'
 
-    # ios build with openssl
+          [properties]
+          sys_root = '$ANDROID_NDK/sysroot'
+
+          [binaries]
+          ar        = '$TOOLCHAIN/bin/aarch64-linux-android-ar'
+          c         = '$TOOLCHAIN/bin/aarch64-linux-android21-clang'
+          cpp       = '$TOOLCHAIN/bin/aarch64-linux-android21-clang++'
+          ranlib    = '$TOOLCHAIN/bin/aarch64-linux-android-ranlib'
+          strip     = '$TOOLCHAIN/bin/aarch64-linux-android-strip'
+          pkgconfig = 'false'
+          EOF
+        - meson setup --werror --cross-file android-cross-file.txt builddir
+        - meson compile -C builddir
+
+    # ios build
     - os: osx
       osx_image: xcode11.2
       env:
         - TEST="ios"
+      before_install:
+        - pip3 install meson ninja
       script:
         - wget -q https://raw.githubusercontent.com/leetal/ios-cmake/master/ios.toolchain.cmake
         - mkdir build && cd build
@@ -257,3 +380,25 @@ matrix:
           ./configure --host arm-apple-darwin
         - make
         - make shared_library
+        - |
+          cat > ios-cross-file.txt <<EOF
+          [host_machine]
+          system = 'darwin'
+          cpu_family = 'aarch64'
+          cpu = 'aarch64'
+          endian = 'little'
+
+          [properties]
+          c_args =      ['-arch', 'arm64', '--sysroot=$(xcrun --sdk iphoneos --show-sdk-path)', '-miphoneos-version-min=8.0']
+          c_link_args = ['-arch', 'arm64', '--sysroot=$(xcrun --sdk iphoneos --show-sdk-path)', '-miphoneos-version-min=8.0']
+
+          [binaries]
+          ar        = '$(xcrun --find --sdk iphoneos ar)'
+          c         = '$(xcrun --find --sdk iphoneos clang)'
+          cpp       = '$(xcrun --find --sdk iphoneos clang++)'
+          ranlib    = '$(xcrun --find --sdk iphoneos ranlib)'
+          strip     = '$(xcrun --find --sdk iphoneos strip)'
+          pkgconfig = 'false'
+          EOF
+        - meson setup --werror -Db_bitcode=true --cross-file ios-cross-file.txt builddir
+        - meson compile -C builddir

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,3 @@
+# Meson build file maintainers
+meson.build @nirbheek @tp-m @xhaakon
+meson_options.txt @nirbheek @tp-m @xhaakon

--- a/Makefile.in
+++ b/Makefile.in
@@ -319,10 +319,22 @@ superclean: clean
 
 distclean: superclean
 
-distname = libsrtp-$(shell cat VERSION)
+distversion = $(shell cat VERSION)
+distname = libsrtp-$(distversion)
+
+mesonprojver = $(shell sed -n -e "s/project.*version\s*:\s'\([0-9.]\+\)'.*/\1/p" meson.build)
 
 distribution: runtest superclean
 	if ! [ -f VERSION ]; then exit 1; fi
+	@# Check that the project version set in meson matches the release version
+	@if [ $(distversion) != $(mesonprojver) ]; then \
+		echo "==================================================="; \
+		echo "Meson project version is $(mesonprojver) which is incorrect."; \
+		echo "Please edit meson.build and change the 'version:'"; \
+		echo "field in the project() call to $(distversion)"; \
+		echo "==================================================="; \
+		exit 1; \
+	fi
 	if [ -f ../$(distname).tgz ]; then               \
 		   mv ../$(distname).tgz ../$(distname).tgz.bak; \
 		fi

--- a/README.md
+++ b/README.md
@@ -336,6 +336,36 @@ cmake .. -G "Visual Studio 15 2017 Win64"
 ```
 
 --------------------------------------------------------------------------------
+<a name="using-meson"></a>
+## Using Meson
+
+On all platforms including Windows, one can build using [Meson](https://mesonbuild.org).
+Steps to download Meson are here: https://mesonbuild.com/Getting-meson.html
+
+To build with Meson, you can do something like:
+
+```
+# Setup the build subdirectory
+meson setup --prefix=/path/to/prefix builddir
+
+# Build the project
+meson compile -C builddir
+
+# Run tests
+meson test -C builddir
+
+# Optionally, install
+meson install -C builddir
+```
+
+To build with Visual Studio, run the above commands from inside a Visual Studio
+command prompt, or run `vcvarsall.bat` with the appropriate arguments inside
+a Command Prompt.
+
+Note that you can also replace the above commands with the appropriate `ninja`
+targets: `ninja -C build`, `ninja -C build test`, `ninja -C build install`.
+
+--------------------------------------------------------------------------------
 
 <a name="applications"></a>
 # Applications

--- a/crypto/cipher/aes.c
+++ b/crypto/cipher/aes.c
@@ -1796,7 +1796,7 @@ static inline void aes_inv_final_round(v128_t *state, const v128_t *round_key)
     v128_xor_eq(state, round_key);
 }
 
-#elif CPU_RISC
+#elif defined(CPU_RISC)
 
 static inline void aes_round(v128_t *state, const v128_t *round_key)
 {

--- a/crypto/test/meson.build
+++ b/crypto/test/meson.build
@@ -1,0 +1,39 @@
+# crypto test suite
+
+test_apps = [
+  'cipher_driver',
+  'datatypes_driver',
+  'stat_driver',
+  'sha1_driver',
+  'kernel_driver',
+  'env',
+]
+
+foreach test_name : test_apps
+  test_exe = executable(test_name,
+    '@0@.c'.format(test_name), '../../test/getopt_s.c', '../../test/util.c',
+    include_directories: [config_incs, crypto_incs, srtp2_incs, test_incs],
+    dependencies: [srtp2_deps, syslibs],
+    link_with: libsrtp2_for_tests)
+  test(test_name, test_exe, args: ['-v'])
+endforeach
+
+if not use_openssl and not use_nss
+  test_exe = executable('aes_calc',
+    'aes_calc.c', '../../test/getopt_s.c', '../../test/util.c',
+    include_directories: [config_incs, crypto_incs, srtp2_incs, test_incs],
+    dependencies: [srtp2_deps, syslibs],
+    link_with: libsrtp2_for_tests)
+
+  # data values used to test the aes_calc application for AES-128
+  k128 = '000102030405060708090a0b0c0d0e0f'
+  p128 = '00112233445566778899aabbccddeeff'
+  c128 = '69c4e0d86a7b0430d8cdb78070b4c55a'
+  test('aes_calc_128', test_exe, args: [k128, p128, c128])
+
+  # data values used to test the aes_calc application for AES-256
+  k256 = '000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f'
+  p256 = '00112233445566778899aabbccddeeff'
+  c256 = '8ea2b7ca516745bfeafc49904b496089'
+  test('aes_calc_256', test_exe, args: [k256, p256, c256])
+endif

--- a/doc/Doxyfile.in
+++ b/doc/Doxyfile.in
@@ -38,7 +38,7 @@ PROJECT_NAME           = libSRTP
 # could be handy for archiving the generated documentation or if some version
 # control system is used.
 
-PROJECT_NUMBER         = LIBSRTPVERSIONNUMBER
+PROJECT_NUMBER         = @LIBSRTPVERSIONNUMBER@
 
 # Using the PROJECT_BRIEF tag one can provide an optional one line description
 # for a project that appears at the top of each page and should give viewer a

--- a/doc/Makefile.in
+++ b/doc/Makefile.in
@@ -21,7 +21,7 @@ libsrtpdoc:
 	@if test ! -e Doxyfile.in; then \
 		echo "*** Sorry, can't build doc outside source dir"; exit 1; \
 	fi
-	sed 's/LIBSRTPVERSIONNUMBER/$(version)/' Doxyfile.in > Doxyfile
+	sed 's/@LIBSRTPVERSIONNUMBER@/$(version)/' Doxyfile.in > Doxyfile
 	doxygen
 
 clean:

--- a/doc/meson.build
+++ b/doc/meson.build
@@ -1,0 +1,22 @@
+# libSRTP documentation
+
+doxygen = find_program('doxygen', required: get_option('doc'))
+
+if not doxygen.found()
+  subdir_done()
+endif
+
+doc_config = configuration_data()
+doc_config.set('LIBSRTPVERSIONNUMBER', meson.project_version())
+
+doxyfile = configure_file(input: 'Doxyfile.in',
+  output: 'Doxyfile',
+  configuration: doc_config)
+
+# can be built on demand with ninja -C builddir doc/html
+doxygen_html_docs = custom_target('doc',
+  build_by_default: false,
+  command: [doxygen, doxyfile],
+  output: ['html'])
+
+alias_target('libsrtp2doc', doxygen_html_docs)

--- a/fuzzer/meson.build
+++ b/fuzzer/meson.build
@@ -1,0 +1,31 @@
+# libSRTP fuzzer
+if not add_languages('cpp', required: get_option('fuzzer').enabled())
+  subdir_done()
+endif
+
+cxx = meson.get_compiler('cpp')
+if cxx.get_id() != 'clang'
+  err_msg = 'libSRTP fuzzer requires compilation with clang, but compiler is ' + cxx.get_id()
+  if get_option('fuzzer').enabled()
+    error(err_msg)
+  else
+    warning(err_msg)
+    subdir_done()
+  endif
+endif
+
+libfuzzer = cxx.find_library('libFuzzer', required: get_option('fuzzer'))
+
+# libFuzzer.a seems to need pthread, at least on Linux
+threads = dependency('threads')
+
+if libfuzzer.found()
+  executable('srtp-fuzzer',
+    'fuzzer.c', 'testmem.c', 'mt19937.cpp',
+    include_directories: [config_incs, crypto_incs, srtp2_incs],
+    cpp_args: ['-fsanitize=fuzzer'],
+    override_options : ['cpp_std=c++11'],
+    dependencies: [libfuzzer, threads],
+    link_with: libsrtp2,
+    install: false)
+endif

--- a/include/srtp2/meson.build
+++ b/include/srtp2/meson.build
@@ -1,0 +1,8 @@
+# Copy public headers scattered across the source tree into a single directory
+# so that we can use it in declare_dependency()
+foreach h : public_headers
+  configure_file(input: h,
+    output: '@BASENAME@.h',
+    copy: true)
+endforeach
+public_incs = include_directories('.')

--- a/meson.build
+++ b/meson.build
@@ -1,4 +1,4 @@
-project('libsrtp2', 'c', version: '2.3.0',
+project('libsrtp2', 'c', version: '2.4.0',
   meson_version: '>= 0.52.0',
   default_options: ['buildtype=debugoptimized'])
 

--- a/meson.build
+++ b/meson.build
@@ -88,8 +88,8 @@ foreach type : ['unsigned long', 'unsigned long long']
   endif
 endforeach
 
-if not cc.compiles('inline void func(); void func() { } int main() { func(); return 0; }')
-  if cc.compiles('__inline void func(); void func() { } int main() { func(); return 0; }')
+if not cc.compiles('inline void func(); void func() { } int main() { func(); return 0; }', name: 'inline keyword check')
+  if cc.compiles('__inline void func(); void func() { } int main() { func(); return 0; }', name: '__inline keyword check')
     cdata.set('inline', '__inline')
   else
     cdata.set('inline', '')

--- a/meson.build
+++ b/meson.build
@@ -1,0 +1,290 @@
+project('libsrtp2', 'c', version: '2.3.0',
+  meson_version: '>= 0.52.0',
+  default_options: ['buildtype=debugoptimized'])
+
+soversion = 1
+
+cc = meson.get_compiler('c')
+host_system = host_machine.system()
+
+srtp2_deps = []
+syslibs = []
+
+if host_system == 'windows'
+  syslibs += [cc.find_library('ws2_32')] # for socket
+endif
+
+cdata = configuration_data()
+cdata.set_quoted('PACKAGE_VERSION', meson.project_version())
+cdata.set_quoted('PACKAGE_STRING', '@0@ @1@'.format(meson.project_name(), meson.project_version()))
+
+check_headers = [
+  'arpa/inet.h',
+  'byteswap.h',
+  'inttypes.h',
+  'machine/types.h',
+  'netinet/in.h',
+  'stdint.h',
+  'stdlib.h',
+  'sys/int_types.h',
+  'sys/socket.h',
+  'sys/types.h',
+  'sys/uio.h',
+  'unistd.h',
+]
+
+if host_system == 'windows'
+  check_headers += ['windows.h', 'winsock2.h']
+endif
+
+foreach h : check_headers
+  if cc.has_header(h)
+    cdata.set('HAVE_' + h.to_upper().underscorify(), true)
+  endif
+endforeach
+
+check_functions = [
+  'sigaction',
+  'inet_aton',
+  'usleep',
+  'socket',
+]
+
+foreach f : check_functions
+  if cc.has_function(f, dependencies: syslibs)
+    cdata.set('HAVE_' + f.to_upper().underscorify(), true)
+  endif
+endforeach
+
+if host_machine.endian() == 'big'
+  cdata.set('WORDS_BIGENDIAN', true)
+endif
+
+# This follows the checks in configure.ac, but is it up-to-date ?!
+if host_machine.cpu_family() in ['x86', 'x86_64']
+  cdata.set('CPU_CISC', true, description: 'Building for a CISC machine (e.g. Intel)')
+  cdata.set('HAVE_X86', true, description: 'Use x86 inlined assembly code')
+else
+  cdata.set('CPU_RISC', true, description: 'Building for a RISC machine (assume slow byte access)')
+endif
+
+# Pretty much all supported platforms have stdint.h nowadays
+assert(cc.has_header('stdint.h'), 'stdint.h not available!')
+
+# we'll just assume these types are available via stdint.h
+foreach type : ['int8_t', 'uint8_t', 'int16_t', 'uint16_t', 'int32_t', 'uint32_t', 'uint64_t']
+  cdata.set('HAVE_' + type.to_upper().underscorify(), true)
+endforeach
+
+if not cc.has_type('size_t', prefix: '#include <sys/types.h>')
+  cdata.set('size_t', 'unsigned int')
+endif
+
+# check type availability and size
+foreach type : ['unsigned long', 'unsigned long long']
+  if cc.has_type(type)
+    cdata.set('HAVE_' + type.to_upper().underscorify(), true)
+    cdata.set('SIZEOF_' + type.to_upper().underscorify(), cc.sizeof(type))
+  endif
+endforeach
+
+if not cc.compiles('inline void func(); void func() { } int main() { func(); return 0; }')
+  if cc.compiles('__inline void func(); void func() { } int main() { func(); return 0; }')
+    cdata.set('inline', '__inline')
+  else
+    cdata.set('inline', '')
+  endif
+endif
+
+if get_option('log-stdout')
+  cdata.set('ERR_REPORTING_STDOUT', true)
+endif
+
+if get_option('log-file') != ''
+  cdata.set('ERR_REPORTING_FILE', get_option('log-file'))
+endif
+
+if cdata.has('ERR_REPORTING_STDOUT') and cdata.has('ERR_REPORTING_FILE')
+  error('The log-stdout and log-file options are mutually exclusive!')
+endif
+
+if get_option('debug-logging')
+  cdata.set('ENABLE_DEBUG_LOGGING', true)
+endif
+
+use_openssl = false
+use_nss = false
+
+crypto_library = get_option('crypto-library')
+if crypto_library == 'openssl'
+  openssl_dep = dependency('openssl', version: '>= 1.0.1', required: true)
+  srtp2_deps += [openssl_dep]
+  cdata.set('GCM', true)
+  cdata.set('OPENSSL', true)
+  cdata.set('USE_EXTERNAL_CRYPTO', true)
+  use_openssl = true
+  # NOTE: This is not available in upstream OpenSSL yet. It's only in 'certain'
+  # forks of OpenSSL: https://github.com/cisco/libsrtp/issues/458
+  if cc.has_function('kdf_srtp', dependencies: openssl_dep)
+    cdata.set('OPENSSL_KDF', true)
+  elif get_option('crypto-library-kdf').enabled()
+    error('KDF support has been enabled, but OpenSSL does not provide it')
+  endif
+elif crypto_library == 'nss'
+  nss_dep = dependency('nss', version: '>= 1.0.1', required: true)
+  srtp2_deps += [nss_dep]
+  cdata.set('GCM', true)
+  cdata.set('NSS', true)
+  cdata.set('USE_EXTERNAL_CRYPTO', true)
+  use_nss = true
+  # TODO(RLB): Use NSS for KDF
+  if get_option('crypto-library-kdf').enabled()
+    error('KDF support has not been implemented for NSS')
+  endif
+endif
+
+configure_file(output: 'config.h', configuration: cdata)
+
+add_project_arguments('-DHAVE_CONFIG_H', language: 'c')
+
+if get_option('buildtype') != 'plain'
+  w_args = ['-Wstrict-prototypes']
+  add_project_arguments(cc.get_supported_arguments(w_args), language: 'c')
+endif
+
+if get_option('optimization') not in ['0', 'g', 's']
+  # -fexpensive-optimizations set already by default for -O2, -O3
+  o_args = ['-funroll-loops']
+  add_project_arguments(cc.get_supported_arguments(o_args), language: 'c')
+endif
+
+sources = files(
+  'srtp/ekt.c',
+  'srtp/srtp.c',
+  )
+
+ciphers_sources = files(
+  'crypto/cipher/cipher.c',
+  'crypto/cipher/null_cipher.c',
+  )
+
+if use_openssl
+  ciphers_sources += files(
+    'crypto/cipher/aes_icm_ossl.c',
+    'crypto/cipher/aes_gcm_ossl.c',
+  )
+elif use_nss
+  ciphers_sources += files(
+    'crypto/cipher/aes_icm_nss.c',
+    'crypto/cipher/aes_gcm_nss.c',
+  )
+else
+  ciphers_sources += files(
+    'crypto/cipher/aes.c',
+    'crypto/cipher/aes_icm.c',
+  )
+endif
+
+hashes_sources = files(
+  'crypto/hash/auth.c',
+  'crypto/hash/null_auth.c',
+  )
+
+if use_openssl
+  hashes_sources += files(
+    'crypto/hash/hmac_ossl.c',
+  )
+elif use_nss
+  # TODO(RLB): Use NSS for HMAC
+  hashes_sources += files(
+    'crypto/hash/hmac.c',
+    'crypto/hash/sha1.c',
+  )
+else
+  hashes_sources += files(
+    'crypto/hash/hmac.c',
+    'crypto/hash/sha1.c',
+  )
+endif
+
+kernel_sources = files(
+  'crypto/kernel/alloc.c',
+  'crypto/kernel/crypto_kernel.c',
+  'crypto/kernel/err.c',
+  'crypto/kernel/key.c',
+)
+
+math_sources = files(
+  'crypto/math/datatypes.c',
+  'crypto/math/stat.c',
+)
+
+replay_sources = files(
+  'crypto/replay/rdb.c',
+  'crypto/replay/rdbx.c',
+  'crypto/replay/ut_sim.c',
+)
+
+public_headers = files(
+  'include/srtp.h',
+  'crypto/include/auth.h',
+  'crypto/include/cipher.h',
+  'crypto/include/crypto_types.h',
+)
+install_headers(public_headers, subdir : 'srtp2')
+
+config_incs = include_directories('.')
+crypto_incs = include_directories('crypto/include')
+srtp2_incs = include_directories('include')
+test_incs = include_directories('test')
+
+default_library = get_option('default_library')
+
+libsrtp2_static = static_library('srtp2', sources, ciphers_sources, hashes_sources,
+  kernel_sources, math_sources, replay_sources,
+  dependencies: [srtp2_deps, syslibs],
+  include_directories: [crypto_incs, srtp2_incs],
+  install: default_library != 'shared')
+
+if default_library != 'static'
+  libsrtp2 = shared_library('srtp2',
+    dependencies: [srtp2_deps, syslibs],
+    soversion : soversion,
+    vs_module_defs: 'srtp.def',
+    link_whole: libsrtp2_static,
+    install: true)
+else
+  libsrtp2 = libsrtp2_static
+endif
+
+subdir('include/srtp2') # copies public_headers into the builddir and sets public_incs
+
+libsrtp2_dep = declare_dependency(link_with: libsrtp2,
+  include_directories: public_incs)
+
+if not get_option('tests').disabled()
+  # Tests use non-public API, and when building on Windows the only symbols we
+  # export are those in srtp.def, so link to the static library in that case.
+  if host_system == 'windows'
+    libsrtp2_for_tests = libsrtp2_static
+  else
+    libsrtp2_for_tests = libsrtp2
+  endif
+  subdir('crypto/test')
+  subdir('test')
+endif
+
+if not get_option('fuzzer').disabled()
+  subdir('fuzzer')
+endif
+
+if not get_option('doc').disabled()
+  subdir('doc')
+endif
+
+pkgconfig = import('pkgconfig')
+pkgconfig.generate(libsrtp2,
+  filebase: meson.project_name(),
+  name: meson.project_name(),
+  version: meson.project_version(),
+  description: 'Library for SRTP (Secure Realtime Transport Protocol)')

--- a/meson.build
+++ b/meson.build
@@ -76,7 +76,13 @@ foreach type : ['int8_t', 'uint8_t', 'int16_t', 'uint16_t', 'int32_t', 'uint32_t
   cdata.set('HAVE_' + type.to_upper().underscorify(), true)
 endforeach
 
-if not cc.has_type('size_t', prefix: '#include <sys/types.h>')
+size_t_prefix = '''
+#ifdef _WIN32
+#include <crtdefs.h>
+#endif
+#include <sys/types.h>
+'''
+if not cc.has_type('size_t', prefix: size_t_prefix)
   cdata.set('size_t', 'unsigned int')
 endif
 

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -1,0 +1,18 @@
+option('debug-logging', type : 'boolean', value : false,
+  description : 'Enable debug logging in all modules')
+option('log-stdout', type : 'boolean', value : false,
+  description : 'Redirect logging to stdout')
+option('log-file', type : 'string', value : '',
+  description : 'Write logging output into this file')
+option('crypto-library', type: 'combo', choices : ['none', 'openssl', 'nss'], value : 'none',
+  description : 'What external crypto library to leverage, if any (OpenSSL or NSS)')
+option('crypto-library-kdf', type : 'feature', value : 'auto',
+  description : 'Use the external crypto library for Key Derivation Function support')
+option('fuzzer', type : 'feature', value : 'disabled',
+  description : 'Build libsrtp2 fuzzer (requires build with clang)')
+option('tests', type : 'feature', value : 'auto', yield : true,
+  description : 'Build test applications')
+option('pcap-tests', type : 'feature', value : 'auto',
+  description : 'Build test application that require libpcap')
+option('doc', type : 'feature', value : 'auto', yield : true,
+  description : 'Generate API documentation with doxygen')

--- a/test/meson.build
+++ b/test/meson.build
@@ -1,7 +1,9 @@
 # test suite
 
-# TODO: add test setup for valgrind: run test_srtp -v + srtp_driver -v
-# through valgrind --leak-check=full
+# XXX: Makefile only runs test_srtp and srtp_driver with valgrind
+add_test_setup('valgrind',
+  exe_wrapper: ['valgrind', '--leak-check=full'],
+  timeout_multiplier: 10)
 
 test_apps = [
   ['srtp_driver', {'extra_sources': 'util.c', 'run_args': '-v'}],
@@ -9,7 +11,7 @@ test_apps = [
   ['roc_driver', {'run_args': '-v'}],
   ['rdbx_driver', {'run_args': '-v'}],
   ['dtls_srtp_driver',  {'extra_sources': 'util.c'}],
-  ['test_srtp'],
+  ['test_srtp', {'run_args': '-v'}],
   ['rtpw', {'extra_sources': ['rtp.c', 'util.c', '../crypto/math/datatypes.c'], 'define_test': false}],
 ]
 

--- a/test/meson.build
+++ b/test/meson.build
@@ -33,7 +33,14 @@ foreach t : test_apps
 endforeach
 
 # rtpw test needs to be run using shell scripts
-if find_program('sh', 'bash', required: false).found()
+can_run_rtpw = find_program('sh', 'bash', required: false).found()
+
+# Meson only passes the exe_wrapper to shell scripts starting 0.55
+if meson.is_cross_build() and meson.version().version_compare('<0.55')
+  can_run_rtpw = false
+endif
+
+if can_run_rtpw
   words_txt = files('words.txt')
 
   rtpw_test_sh = find_program('rtpw_test.sh', required: false)

--- a/test/meson.build
+++ b/test/meson.build
@@ -1,0 +1,69 @@
+# test suite
+
+# TODO: add test setup for valgrind: run test_srtp -v + srtp_driver -v
+# through valgrind --leak-check=full
+
+test_apps = [
+  ['srtp_driver', {'extra_sources': 'util.c', 'run_args': '-v'}],
+  ['replay_driver', {'run_args': '-v'}],
+  ['roc_driver', {'run_args': '-v'}],
+  ['rdbx_driver', {'run_args': '-v'}],
+  ['dtls_srtp_driver',  {'extra_sources': 'util.c'}],
+  ['test_srtp'],
+  ['rtpw', {'extra_sources': ['rtp.c', 'util.c', '../crypto/math/datatypes.c'], 'define_test': false}],
+]
+
+foreach t : test_apps
+  test_name = t.get(0)
+  test_dict = t.get(1, {})
+  test_extra_sources = test_dict.get('extra_sources', [])
+  test_run_args = test_dict.get('run_args', [])
+
+  test_exe = executable(test_name,
+    '@0@.c'.format(test_name), 'getopt_s.c', test_extra_sources,
+    include_directories: [config_incs, crypto_incs, srtp2_incs, test_incs],
+    dependencies: [srtp2_deps, syslibs],
+    link_with: libsrtp2_for_tests)
+
+  if test_dict.get('define_test', true)
+    test(test_name, test_exe, args: test_run_args)
+  else
+    set_variable(test_name + '_exe', test_exe)
+  endif
+endforeach
+
+# rtpw test needs to be run using shell scripts
+if find_program('sh', 'bash', required: false).found()
+  words_txt = files('words.txt')
+
+  rtpw_test_sh = find_program('rtpw_test.sh', required: false)
+  if rtpw_test_sh.found()
+    test('rtpw_test', rtpw_test_sh,
+         args: ['-w', words_txt],
+         depends: rtpw_exe,
+         is_parallel: false,
+         workdir: meson.current_build_dir())
+  endif
+
+  rtpw_test_gcm_sh = find_program('rtpw_test_gcm.sh', required: false)
+  if (use_openssl or use_nss) and rtpw_test_gcm_sh.found()
+    test('rtpw_test_gcm', rtpw_test_gcm_sh,
+         args: ['-w', words_txt],
+         depends: rtpw_exe,
+         is_parallel: false,
+         workdir: meson.current_build_dir())
+  endif
+endif
+
+# rtp_decoder
+pcap_dep = dependency('libpcap', required: get_option('pcap-tests'))
+
+if pcap_dep.found()
+  executable('rtp_decoder',
+    'rtp_decoder.c', 'getopt_s.c', 'rtp.c', 'util.c', 'getopt_s.c',
+    '../crypto/math/datatypes.c',
+    include_directories: [config_incs, crypto_incs, srtp2_incs, test_incs],
+    dependencies: [srtp2_deps, pcap_dep, syslibs],
+    link_with: libsrtp2,
+    install: false)
+endif

--- a/test/rtpw.c
+++ b/test/rtpw.c
@@ -671,7 +671,7 @@ void handle_signal(int signum)
 
 int setup_signal_handler(char *name)
 {
-#if HAVE_SIGACTION
+#ifdef HAVE_SIGACTION
     struct sigaction act;
     memset(&act, 0, sizeof(act));
 

--- a/test/rtpw.c
+++ b/test/rtpw.c
@@ -96,7 +96,7 @@
 
 #ifndef HAVE_USLEEP
 #ifdef HAVE_WINDOWS_H
-#define usleep(us) Sleep((us) / 1000)
+#define usleep(us) Sleep(((DWORD)us) / 1000)
 #else
 #define usleep(us) sleep((us) / 1000000)
 #endif

--- a/test/rtpw_test.sh
+++ b/test/rtpw_test.sh
@@ -58,6 +58,7 @@ case $(uname -s) in
 esac
 
 RTPW=./rtpw$EXE
+[ -n "$MESON_EXE_WRAPPER" ] && RTPW="$MESON_EXE_WRAPPER $RTPW"
 DEST_PORT=9999
 DURATION=3
 
@@ -73,7 +74,7 @@ ARGS="-b $key -a -e 128"
 
 killall rtpw 2>/dev/null
 
-if test -x $RTPW; then
+if test -n $MESON_EXE_WRAPPER || test -x $RTPW; then
 
 echo  $0 ": starting rtpw receiver process... "
 

--- a/test/rtpw_test_gcm.sh
+++ b/test/rtpw_test_gcm.sh
@@ -58,6 +58,7 @@ case $(uname -s) in
 esac
 
 RTPW=./rtpw$EXE
+[ -n "$MESON_EXE_WRAPPER" ] && RTPW="$MESON_EXE_WRAPPER $RTPW"
 DEST_PORT=9999
 DURATION=3
 
@@ -69,7 +70,7 @@ DURATION=3
 
 killall rtpw 2>/dev/null
 
-if test -x $RTPW; then
+if test -n $MESON_EXE_WRAPPER || test -x $RTPW; then
 
 GCMARGS128="-k 01234567890123456789012345678901234567890123456789012345 -g -e 128"
 echo  $0 ": starting GCM mode 128-bit rtpw receiver process... "


### PR DESCRIPTION
Hi! I'm a [GStreamer](gstreamer.freedesktop.org/) developer, and [for the same reasons as OpenH264](https://github.com/cisco/openh264/pull/2955), we've written Meson build files for libsrtp. We use libsrtp in gstreamer for WebRTC DTLS.

The Meson build system is being adopted by projects such as GNOME, GTK, Mesa, GStreamer, etc. I am not sure if such a pull request is welcome, but it would be amazing if you could consider merging this :)

----
These Meson build files have feature-parity with the Autoconf/Make build files, the Visual Studio solution, and the CMake build files. They are also simpler, faster, and support all target platforms supported by libsrtp (that I know of). The following have been tested:

Linux, macOS, Windows (MinGW), Windows (MSVC), Windows (UWP/WinRT), Cross-Android (all arches), Cross-iOS (all arches), Cross-Linux, Cross-Windows (MinGW).

Meson supports a superset of the currently-supported target platforms, and no platform-specific code should be needed for those, so this also improves cross-platform support.

The build outputs should be ABI-compatible with the outputs by Autoconf, but this has not been verified in detail.

I've also updated the README, and (pasted from there) the steps to try this out are:

```
# Setup the build subdirectory
meson setup --prefix=/path/to/prefix builddir
# Build the project
meson compile -C builddir
# Run tests
meson test -C builddir
# Optionally, install
meson install -C builddir
```