### PR TITLE
Fix UWP build

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -184,6 +184,7 @@ if(ENABLE_OPENSSL)
 endif()
 if(WIN32)
   target_link_libraries(srtp2 ws2_32)
+  target_compile_definitions(srtp2 PUBLIC _CRT_SECURE_NO_WARNINGS)
 endif()
 
 install(TARGETS srtp2 DESTINATION lib)

--- a/crypto/kernel/crypto_kernel.c
+++ b/crypto/kernel/crypto_kernel.c
@@ -277,7 +277,8 @@ static inline srtp_err_status_t srtp_crypto_kernel_do_load_cipher_type(
     srtp_cipher_type_id_t id,
     int replace)
 {
-    srtp_kernel_cipher_type_t *ctype, *new_ctype;
+    srtp_kernel_cipher_type_t *ctype;
+    srtp_kernel_cipher_type_t *new_ctype = NULL;
     srtp_err_status_t status;
 
     /* defensive coding */
@@ -354,7 +355,8 @@ srtp_err_status_t srtp_crypto_kernel_do_load_auth_type(
     srtp_auth_type_id_t id,
     int replace)
 {
-    srtp_kernel_auth_type_t *atype, *new_atype;
+    srtp_kernel_auth_type_t *atype;
+    srtp_kernel_auth_type_t *new_atype = NULL;
     srtp_err_status_t status;
 
     /* defensive coding */

--- a/test/srtp_driver.c
+++ b/test/srtp_driver.c
@@ -2311,7 +2311,8 @@ srtp_err_status_t srtp_validate_aes_256()
 srtp_err_status_t srtp_create_big_policy(srtp_policy_t **list)
 {
     extern const srtp_policy_t *policy_array[];
-    srtp_policy_t *p, *tmp;
+    srtp_policy_t *p = NULL;
+    srtp_policy_t *tmp;
     int i = 0;
     uint32_t ssrc = 0;
 


### PR DESCRIPTION
UWP, an application framework from Microsoft for Windows, aims higher in terms of security. And as a result, unfortunately, they thought of turning warnings into errors and introducing some safer functions that are not portable.

This pull request removes two obstacles in front of building the current version in UWP
1. UWP finds usage of uninitialized local pointers as evil, reporting errors upon them. This is quite reasonable and has an easy fix of initializing the pointers as NULL, so I've done this to about three of them.
2. UWP thinks using sscanf is wrong and suggests using sscanf_s intsead, which I would not agree if I am in charge of maintaining a portable library. Defining _CRT_SECURE_NO_WARNINGS tells UWP to stop talk about this, so I have added this definition. I added it as a public one of srtp2, so it can spread through the project.

![image](https://user-images.githubusercontent.com/5001447/99485131-ad648f00-2916-11eb-8f4b-6e01f5691eb4.png)
