### PR TITLE
cmake: Set the VERSION property of the srtp2 library

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -176,6 +176,8 @@ add_library(srtp2
   ${SOURCES_H}
 )
 
+set_target_properties(srtp2 PROPERTIES VERSION ${PACKAGE_VERSION})
+
 target_include_directories(srtp2 PUBLIC crypto/include include)
 if(ENABLE_OPENSSL)
   target_link_libraries(srtp2 OpenSSL::Crypto)


### PR DESCRIPTION
From the [cmake documentation](https://cmake.org/cmake/help/v2.8.12/cmake.html#command:set_target_properties):

> For shared libraries VERSION and SOVERSION can be used to specify the build version and API version respectively. When building or installing appropriate symlinks are created if the platform supports symlinks and the linker supports so-names. If only one of both is specified the missing is assumed to have the same version number. For executables VERSION can be used to specify the build version. When building or installing appropriate symlinks are created if the platform supports symlinks. For shared libraries and executables on Windows the VERSION attribute is parsed to extract a "major.minor" version number. These numbers are used as the image version of the binary.

Helpful to see the version off the actual shared library file and symlinks are created accordingly. Pretty much standard with many libraries on Linux.