### PR TITLE
ci: fix meson build on ubuntu 16.04

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -234,7 +234,7 @@ matrix:
         - sudo docker exec --tty mipsX apt-get update
         - sudo docker exec --tty mipsX apt-get install build-essential -y
         - sudo docker exec --tty mipsX apt-get install qemu-user-static qemu-system-mips gcc-mips-linux-gnu python3-pip -y
-        - sudo docker exec --tty mipsX pip3 install meson ninja
+        - sudo docker exec --tty mipsX pip3 install meson==0.56.2 ninja
       script:
         - sudo docker exec --tty mipsX bash -c 'EXTRA_CFLAGS=-static CC=mips-linux-gnu-gcc ./configure --host=mips-linux-gnu'
         - sudo docker exec --tty mipsX make


### PR DESCRIPTION
Meson requires Python 3.6 from v0.57 onwards, so install the
last Meson version known to work with Python 3.5 on the
Ubuntu 16.04-based CI.

Should hopefully fix the meson mips build on the CI.