### PR TITLE
Rework check for OPENSSL_cleanse()

### DIFF
--- a/configure
+++ b/configure
@@ -5520,6 +5520,65 @@ if test -n "$crypto_CFLAGS"; then
     pkg_cv_crypto_CFLAGS="$crypto_CFLAGS"
  elif test -n "$PKG_CONFIG"; then
     if test -n "$PKG_CONFIG" && \
+    { { $as_echo "$as_me:${as_lineno-$LINENO}: \$PKG_CONFIG --exists --print-errors \"libcrypto >= 1.0.2i\""; } >&5
+  ($PKG_CONFIG --exists --print-errors "libcrypto >= 1.0.2i") 2>&5
+  ac_status=$?
+  $as_echo "$as_me:${as_lineno-$LINENO}: \$? = $ac_status" >&5
+  test $ac_status = 0; }; then
+  pkg_cv_crypto_CFLAGS=`$PKG_CONFIG --cflags "libcrypto >= 1.0.2i" 2>/dev/null`
+		      test "x$?" != "x0" && pkg_failed=yes
+else
+  pkg_failed=yes
+fi
+ else
+    pkg_failed=untried
+fi
+if test -n "$crypto_LIBS"; then
+    pkg_cv_crypto_LIBS="$crypto_LIBS"
+ elif test -n "$PKG_CONFIG"; then
+    if test -n "$PKG_CONFIG" && \
+    { { $as_echo "$as_me:${as_lineno-$LINENO}: \$PKG_CONFIG --exists --print-errors \"libcrypto >= 1.0.2i\""; } >&5
+  ($PKG_CONFIG --exists --print-errors "libcrypto >= 1.0.2i") 2>&5
+  ac_status=$?
+  $as_echo "$as_me:${as_lineno-$LINENO}: \$? = $ac_status" >&5
+  test $ac_status = 0; }; then
+  pkg_cv_crypto_LIBS=`$PKG_CONFIG --libs "libcrypto >= 1.0.2i" 2>/dev/null`
+		      test "x$?" != "x0" && pkg_failed=yes
+else
+  pkg_failed=yes
+fi
+ else
+    pkg_failed=untried
+fi
+
+
+
+if test $pkg_failed = yes; then
+   	{ $as_echo "$as_me:${as_lineno-$LINENO}: result: no" >&5
+$as_echo "no" >&6; }
+
+if $PKG_CONFIG --atleast-pkgconfig-version 0.20; then
+        _pkg_short_errors_supported=yes
+else
+        _pkg_short_errors_supported=no
+fi
+        if test $_pkg_short_errors_supported = yes; then
+	        crypto_PKG_ERRORS=`$PKG_CONFIG --short-errors --print-errors --cflags --libs "libcrypto >= 1.0.2i" 2>&1`
+        else
+	        crypto_PKG_ERRORS=`$PKG_CONFIG --print-errors --cflags --libs "libcrypto >= 1.0.2i" 2>&1`
+        fi
+	# Put the nasty error message in config.log where it belongs
+	echo "$crypto_PKG_ERRORS" >&5
+
+
+pkg_failed=no
+{ $as_echo "$as_me:${as_lineno-$LINENO}: checking for crypto" >&5
+$as_echo_n "checking for crypto... " >&6; }
+
+if test -n "$crypto_CFLAGS"; then
+    pkg_cv_crypto_CFLAGS="$crypto_CFLAGS"
+ elif test -n "$PKG_CONFIG"; then
+    if test -n "$PKG_CONFIG" && \
     { { $as_echo "$as_me:${as_lineno-$LINENO}: \$PKG_CONFIG --exists --print-errors \"libcrypto >= 1.0.1\""; } >&5
   ($PKG_CONFIG --exists --print-errors "libcrypto >= 1.0.1") 2>&5
   ac_status=$?
@@ -5601,7 +5660,113 @@ else
         { $as_echo "$as_me:${as_lineno-$LINENO}: result: yes" >&5
 $as_echo "yes" >&6; }
 	CFLAGS="$CFLAGS $crypto_CFLAGS"
+          LIBS="$crypto_LIBS $LIBS"
+          openssl_cleanse_broken=maybe
+fi
+elif test $pkg_failed = untried; then
+     	{ $as_echo "$as_me:${as_lineno-$LINENO}: result: no" >&5
+$as_echo "no" >&6; }
+
+pkg_failed=no
+{ $as_echo "$as_me:${as_lineno-$LINENO}: checking for crypto" >&5
+$as_echo_n "checking for crypto... " >&6; }
+
+if test -n "$crypto_CFLAGS"; then
+    pkg_cv_crypto_CFLAGS="$crypto_CFLAGS"
+ elif test -n "$PKG_CONFIG"; then
+    if test -n "$PKG_CONFIG" && \
+    { { $as_echo "$as_me:${as_lineno-$LINENO}: \$PKG_CONFIG --exists --print-errors \"libcrypto >= 1.0.1\""; } >&5
+  ($PKG_CONFIG --exists --print-errors "libcrypto >= 1.0.1") 2>&5
+  ac_status=$?
+  $as_echo "$as_me:${as_lineno-$LINENO}: \$? = $ac_status" >&5
+  test $ac_status = 0; }; then
+  pkg_cv_crypto_CFLAGS=`$PKG_CONFIG --cflags "libcrypto >= 1.0.1" 2>/dev/null`
+		      test "x$?" != "x0" && pkg_failed=yes
+else
+  pkg_failed=yes
+fi
+ else
+    pkg_failed=untried
+fi
+if test -n "$crypto_LIBS"; then
+    pkg_cv_crypto_LIBS="$crypto_LIBS"
+ elif test -n "$PKG_CONFIG"; then
+    if test -n "$PKG_CONFIG" && \
+    { { $as_echo "$as_me:${as_lineno-$LINENO}: \$PKG_CONFIG --exists --print-errors \"libcrypto >= 1.0.1\""; } >&5
+  ($PKG_CONFIG --exists --print-errors "libcrypto >= 1.0.1") 2>&5
+  ac_status=$?
+  $as_echo "$as_me:${as_lineno-$LINENO}: \$? = $ac_status" >&5
+  test $ac_status = 0; }; then
+  pkg_cv_crypto_LIBS=`$PKG_CONFIG --libs "libcrypto >= 1.0.1" 2>/dev/null`
+		      test "x$?" != "x0" && pkg_failed=yes
+else
+  pkg_failed=yes
+fi
+ else
+    pkg_failed=untried
+fi
+
+
+
+if test $pkg_failed = yes; then
+   	{ $as_echo "$as_me:${as_lineno-$LINENO}: result: no" >&5
+$as_echo "no" >&6; }
+
+if $PKG_CONFIG --atleast-pkgconfig-version 0.20; then
+        _pkg_short_errors_supported=yes
+else
+        _pkg_short_errors_supported=no
+fi
+        if test $_pkg_short_errors_supported = yes; then
+	        crypto_PKG_ERRORS=`$PKG_CONFIG --short-errors --print-errors --cflags --libs "libcrypto >= 1.0.1" 2>&1`
+        else
+	        crypto_PKG_ERRORS=`$PKG_CONFIG --print-errors --cflags --libs "libcrypto >= 1.0.1" 2>&1`
+        fi
+	# Put the nasty error message in config.log where it belongs
+	echo "$crypto_PKG_ERRORS" >&5
+
+	as_fn_error $? "Package requirements (libcrypto >= 1.0.1) were not met:
+
+$crypto_PKG_ERRORS
+
+Consider adjusting the PKG_CONFIG_PATH environment variable if you
+installed software in a non-standard prefix.
+
+Alternatively, you may set the environment variables crypto_CFLAGS
+and crypto_LIBS to avoid the need to call pkg-config.
+See the pkg-config man page for more details." "$LINENO" 5
+elif test $pkg_failed = untried; then
+     	{ $as_echo "$as_me:${as_lineno-$LINENO}: result: no" >&5
+$as_echo "no" >&6; }
+	{ { $as_echo "$as_me:${as_lineno-$LINENO}: error: in \`$ac_pwd':" >&5
+$as_echo "$as_me: error: in \`$ac_pwd':" >&2;}
+as_fn_error $? "The pkg-config script could not be found or is too old.  Make sure it
+is in your PATH or set the PKG_CONFIG environment variable to the full
+path to pkg-config.
+
+Alternatively, you may set the environment variables crypto_CFLAGS
+and crypto_LIBS to avoid the need to call pkg-config.
+See the pkg-config man page for more details.
+
+To get pkg-config, see <http://pkg-config.freedesktop.org/>.
+See \`config.log' for more details" "$LINENO" 5; }
+else
+	crypto_CFLAGS=$pkg_cv_crypto_CFLAGS
+	crypto_LIBS=$pkg_cv_crypto_LIBS
+        { $as_echo "$as_me:${as_lineno-$LINENO}: result: yes" >&5
+$as_echo "yes" >&6; }
+	CFLAGS="$CFLAGS $crypto_CFLAGS"
+          LIBS="$crypto_LIBS $LIBS"
+          openssl_cleanse_broken=maybe
+fi
+else
+	crypto_CFLAGS=$pkg_cv_crypto_CFLAGS
+	crypto_LIBS=$pkg_cv_crypto_LIBS
+        { $as_echo "$as_me:${as_lineno-$LINENO}: result: yes" >&5
+$as_echo "yes" >&6; }
+	CFLAGS="$CFLAGS $crypto_CFLAGS"
         LIBS="$crypto_LIBS $LIBS"
+        openssl_cleanse_broken=no
 fi
    else
      { $as_echo "$as_me:${as_lineno-$LINENO}: checking for dlopen in -ldl" >&5
@@ -5897,35 +6062,37 @@ $as_echo "#define OPENSSL 1" >>confdefs.h
    USE_EXTERNAL_CRYPTO=1
 
 
-   { $as_echo "$as_me:${as_lineno-$LINENO}: checking if OPENSSL_cleanse is broken" >&5
+   if test "x$openssl_cleanse_broken" != "xno"; then :
+
+     { $as_echo "$as_me:${as_lineno-$LINENO}: checking if OPENSSL_cleanse is broken" >&5
 $as_echo_n "checking if OPENSSL_cleanse is broken... " >&6; }
-   if test "$cross_compiling" = yes; then :
+     if test "$cross_compiling" = yes; then :
   openssl_cleanse_broken=maybe
 else
   cat confdefs.h - <<_ACEOF >conftest.$ac_ext
 /* end confdefs.h.  */
 
-     #include <stdio.h>
-     #include <openssl/crypto.h>
+       #include <stdio.h>
+       #include <openssl/crypto.h>
 
 int
 main ()
 {
 
-     #define BUFFER_SIZE (16)
-     char buffer[BUFFER_SIZE];
-     int i;
-     for (i = 0; i < BUFFER_SIZE; i++) {
-       buffer[i] = i & 0xff;
-     }
-     OPENSSL_cleanse(buffer, BUFFER_SIZE);
-     for (i = 0; i < BUFFER_SIZE; i++) {
-       if (buffer[i]) {
-         printf("Buffer contents not zero at position %d (is %d)\n", i,
-             buffer[i]);
-         return 1;
+       #define BUFFER_SIZE (16)
+       char buffer[BUFFER_SIZE];
+       int i;
+       for (i = 0; i < BUFFER_SIZE; i++) {
+         buffer[i] = i & 0xff;
        }
-     }
+       OPENSSL_cleanse(buffer, BUFFER_SIZE);
+       for (i = 0; i < BUFFER_SIZE; i++) {
+         if (buffer[i]) {
+           printf("Buffer contents not zero at position %d (is %d)\n", i,
+               buffer[i]);
+           return 1;
+         }
+       }
 
   ;
   return 0;
@@ -5940,13 +6107,15 @@ rm -f core *.core core.conftest.* gmon.out bb.out conftest$ac_exeext \
   conftest.$ac_objext conftest.beam conftest.$ac_ext
 fi
 
-   { $as_echo "$as_me:${as_lineno-$LINENO}: result: $openssl_cleanse_broken" >&5
+     { $as_echo "$as_me:${as_lineno-$LINENO}: result: $openssl_cleanse_broken" >&5
 $as_echo "$openssl_cleanse_broken" >&6; }
-   if test "x$openssl_cleanse_broken" != "xno"; then :
+     if test "x$openssl_cleanse_broken" != "xno"; then :
 
 
 $as_echo "#define OPENSSL_CLEANSE_BROKEN 1" >>confdefs.h
 
+
+fi
 
 fi
 

--- a/configure
+++ b/configure
@@ -5900,10 +5900,7 @@ $as_echo "#define OPENSSL 1" >>confdefs.h
    { $as_echo "$as_me:${as_lineno-$LINENO}: checking if OPENSSL_cleanse is broken" >&5
 $as_echo_n "checking if OPENSSL_cleanse is broken... " >&6; }
    if test "$cross_compiling" = yes; then :
-  { { $as_echo "$as_me:${as_lineno-$LINENO}: error: in \`$ac_pwd':" >&5
-$as_echo "$as_me: error: in \`$ac_pwd':" >&2;}
-as_fn_error $? "cannot run test program while cross compiling
-See \`config.log' for more details" "$LINENO" 5; }
+  openssl_cleanse_broken=maybe
 else
   cat confdefs.h - <<_ACEOF >conftest.$ac_ext
 /* end confdefs.h.  */
@@ -5937,12 +5934,7 @@ _ACEOF
 if ac_fn_c_try_run "$LINENO"; then :
   openssl_cleanse_broken=no
 else
-
-     openssl_cleanse_broken=yes
-
-$as_echo "#define OPENSSL_CLEANSE_BROKEN 1" >>confdefs.h
-
-
+  openssl_cleanse_broken=yes
 fi
 rm -f core *.core core.conftest.* gmon.out bb.out conftest$ac_exeext \
   conftest.$ac_objext conftest.beam conftest.$ac_ext
@@ -5950,6 +5942,13 @@ fi
 
    { $as_echo "$as_me:${as_lineno-$LINENO}: result: $openssl_cleanse_broken" >&5
 $as_echo "$openssl_cleanse_broken" >&6; }
+   if test "x$openssl_cleanse_broken" != "xno"; then :
+
+
+$as_echo "#define OPENSSL_CLEANSE_BROKEN 1" >>confdefs.h
+
+
+fi
 
    { $as_echo "$as_me:${as_lineno-$LINENO}: checking whether to leverage OpenSSL KDF algorithm" >&5
 $as_echo_n "checking whether to leverage OpenSSL KDF algorithm... " >&6; }

--- a/configure.ac
+++ b/configure.ac
@@ -242,9 +242,14 @@ if test "$enable_openssl" = "yes"; then
       [AC_MSG_RESULT([no])])
 
    if test "x$PKG_CONFIG" != "x"; then
-     PKG_CHECK_MODULES([crypto], [libcrypto >= 1.0.1],
+     PKG_CHECK_MODULES([crypto], [libcrypto >= 1.0.2i],
        [CFLAGS="$CFLAGS $crypto_CFLAGS"
-        LIBS="$crypto_LIBS $LIBS"])
+        LIBS="$crypto_LIBS $LIBS"
+        openssl_cleanse_broken=no],
+       [PKG_CHECK_MODULES([crypto], [libcrypto >= 1.0.1],
+         [CFLAGS="$CFLAGS $crypto_CFLAGS"
+          LIBS="$crypto_LIBS $LIBS"
+          openssl_cleanse_broken=maybe])])
    else
      AC_CHECK_LIB([dl], [dlopen], [], [AC_MSG_WARN([can't find libdl])])
      AC_CHECK_LIB([z], [inflate], [], [AC_MSG_WARN([can't find libz])])
@@ -263,29 +268,31 @@ if test "$enable_openssl" = "yes"; then
    HMAC_OBJS=crypto/hash/hmac_ossl.o
    AC_SUBST([USE_EXTERNAL_CRYPTO], [1])
 
-   AC_MSG_CHECKING([if OPENSSL_cleanse is broken])
-   AC_RUN_IFELSE([AC_LANG_PROGRAM([
-     #include <stdio.h>
-     #include <openssl/crypto.h>
-   ], [
-     #define BUFFER_SIZE (16)
-     char buffer[[BUFFER_SIZE]];
-     int i;
-     for (i = 0; i < BUFFER_SIZE; i++) {
-       buffer[[i]] = i & 0xff;
-     }
-     OPENSSL_cleanse(buffer, BUFFER_SIZE);
-     for (i = 0; i < BUFFER_SIZE; i++) {
-       if (buffer[[i]]) {
-         printf("Buffer contents not zero at position %d (is %d)\n", i,
-             buffer[[i]]);
-         return 1;
-       }
-     }
-   ])], [openssl_cleanse_broken=no], [openssl_cleanse_broken=yes], [openssl_cleanse_broken=maybe])
-   AC_MSG_RESULT([$openssl_cleanse_broken])
    AS_IF([test "x$openssl_cleanse_broken" != "xno"], [
-     AC_DEFINE([OPENSSL_CLEANSE_BROKEN], [1], [Define this if OPENSSL_cleanse is broken.])
+     AC_MSG_CHECKING([if OPENSSL_cleanse is broken])
+     AC_RUN_IFELSE([AC_LANG_PROGRAM([
+       #include <stdio.h>
+       #include <openssl/crypto.h>
+     ], [
+       #define BUFFER_SIZE (16)
+       char buffer[[BUFFER_SIZE]];
+       int i;
+       for (i = 0; i < BUFFER_SIZE; i++) {
+         buffer[[i]] = i & 0xff;
+       }
+       OPENSSL_cleanse(buffer, BUFFER_SIZE);
+       for (i = 0; i < BUFFER_SIZE; i++) {
+         if (buffer[[i]]) {
+           printf("Buffer contents not zero at position %d (is %d)\n", i,
+               buffer[[i]]);
+           return 1;
+         }
+       }
+     ])], [openssl_cleanse_broken=no], [openssl_cleanse_broken=yes], [openssl_cleanse_broken=maybe])
+     AC_MSG_RESULT([$openssl_cleanse_broken])
+     AS_IF([test "x$openssl_cleanse_broken" != "xno"], [
+       AC_DEFINE([OPENSSL_CLEANSE_BROKEN], [1], [Define this if OPENSSL_cleanse is broken.])
+     ])
    ])
 
    AC_MSG_CHECKING([whether to leverage OpenSSL KDF algorithm])

--- a/configure.ac
+++ b/configure.ac
@@ -282,11 +282,11 @@ if test "$enable_openssl" = "yes"; then
          return 1;
        }
      }
-   ])], [openssl_cleanse_broken=no], [
-     openssl_cleanse_broken=yes
+   ])], [openssl_cleanse_broken=no], [openssl_cleanse_broken=yes], [openssl_cleanse_broken=maybe])
+   AC_MSG_RESULT([$openssl_cleanse_broken])
+   AS_IF([test "x$openssl_cleanse_broken" != "xno"], [
      AC_DEFINE([OPENSSL_CLEANSE_BROKEN], [1], [Define this if OPENSSL_cleanse is broken.])
    ])
-   AC_MSG_RESULT([$openssl_cleanse_broken])
 
    AC_MSG_CHECKING([whether to leverage OpenSSL KDF algorithm])
    AC_ARG_ENABLE([openssl-kdf],


### PR DESCRIPTION
Don't realize a runtime check for OPENSSL_cleanse() when not needed (newer OpenSSL versions), or not possible (when cross compiling, see #479).
