### PR TITLE
Fix gcc11 warning by defining output length

### DIFF
--- a/crypto/hash/sha1.c
+++ b/crypto/hash/sha1.c
@@ -284,7 +284,7 @@ void srtp_sha1_update(srtp_sha1_ctx_t *ctx,
  * into the twenty octets located at *output
  */
 
-void srtp_sha1_final(srtp_sha1_ctx_t *ctx, uint32_t *output)
+void srtp_sha1_final(srtp_sha1_ctx_t *ctx, uint32_t output[5])
 {
     uint32_t A, B, C, D, E, TEMP;
     uint32_t W[80];


### PR DESCRIPTION
When trying to compile Firefox with gcc 11 we found and fixed a warning.