### PR TITLE
support running against nss >= 3.52

### DIFF
--- a/crypto/hash/hmac_nss.c
+++ b/crypto/hash/hmac_nss.c
@@ -42,6 +42,9 @@
 #include "alloc.h"
 #include "err.h" /* for srtp_debug */
 #include "auth_test_cases.h"
+
+#define NSS_PKCS11_2_0_COMPAT 1
+
 #include <nss.h>
 #include <pk11pub.h>
 

--- a/crypto/include/aes_gcm.h
+++ b/crypto/include/aes_gcm.h
@@ -85,6 +85,8 @@ typedef struct {
 
 #ifdef NSS
 
+#define NSS_PKCS11_2_0_COMPAT 1
+
 #include <nss.h>
 #include <pk11pub.h>
 

--- a/crypto/include/aes_icm_ext.h
+++ b/crypto/include/aes_icm_ext.h
@@ -79,6 +79,8 @@ typedef struct {
 
 #ifdef NSS
 
+#define NSS_PKCS11_2_0_COMPAT 1
+
 #include <nss.h>
 #include <pk11pub.h>
 


### PR DESCRIPTION
Fix for #523

This is described in more detail at:
https://bugzilla.mozilla.org/show_bug.cgi?id=1637488#c3

Have decided to go with using NSS_PKCS11_2_0_COMPAT for now
as it provides the most fexibility.
Consider moving to the new PK11_AEADOp api in the future but
that will put a requirment on nss version at both compile and
run time.