### PR TITLE
use nss based hmac when nss enabled

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -143,7 +143,7 @@ hashes  = crypto/hash/null_auth.o  crypto/hash/auth.o            \
 	  $(HMAC_OBJS)
 
 replay  = crypto/replay/rdb.o crypto/replay/rdbx.o               \
-		  crypto/replay/ut_sim.o
+	  crypto/replay/ut_sim.o
 
 math    = crypto/math/datatypes.o crypto/math/stat.o
 
@@ -152,7 +152,7 @@ ust     = crypto/ust/ust.o
 err     = crypto/kernel/err.o
 
 kernel  = crypto/kernel/crypto_kernel.o  crypto/kernel/alloc.o   \
-		  crypto/kernel/key.o $(err) # $(ust)
+	  crypto/kernel/key.o $(err) # $(ust)
 
 cryptobj =  $(ciphers) $(hashes) $(math) $(kernel) $(replay)
 
@@ -180,11 +180,12 @@ libsrtp2.so: $(srtpobj) $(cryptobj)
 # test applications
 ifneq (1, $(USE_EXTERNAL_CRYPTO))
 AES_CALC = crypto/test/aes_calc$(EXE)
+SHA1_DRIVER = crypto/test/sha1_driver$(EXE)
 endif
 
 crypto_testapp = $(AES_CALC) crypto/test/cipher_driver$(EXE) \
 	crypto/test/datatypes_driver$(EXE) crypto/test/kernel_driver$(EXE) \
-	crypto/test/sha1_driver$(EXE) crypto/test/stat_driver$(EXE) \
+	$(SHA1_DRIVER) crypto/test/stat_driver$(EXE) \
 	crypto/test/env$(EXE)
 
 testapp = $(crypto_testapp) test/srtp_driver$(EXE) test/replay_driver$(EXE) \

--- a/configure
+++ b/configure
@@ -4691,7 +4691,7 @@ rm -f core conftest.err conftest.$ac_objext conftest.$ac_ext
   done
 
   OOPT=""
-  for f in -O4 -O3; do
+  for f in -O3; do
     if test "x$OOPT" = "x"; then
       { $as_echo "$as_me:${as_lineno-$LINENO}: checking whether ${CC-c} accepts $f" >&5
 $as_echo_n "checking whether ${CC-c} accepts $f... " >&6; }
@@ -6456,9 +6456,7 @@ $as_echo "#define GCM 1" >>confdefs.h
 $as_echo "#define NSS 1" >>confdefs.h
 
    AES_ICM_OBJS="crypto/cipher/aes_icm_nss.o crypto/cipher/aes_gcm_nss.o"
-
-   # TODO(RLB): Use NSS for HMAC
-   HMAC_OBJS="crypto/hash/hmac.o crypto/hash/sha1.o"
+   HMAC_OBJS="crypto/hash/hmac_nss.o"
 
    # TODO(RLB): Use NSS for KDF
 

--- a/configure.ac
+++ b/configure.ac
@@ -353,9 +353,7 @@ elif test "$enable_nss" = "yes"; then
    AC_DEFINE([GCM], [1], [Define this to use AES-GCM.])
    AC_DEFINE([NSS], [1], [Define this to use NSS crypto.])
    AES_ICM_OBJS="crypto/cipher/aes_icm_nss.o crypto/cipher/aes_gcm_nss.o"
-
-   # TODO(RLB): Use NSS for HMAC
-   HMAC_OBJS="crypto/hash/hmac.o crypto/hash/sha1.o"
+   HMAC_OBJS="crypto/hash/hmac_nss.o"
 
    # TODO(RLB): Use NSS for KDF
 

--- a/crypto/Makefile.in
+++ b/crypto/Makefile.in
@@ -61,10 +61,11 @@ dummy : all runtest
 # test applications
 ifneq (1, $(USE_EXTERNAL_CRYPTO))
 AES_CALC = test/aes_calc$(EXE)
+SHA1_DRIVER = test/sha1_driver$(EXE)
 endif
 
 testapp = test/cipher_driver$(EXE) test/datatypes_driver$(EXE) \
-	  test/stat_driver$(EXE) test/sha1_driver$(EXE) \
+	  test/stat_driver$(EXE) $(SHA1_DRIVER) \
 	  test/kernel_driver$(EXE) $(AES_CALC) \
 	  test/env$(EXE)
 
@@ -86,11 +87,11 @@ runtest: $(testapp)
 ifneq (1, $(USE_EXTERNAL_CRYPTO))
 	$(FIND_LIBRARIES) test `test/aes_calc $(k128) $(p128)` = $(c128)
 	$(FIND_LIBRARIES) test `test/aes_calc $(k256) $(p256)` = $(c256)
+	$(FIND_LIBRARIES) test/sha1_driver$(EXE) -v >/dev/null
 endif
 	$(FIND_LIBRARIES) test/cipher_driver$(EXE) -v >/dev/null
 	$(FIND_LIBRARIES) test/datatypes_driver$(EXE) -v >/dev/null
 	$(FIND_LIBRARIES) test/stat_driver$(EXE) >/dev/null
-	$(FIND_LIBRARIES) test/sha1_driver$(EXE) -v >/dev/null
 	$(FIND_LIBRARIES) test/kernel_driver$(EXE) -v >/dev/null
 	@echo "crypto test applications passed."
 

--- a/crypto/hash/auth.c
+++ b/crypto/hash/auth.c
@@ -123,6 +123,12 @@ srtp_err_status_t srtp_auth_type_test(const srtp_auth_type_t *at,
             return status;
         }
 
+        status = srtp_auth_start(a);
+        if (status) {
+            srtp_auth_dealloc(a);
+            return status;
+        }
+
         /* zeroize tag then compute */
         octet_string_set_to_zero(tag, test_case->tag_length_octets);
         status = srtp_auth_compute(a, test_case->data,

--- a/crypto/hash/hmac_nss.c
+++ b/crypto/hash/hmac_nss.c
@@ -92,7 +92,8 @@ static srtp_err_status_t srtp_hmac_alloc(srtp_auth_t **a,
         return srtp_err_status_alloc_fail;
     }
 
-    hmac = (srtp_hmac_nss_ctx_t *)srtp_crypto_alloc(sizeof(srtp_hmac_nss_ctx_t));
+    hmac =
+        (srtp_hmac_nss_ctx_t *)srtp_crypto_alloc(sizeof(srtp_hmac_nss_ctx_t));
     if (hmac == NULL) {
         NSS_ShutdownContext(nss);
         srtp_crypto_free(*a);
@@ -184,7 +185,7 @@ static srtp_err_status_t srtp_hmac_init(void *statev,
 
     SECItem key_item = { siBuffer, (unsigned char *)key, key_len };
     sym_key = PK11_ImportSymKey(slot, CKM_SHA_1_HMAC, PK11_OriginUnwrap,
-                            CKA_SIGN, &key_item, NULL);
+                                CKA_SIGN, &key_item, NULL);
     PK11_FreeSlot(slot);
 
     if (!sym_key) {
@@ -246,7 +247,8 @@ static srtp_err_status_t srtp_hmac_compute(void *statev,
         return srtp_err_status_auth_fail;
     }
 
-    if (PK11_DigestFinal(hmac->ctx, hash_value, &len, SHA1_DIGEST_SIZE) != SECSuccess) {
+    if (PK11_DigestFinal(hmac->ctx, hash_value, &len, SHA1_DIGEST_SIZE) !=
+        SECSuccess) {
         return srtp_err_status_auth_fail;
     }
 

--- a/crypto/hash/hmac_nss.c
+++ b/crypto/hash/hmac_nss.c
@@ -89,6 +89,7 @@ static srtp_err_status_t srtp_hmac_alloc(srtp_auth_t **a,
 
     *a = (srtp_auth_t *)srtp_crypto_alloc(sizeof(srtp_auth_t));
     if (*a == NULL) {
+        NSS_ShutdownContext(nss);
         return srtp_err_status_alloc_fail;
     }
 

--- a/crypto/hash/hmac_nss.c
+++ b/crypto/hash/hmac_nss.c
@@ -1,12 +1,4 @@
 /*
- * hmac_ossl.c
- *
- * Implementation of hmac srtp_auth_type_t that leverages OpenSSL
- *
- * John A. Foley
- * Cisco Systems, Inc.
- */
-/*
  *
  * Copyright(c) 2013-2017, Cisco Systems, Inc.
  * All rights reserved.
@@ -50,23 +42,31 @@
 #include "alloc.h"
 #include "err.h" /* for srtp_debug */
 #include "auth_test_cases.h"
-#include <openssl/evp.h>
-#include <openssl/hmac.h>
+#include <nss.h>
+#include <pk11pub.h>
 
 #define SHA1_DIGEST_SIZE 20
 
 /* the debug module for authentiation */
 
 srtp_debug_module_t srtp_mod_hmac = {
-    0,                   /* debugging is off by default */
-    "hmac sha-1 openssl" /* printable name for module   */
+    0,               /* debugging is off by default */
+    "hmac sha-1 nss" /* printable name for module   */
 };
+
+typedef struct {
+    NSSInitContext *nss;
+    PK11SymKey *key;
+    PK11Context *ctx;
+} srtp_hmac_nss_ctx_t;
 
 static srtp_err_status_t srtp_hmac_alloc(srtp_auth_t **a,
                                          int key_len,
                                          int out_len)
 {
     extern const srtp_auth_type_t srtp_hmac;
+    srtp_hmac_nss_ctx_t *hmac;
+    NSSInitContext *nss;
 
     debug_print(srtp_mod_hmac, "allocating auth func with key length %d",
                 key_len);
@@ -78,40 +78,34 @@ static srtp_err_status_t srtp_hmac_alloc(srtp_auth_t **a,
         return srtp_err_status_bad_param;
     }
 
-/* OpenSSL 1.1.0 made HMAC_CTX an opaque structure, which must be allocated
-   using HMAC_CTX_new.  But this function doesn't exist in OpenSSL 1.0.x. */
-#if OPENSSL_VERSION_NUMBER < 0x10100000L || LIBRESSL_VERSION_NUMBER
-    {
-        /* allocate memory for auth and HMAC_CTX structures */
-        uint8_t *pointer;
-        HMAC_CTX *new_hmac_ctx;
-        pointer = (uint8_t *)srtp_crypto_alloc(sizeof(HMAC_CTX) +
-                                               sizeof(srtp_auth_t));
-        if (pointer == NULL) {
-            return srtp_err_status_alloc_fail;
-        }
-        *a = (srtp_auth_t *)pointer;
-        (*a)->state = pointer + sizeof(srtp_auth_t);
-        new_hmac_ctx = (HMAC_CTX *)((*a)->state);
-
-        HMAC_CTX_init(new_hmac_ctx);
+    /* Initialize NSS equiv of NSS_NoDB_Init(NULL) */
+    nss = NSS_InitContext("", "", "", "", NULL,
+                          NSS_INIT_READONLY | NSS_INIT_NOCERTDB |
+                              NSS_INIT_NOMODDB | NSS_INIT_FORCEOPEN |
+                              NSS_INIT_OPTIMIZESPACE);
+    if (!nss) {
+        return srtp_err_status_auth_fail;
     }
 
-#else
     *a = (srtp_auth_t *)srtp_crypto_alloc(sizeof(srtp_auth_t));
     if (*a == NULL) {
         return srtp_err_status_alloc_fail;
     }
 
-    (*a)->state = HMAC_CTX_new();
-    if ((*a)->state == NULL) {
+    hmac = (srtp_hmac_nss_ctx_t *)srtp_crypto_alloc(sizeof(srtp_hmac_nss_ctx_t));
+    if (hmac == NULL) {
+        NSS_ShutdownContext(nss);
         srtp_crypto_free(*a);
         *a = NULL;
         return srtp_err_status_alloc_fail;
     }
-#endif
+
+    hmac->nss = nss;
+    hmac->key = NULL;
+    hmac->ctx = NULL;
 
     /* set pointers */
+    (*a)->state = hmac;
     (*a)->type = &srtp_hmac;
     (*a)->out_len = out_len;
     (*a)->key_len = key_len;
@@ -122,22 +116,30 @@ static srtp_err_status_t srtp_hmac_alloc(srtp_auth_t **a,
 
 static srtp_err_status_t srtp_hmac_dealloc(srtp_auth_t *a)
 {
-    HMAC_CTX *hmac_ctx;
+    srtp_hmac_nss_ctx_t *hmac;
 
-    hmac_ctx = (HMAC_CTX *)a->state;
+    hmac = (srtp_hmac_nss_ctx_t *)a->state;
+    if (hmac) {
+        /* free any PK11 values that have been created */
+        if (hmac->key) {
+            PK11_FreeSymKey(hmac->key);
+            hmac->key = NULL;
+        }
 
-#if OPENSSL_VERSION_NUMBER < 0x10100000L || LIBRESSL_VERSION_NUMBER
-    HMAC_CTX_cleanup(hmac_ctx);
+        if (hmac->ctx) {
+            PK11_DestroyContext(hmac->ctx, PR_TRUE);
+            hmac->ctx = NULL;
+        }
 
-    /* zeroize entire state*/
-    octet_string_set_to_zero(a, sizeof(HMAC_CTX) + sizeof(srtp_auth_t));
+        if (hmac->nss) {
+            NSS_ShutdownContext(hmac->nss);
+            hmac->nss = NULL;
+        }
 
-#else
-    HMAC_CTX_free(hmac_ctx);
-
-    /* zeroize entire state*/
-    octet_string_set_to_zero(a, sizeof(srtp_auth_t));
-#endif
+        /* zeroize everything */
+        octet_string_set_to_zero(hmac, sizeof(srtp_hmac_nss_ctx_t));
+        srtp_crypto_free(hmac);
+    }
 
     /* free memory */
     srtp_crypto_free(a);
@@ -147,11 +149,12 @@ static srtp_err_status_t srtp_hmac_dealloc(srtp_auth_t *a)
 
 static srtp_err_status_t srtp_hmac_start(void *statev)
 {
-    HMAC_CTX *state = (HMAC_CTX *)statev;
+    srtp_hmac_nss_ctx_t *hmac;
+    hmac = (srtp_hmac_nss_ctx_t *)statev;
 
-    if (HMAC_Init_ex(state, NULL, 0, NULL, NULL) == 0)
+    if (PK11_DigestBegin(hmac->ctx) != SECSuccess) {
         return srtp_err_status_auth_fail;
-
+    }
     return srtp_err_status_ok;
 }
 
@@ -159,10 +162,45 @@ static srtp_err_status_t srtp_hmac_init(void *statev,
                                         const uint8_t *key,
                                         int key_len)
 {
-    HMAC_CTX *state = (HMAC_CTX *)statev;
+    srtp_hmac_nss_ctx_t *hmac;
+    hmac = (srtp_hmac_nss_ctx_t *)statev;
+    PK11SymKey *sym_key;
+    PK11Context *ctx;
 
-    if (HMAC_Init_ex(state, key, key_len, EVP_sha1(), NULL) == 0)
+    if (hmac->ctx) {
+        PK11_DestroyContext(hmac->ctx, PR_TRUE);
+        hmac->ctx = NULL;
+    }
+
+    if (hmac->key) {
+        PK11_FreeSymKey(hmac->key);
+        hmac->key = NULL;
+    }
+
+    PK11SlotInfo *slot = PK11_GetBestSlot(CKM_SHA_1_HMAC, NULL);
+    if (!slot) {
+        return srtp_err_status_bad_param;
+    }
+
+    SECItem key_item = { siBuffer, (unsigned char *)key, key_len };
+    sym_key = PK11_ImportSymKey(slot, CKM_SHA_1_HMAC, PK11_OriginUnwrap,
+                            CKA_SIGN, &key_item, NULL);
+    PK11_FreeSlot(slot);
+
+    if (!sym_key) {
         return srtp_err_status_auth_fail;
+    }
+
+    SECItem param_item = { siBuffer, NULL, 0 };
+    ctx = PK11_CreateContextBySymKey(CKM_SHA_1_HMAC, CKA_SIGN, sym_key,
+                                     &param_item);
+    if (!ctx) {
+        PK11_FreeSymKey(sym_key);
+        return srtp_err_status_auth_fail;
+    }
+
+    hmac->key = sym_key;
+    hmac->ctx = ctx;
 
     return srtp_err_status_ok;
 }
@@ -171,13 +209,15 @@ static srtp_err_status_t srtp_hmac_update(void *statev,
                                           const uint8_t *message,
                                           int msg_octets)
 {
-    HMAC_CTX *state = (HMAC_CTX *)statev;
+    srtp_hmac_nss_ctx_t *hmac;
+    hmac = (srtp_hmac_nss_ctx_t *)statev;
 
     debug_print(srtp_mod_hmac, "input: %s",
                 srtp_octet_string_hex_string(message, msg_octets));
 
-    if (HMAC_Update(state, message, msg_octets) == 0)
+    if (PK11_DigestOp(hmac->ctx, message, msg_octets) != SECSuccess) {
         return srtp_err_status_auth_fail;
+    }
 
     return srtp_err_status_ok;
 }
@@ -188,7 +228,8 @@ static srtp_err_status_t srtp_hmac_compute(void *statev,
                                            int tag_len,
                                            uint8_t *result)
 {
-    HMAC_CTX *state = (HMAC_CTX *)statev;
+    srtp_hmac_nss_ctx_t *hmac;
+    hmac = (srtp_hmac_nss_ctx_t *)statev;
     uint8_t hash_value[SHA1_DIGEST_SIZE];
     int i;
     unsigned int len;
@@ -201,12 +242,13 @@ static srtp_err_status_t srtp_hmac_compute(void *statev,
         return srtp_err_status_bad_param;
     }
 
-    /* hash message, copy output into H */
-    if (HMAC_Update(state, message, msg_octets) == 0)
+    if (PK11_DigestOp(hmac->ctx, message, msg_octets) != SECSuccess) {
         return srtp_err_status_auth_fail;
+    }
 
-    if (HMAC_Final(state, hash_value, &len) == 0)
+    if (PK11_DigestFinal(hmac->ctx, hash_value, &len, SHA1_DIGEST_SIZE) != SECSuccess) {
         return srtp_err_status_auth_fail;
+    }
 
     if (len < tag_len)
         return srtp_err_status_auth_fail;

--- a/crypto/include/sha1.h
+++ b/crypto/include/sha1.h
@@ -52,87 +52,11 @@
 #endif
 
 #include "err.h"
-#ifdef OPENSSL
-#include <openssl/evp.h>
-#include <stdint.h>
-#else
 #include "datatypes.h"
-#endif
 
 #ifdef __cplusplus
 extern "C" {
 #endif
-
-#ifdef OPENSSL
-
-/*
- * srtp_sha1_init(&ctx) initializes the SHA1 context ctx
- *
- * srtp_sha1_update(&ctx, msg, len) hashes the len octets starting at msg
- * into the SHA1 context
- *
- * srtp_sha1_final(&ctx, output) performs the final processing of the SHA1
- * context and writes the result to the 20 octets at output
- *
- * Return values are ignored on the EVP functions since all three
- * of these functions return void.
- *
- */
-
-/* OpenSSL 1.1.0 made EVP_MD_CTX an opaque structure, which must be allocated
-   using EVP_MD_CTX_new. But this function doesn't exist in OpenSSL 1.0.x. */
-#if OPENSSL_VERSION_NUMBER < 0x10100000L || LIBRESSL_VERSION_NUMBER
-
-typedef EVP_MD_CTX srtp_sha1_ctx_t;
-
-static inline void srtp_sha1_init(srtp_sha1_ctx_t *ctx)
-{
-    EVP_MD_CTX_init(ctx);
-    EVP_DigestInit(ctx, EVP_sha1());
-}
-
-static inline void srtp_sha1_update(srtp_sha1_ctx_t *ctx,
-                                    const uint8_t *M,
-                                    int octets_in_msg)
-{
-    EVP_DigestUpdate(ctx, M, octets_in_msg);
-}
-
-static inline void srtp_sha1_final(srtp_sha1_ctx_t *ctx, uint32_t *output)
-{
-    unsigned int len = 0;
-
-    EVP_DigestFinal(ctx, (unsigned char *)output, &len);
-    EVP_MD_CTX_cleanup(ctx);
-}
-
-#else
-
-typedef EVP_MD_CTX *srtp_sha1_ctx_t;
-
-static inline void srtp_sha1_init(srtp_sha1_ctx_t *ctx)
-{
-    *ctx = EVP_MD_CTX_new();
-    EVP_DigestInit(*ctx, EVP_sha1());
-}
-
-static inline void srtp_sha1_update(srtp_sha1_ctx_t *ctx,
-                                    const uint8_t *M,
-                                    int octets_in_msg)
-{
-    EVP_DigestUpdate(*ctx, M, octets_in_msg);
-}
-
-static inline void srtp_sha1_final(srtp_sha1_ctx_t *ctx, uint32_t *output)
-{
-    unsigned int len = 0;
-
-    EVP_DigestFinal(*ctx, (unsigned char *)output, &len);
-    EVP_MD_CTX_free(*ctx);
-}
-#endif
-
-#else
 
 typedef struct {
     uint32_t H[5];            /* state vector                    */
@@ -174,8 +98,6 @@ void srtp_sha1_final(srtp_sha1_ctx_t *ctx, uint32_t output[5]);
  *  complete sha1 function
  */
 void srtp_sha1_core(const uint32_t M[16], uint32_t hash_value[5]);
-
-#endif /* else OPENSSL */
 
 #ifdef __cplusplus
 }

--- a/crypto/test/meson.build
+++ b/crypto/test/meson.build
@@ -4,10 +4,13 @@ test_apps = [
   'cipher_driver',
   'datatypes_driver',
   'stat_driver',
-  'sha1_driver',
   'kernel_driver',
   'env',
 ]
+
+if not use_openssl and not use_nss
+  test_apps += ['sha1_driver']
+endif
 
 foreach test_name : test_apps
   test_exe = executable(test_name,

--- a/meson.build
+++ b/meson.build
@@ -203,10 +203,8 @@ if use_openssl
     'crypto/hash/hmac_ossl.c',
   )
 elif use_nss
-  # TODO(RLB): Use NSS for HMAC
   hashes_sources += files(
-    'crypto/hash/hmac.c',
-    'crypto/hash/sha1.c',
+    'crypto/hash/hmac_nss.c',
   )
 else
   hashes_sources += files(


### PR DESCRIPTION
This was a missing part of the nss support.

Disable sha1_driver if USE_EXTERNAL_CRYPTO is enabled. The sha1_driver is used to test internal sha1 implementation but that is only used when there is no external hmac implementation.