### PR TITLE
Make crypto types opaque

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -201,6 +201,7 @@ set(SOURCES_H
   crypto/include/cipher_types.h
   crypto/include/crypto_kernel.h
   crypto/include/crypto_types.h
+  crypto/include/crypto_priv.h
   crypto/include/datatypes.h
   crypto/include/err.h
   crypto/include/hmac.h

--- a/crypto/cipher/cipher.c
+++ b/crypto/cipher/cipher.c
@@ -51,7 +51,7 @@
 #include "cipher.h"
 #include "cipher_priv.h"
 #include "crypto_types.h"
-#include "crypto_priv.h"
+#include "cipher_structs.h"
 #include "err.h"   /* for srtp_debug */
 #include "alloc.h" /* for crypto_alloc(), crypto_free()  */
 

--- a/crypto/cipher/cipher.c
+++ b/crypto/cipher/cipher.c
@@ -51,6 +51,7 @@
 #include "cipher.h"
 #include "cipher_priv.h"
 #include "crypto_types.h"
+#include "crypto_priv.h"
 #include "err.h"   /* for srtp_debug */
 #include "alloc.h" /* for crypto_alloc(), crypto_free()  */
 
@@ -164,6 +165,27 @@ int srtp_cipher_get_key_length(const srtp_cipher_t *c)
 {
     return c->key_len;
 }
+
+const srtp_cipher_type_t *srtp_cipher_get_type(const srtp_cipher_t *c) {
+    return c->type;
+}
+
+int srtp_cipher_get_algorithm(const srtp_cipher_t *ct) {
+    return ct->algorithm;
+}
+
+srtp_cipher_type_id_t srtp_cipher_type_get_id(const srtp_cipher_type_t *ct) {
+    return ct->id;
+}
+
+const char *srtp_cipher_type_get_description(const srtp_cipher_type_t *ct) {
+    return ct->description;
+}
+
+const srtp_cipher_test_case_t *srtp_cipher_type_get_test_data(const srtp_cipher_type_t *ct) {
+    return ct->test_data;
+}
+
 
 /*
  * A trivial platform independent random source.

--- a/crypto/cipher/null_cipher.c
+++ b/crypto/cipher/null_cipher.c
@@ -53,7 +53,7 @@
 #include "err.h" /* for srtp_debug */
 #include "alloc.h"
 #include "cipher_types.h"
-#include "crypto_priv.h"
+#include "cipher_structs.h"
 
 static srtp_err_status_t srtp_null_cipher_alloc(srtp_cipher_t **c,
                                                 int key_len,

--- a/crypto/cipher/null_cipher.c
+++ b/crypto/cipher/null_cipher.c
@@ -53,6 +53,7 @@
 #include "err.h" /* for srtp_debug */
 #include "alloc.h"
 #include "cipher_types.h"
+#include "crypto_priv.h"
 
 static srtp_err_status_t srtp_null_cipher_alloc(srtp_cipher_t **c,
                                                 int key_len,

--- a/crypto/hash/auth.c
+++ b/crypto/hash/auth.c
@@ -48,6 +48,7 @@
 #endif
 
 #include "auth.h"
+#include "auth_structs.h"
 #include "err.h"       /* for srtp_debug */
 #include "datatypes.h" /* for octet_string */
 
@@ -57,6 +58,61 @@ srtp_debug_module_t srtp_mod_auth = {
     0,          /* debugging is off by default */
     "auth func" /* printable name for module   */
 };
+
+srtp_err_status_t srtp_auth_type_alloc(const srtp_auth_type_t *at,
+                                       srtp_auth_t **a,
+                                       int key_len,
+                                       int out_len)
+{
+  return at->alloc(a, key_len, out_len);
+}
+
+srtp_err_status_t srtp_auth_dealloc(srtp_auth_t *a)
+{
+  return a->type->dealloc(a);
+}
+
+srtp_err_status_t srtp_auth_init(srtp_auth_t *a, const uint8_t *key)
+{
+  return a->type->init(a->state, key, a->key_len);
+}
+
+srtp_err_status_t srtp_auth_compute(srtp_auth_t *a,
+                                    const uint8_t *buffer,
+                                    int octets_to_auth,
+                                    uint8_t *tag)
+{
+  return a->type->compute(a->state, buffer, octets_to_auth, a->out_len, tag);
+}
+
+srtp_err_status_t srtp_auth_start(srtp_auth_t *a)
+{
+  return a->type->start(a->state);
+}
+
+srtp_err_status_t srtp_auth_update(srtp_auth_t *a,
+                                   const uint8_t *buffer,
+                                   int octets_to_auth)
+{
+  return a->type->update(a->state, buffer, octets_to_auth);
+}
+
+srtp_auth_type_id_t srtp_auth_type_get_id(const srtp_auth_type_t *at) {
+  return at->id;
+}
+
+const char* srtp_auth_type_get_description(const srtp_auth_type_t *at) {
+  return at->description;
+}
+
+const srtp_auth_test_case_t *srtp_auth_type_get_test_data(const srtp_auth_type_t *at) {
+  return at->test_data;
+}
+
+const srtp_auth_type_t *srtp_auth_get_type(const srtp_auth_t *a)
+{
+    return a->type;
+}
 
 int srtp_auth_get_key_length(const srtp_auth_t *a)
 {

--- a/crypto/include/aes_gcm.h
+++ b/crypto/include/aes_gcm.h
@@ -47,6 +47,7 @@
 #define AES_GCM_H
 
 #include "cipher.h"
+#include "cipher_structs.h"
 #include "srtp.h"
 #include "datatypes.h"
 

--- a/crypto/include/aes_icm.h
+++ b/crypto/include/aes_icm.h
@@ -49,6 +49,7 @@
 
 #include "aes.h"
 #include "cipher.h"
+#include "crypto_priv.h"
 
 typedef struct {
     v128_t counter;                       /* holds the counter value          */

--- a/crypto/include/aes_icm.h
+++ b/crypto/include/aes_icm.h
@@ -49,7 +49,7 @@
 
 #include "aes.h"
 #include "cipher.h"
-#include "crypto_priv.h"
+#include "cipher_structs.h"
 
 typedef struct {
     v128_t counter;                       /* holds the counter value          */

--- a/crypto/include/auth_structs.h
+++ b/crypto/include/auth_structs.h
@@ -1,0 +1,106 @@
+/*
+ * auth.h
+ *
+ * common interface to authentication functions
+ *
+ * David A. McGrew
+ * Cisco Systems, Inc.
+ */
+
+/*
+ *
+ * Copyright (c) 2001-2017, Cisco Systems, Inc.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ *   Redistributions of source code must retain the above copyright
+ *   notice, this list of conditions and the following disclaimer.
+ *
+ *   Redistributions in binary form must reproduce the above
+ *   copyright notice, this list of conditions and the following
+ *   disclaimer in the documentation and/or other materials provided
+ *   with the distribution.
+ *
+ *   Neither the name of the Cisco Systems, Inc. nor the names of its
+ *   contributors may be used to endorse or promote products derived
+ *   from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT HOLDERS OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+ * INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+ * STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED
+ * OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ */
+
+#ifndef SRTP_AUTH_STRUCTS_H
+#define SRTP_AUTH_STRUCTS_H
+
+#include "srtp.h"
+#include "crypto_types.h" /* for values of auth_type_id_t */
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+typedef const struct srtp_auth_type_t *srtp_auth_type_pointer;
+typedef struct srtp_auth_t *srtp_auth_pointer_t;
+
+typedef srtp_err_status_t (*srtp_auth_alloc_func)(srtp_auth_pointer_t *ap,
+                                                  int key_len,
+                                                  int out_len);
+
+typedef srtp_err_status_t (*srtp_auth_init_func)(void *state,
+                                                 const uint8_t *key,
+                                                 int key_len);
+
+typedef srtp_err_status_t (*srtp_auth_dealloc_func)(srtp_auth_pointer_t ap);
+
+typedef srtp_err_status_t (*srtp_auth_compute_func)(void *state,
+                                                    const uint8_t *buffer,
+                                                    int octets_to_auth,
+                                                    int tag_len,
+                                                    uint8_t *tag);
+
+typedef srtp_err_status_t (*srtp_auth_update_func)(void *state,
+                                                   const uint8_t *buffer,
+                                                   int octets_to_auth);
+
+typedef srtp_err_status_t (*srtp_auth_start_func)(void *state);
+
+/* srtp_auth_type_t */
+struct srtp_auth_type_t {
+    srtp_auth_alloc_func alloc;
+    srtp_auth_dealloc_func dealloc;
+    srtp_auth_init_func init;
+    srtp_auth_compute_func compute;
+    srtp_auth_update_func update;
+    srtp_auth_start_func start;
+    const char *description;
+    const srtp_auth_test_case_t *test_data;
+    srtp_auth_type_id_t id;
+};
+
+struct srtp_auth_t {
+    const srtp_auth_type_t *type;
+    void *state;
+    int out_len;    /* length of output tag in octets */
+    int key_len;    /* length of key in octets        */
+    int prefix_len; /* length of keystream prefix     */
+};
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* SRTP_AUTH_STRUCTS_H */

--- a/crypto/include/cipher.h
+++ b/crypto/include/cipher.h
@@ -53,6 +53,23 @@ extern "C" {
 #endif
 
 /*
+ * srtp_cipher_type_t defines the 'metadata' for a particular cipher type
+ *
+ * Kept opaque to separate interface from implementation.  See crypto_priv.h for
+ * internal details.
+ */
+typedef struct srtp_cipher_type_t srtp_cipher_type_t;
+
+/*
+ * srtp_cipher_t defines an instantiation of a particular cipher, with fixed
+ * key length, key and salt values
+ *
+ * Kept opaque to separate interface from implementation.  See crypto_priv.h for
+ * internal details.
+ */
+typedef struct srtp_cipher_t srtp_cipher_t;
+
+/*
  * srtp_cipher_direction_t defines a particular cipher operation.
  *
  * A srtp_cipher_direction_t is an enum that describes a particular cipher
@@ -70,59 +87,6 @@ typedef enum {
  * as srtp_cipher_t is not yet defined
  */
 typedef struct srtp_cipher_t *srtp_cipher_pointer_t;
-
-/*
- *  a srtp_cipher_alloc_func_t allocates (but does not initialize) a
- * srtp_cipher_t
- */
-typedef srtp_err_status_t (*srtp_cipher_alloc_func_t)(srtp_cipher_pointer_t *cp,
-                                                      int key_len,
-                                                      int tag_len);
-
-/*
- * a srtp_cipher_init_func_t [re-]initializes a cipher_t with a given key
- */
-typedef srtp_err_status_t (*srtp_cipher_init_func_t)(void *state,
-                                                     const uint8_t *key);
-
-/* a srtp_cipher_dealloc_func_t de-allocates a cipher_t */
-typedef srtp_err_status_t (*srtp_cipher_dealloc_func_t)(
-    srtp_cipher_pointer_t cp);
-
-/*
- * a srtp_cipher_set_aad_func_t processes the AAD data for AEAD ciphers
- */
-typedef srtp_err_status_t (*srtp_cipher_set_aad_func_t)(void *state,
-                                                        const uint8_t *aad,
-                                                        uint32_t aad_len);
-
-/* a srtp_cipher_encrypt_func_t encrypts data in-place */
-typedef srtp_err_status_t (*srtp_cipher_encrypt_func_t)(
-    void *state,
-    uint8_t *buffer,
-    unsigned int *octets_to_encrypt);
-
-/* a srtp_cipher_decrypt_func_t decrypts data in-place */
-typedef srtp_err_status_t (*srtp_cipher_decrypt_func_t)(
-    void *state,
-    uint8_t *buffer,
-    unsigned int *octets_to_decrypt);
-
-/*
- * a srtp_cipher_set_iv_func_t function sets the current initialization vector
- */
-typedef srtp_err_status_t (*srtp_cipher_set_iv_func_t)(
-    void *state,
-    uint8_t *iv,
-    srtp_cipher_direction_t direction);
-
-/*
- * a cipher_get_tag_func_t function is used to get the authentication
- * tag that was calculated by an AEAD cipher.
- */
-typedef srtp_err_status_t (*srtp_cipher_get_tag_func_t)(void *state,
-                                                        uint8_t *tag,
-                                                        uint32_t *len);
 
 /*
  * srtp_cipher_test_case_t is a (list of) key, salt, plaintext, ciphertext,
@@ -146,34 +110,14 @@ typedef struct srtp_cipher_test_case_t {
         *next_test_case; /* pointer to next testcase */
 } srtp_cipher_test_case_t;
 
-/* srtp_cipher_type_t defines the 'metadata' for a particular cipher type */
-typedef struct srtp_cipher_type_t {
-    srtp_cipher_alloc_func_t alloc;
-    srtp_cipher_dealloc_func_t dealloc;
-    srtp_cipher_init_func_t init;
-    srtp_cipher_set_aad_func_t set_aad;
-    srtp_cipher_encrypt_func_t encrypt;
-    srtp_cipher_encrypt_func_t decrypt;
-    srtp_cipher_set_iv_func_t set_iv;
-    srtp_cipher_get_tag_func_t get_tag;
-    const char *description;
-    const srtp_cipher_test_case_t *test_data;
-    srtp_cipher_type_id_t id;
-} srtp_cipher_type_t;
-
-/*
- * srtp_cipher_t defines an instantiation of a particular cipher, with fixed
- * key length, key and salt values
- */
-typedef struct srtp_cipher_t {
-    const srtp_cipher_type_t *type;
-    void *state;
-    int key_len;
-    int algorithm;
-} srtp_cipher_t;
-
 /* some bookkeeping functions */
 int srtp_cipher_get_key_length(const srtp_cipher_t *c);
+const srtp_cipher_type_t *srtp_cipher_get_type(const srtp_cipher_t *c);
+int srtp_cipher_get_algorithm(const srtp_cipher_t *ct);
+
+srtp_cipher_type_id_t srtp_cipher_type_get_id(const srtp_cipher_type_t *ct);
+const char *srtp_cipher_type_get_description(const srtp_cipher_type_t *ct);
+const srtp_cipher_test_case_t *srtp_cipher_type_get_test_data(const srtp_cipher_type_t *ct);
 
 /*
  * srtp_cipher_type_self_test() tests a cipher against test cases provided in

--- a/crypto/include/cipher_structs.h
+++ b/crypto/include/cipher_structs.h
@@ -42,8 +42,8 @@
  *
  */
 
-#ifndef SRTP_CRYPTO_PRIV_H
-#define SRTP_CRYPTO_PRIV_H
+#ifndef SRTP_CIPHER_STRUCTS_H
+#define SRTP_CIPHER_STRUCTS_H
 
 #include "srtp.h"
 #include "crypto_types.h" /* for values of cipher_type_id_t */
@@ -135,5 +135,5 @@ typedef struct srtp_cipher_t {
 }
 #endif
 
-#endif /* SRTP_CRYPTO_PRIV_H */
+#endif /* SRTP_CIPHER_STRUCTS_H */
 

--- a/crypto/include/crypto_priv.h
+++ b/crypto/include/crypto_priv.h
@@ -1,0 +1,139 @@
+/*
+ * cipher.h
+ *
+ * common interface to ciphers
+ *
+ * David A. McGrew
+ * Cisco Systems, Inc.
+ */
+/*
+ *
+ * Copyright (c) 2001-2017 Cisco Systems, Inc.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ *   Redistributions of source code must retain the above copyright
+ *   notice, this list of conditions and the following disclaimer.
+ *
+ *   Redistributions in binary form must reproduce the above
+ *   copyright notice, this list of conditions and the following
+ *   disclaimer in the documentation and/or other materials provided
+ *   with the distribution.
+ *
+ *   Neither the name of the Cisco Systems, Inc. nor the names of its
+ *   contributors may be used to endorse or promote products derived
+ *   from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT HOLDERS OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+ * INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+ * STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED
+ * OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ */
+
+#ifndef SRTP_CRYPTO_PRIV_H
+#define SRTP_CRYPTO_PRIV_H
+
+#include "srtp.h"
+#include "crypto_types.h" /* for values of cipher_type_id_t */
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/*
+ *  a srtp_cipher_alloc_func_t allocates (but does not initialize) a
+ * srtp_cipher_t
+ */
+typedef srtp_err_status_t (*srtp_cipher_alloc_func_t)(srtp_cipher_pointer_t *cp,
+                                                      int key_len,
+                                                      int tag_len);
+
+/*
+ * a srtp_cipher_init_func_t [re-]initializes a cipher_t with a given key
+ */
+typedef srtp_err_status_t (*srtp_cipher_init_func_t)(void *state,
+                                                     const uint8_t *key);
+
+/* a srtp_cipher_dealloc_func_t de-allocates a cipher_t */
+typedef srtp_err_status_t (*srtp_cipher_dealloc_func_t)(
+    srtp_cipher_pointer_t cp);
+
+/*
+ * a srtp_cipher_set_aad_func_t processes the AAD data for AEAD ciphers
+ */
+typedef srtp_err_status_t (*srtp_cipher_set_aad_func_t)(void *state,
+                                                        const uint8_t *aad,
+                                                        uint32_t aad_len);
+
+/* a srtp_cipher_encrypt_func_t encrypts data in-place */
+typedef srtp_err_status_t (*srtp_cipher_encrypt_func_t)(
+    void *state,
+    uint8_t *buffer,
+    unsigned int *octets_to_encrypt);
+
+/* a srtp_cipher_decrypt_func_t decrypts data in-place */
+typedef srtp_err_status_t (*srtp_cipher_decrypt_func_t)(
+    void *state,
+    uint8_t *buffer,
+    unsigned int *octets_to_decrypt);
+
+/*
+ * a srtp_cipher_set_iv_func_t function sets the current initialization vector
+ */
+typedef srtp_err_status_t (*srtp_cipher_set_iv_func_t)(
+    void *state,
+    uint8_t *iv,
+    srtp_cipher_direction_t direction);
+
+/*
+ * a cipher_get_tag_func_t function is used to get the authentication
+ * tag that was calculated by an AEAD cipher.
+ */
+typedef srtp_err_status_t (*srtp_cipher_get_tag_func_t)(void *state,
+                                                        uint8_t *tag,
+                                                        uint32_t *len);
+
+/* srtp_cipher_type_t defines the 'metadata' for a particular cipher type */
+typedef struct srtp_cipher_type_t {
+    srtp_cipher_alloc_func_t alloc;
+    srtp_cipher_dealloc_func_t dealloc;
+    srtp_cipher_init_func_t init;
+    srtp_cipher_set_aad_func_t set_aad;
+    srtp_cipher_encrypt_func_t encrypt;
+    srtp_cipher_encrypt_func_t decrypt;
+    srtp_cipher_set_iv_func_t set_iv;
+    srtp_cipher_get_tag_func_t get_tag;
+    const char *description;
+    const srtp_cipher_test_case_t *test_data;
+    srtp_cipher_type_id_t id;
+} srtp_cipher_type_t;
+
+/*
+ * srtp_cipher_t defines an instantiation of a particular cipher, with fixed
+ * key length, key and salt values
+ */
+typedef struct srtp_cipher_t {
+    const srtp_cipher_type_t *type;
+    void *state;
+    int key_len;
+    int algorithm;
+} srtp_cipher_t;
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* SRTP_CRYPTO_PRIV_H */
+

--- a/crypto/include/hmac.h
+++ b/crypto/include/hmac.h
@@ -47,6 +47,7 @@
 #define HMAC_H
 
 #include "auth.h"
+#include "auth_structs.h"
 #include "sha1.h"
 
 typedef struct {

--- a/crypto/include/null_auth.h
+++ b/crypto/include/null_auth.h
@@ -46,6 +46,7 @@
 #define NULL_AUTH_H
 
 #include "auth.h"
+#include "auth_structs.h"
 
 #ifdef __cplusplus
 extern "C" {

--- a/crypto/kernel/crypto_kernel.c
+++ b/crypto/kernel/crypto_kernel.c
@@ -181,7 +181,7 @@ srtp_err_status_t srtp_crypto_kernel_status()
     /* for each cipher type, describe and test */
     while (ctype != NULL) {
         srtp_err_report(srtp_err_level_info, "cipher: %s\n",
-                        ctype->cipher_type->description);
+                        srtp_cipher_type_get_description(ctype->cipher_type));
         srtp_err_report(srtp_err_level_info, "  self-test: ");
         status = srtp_cipher_type_self_test(ctype->cipher_type);
         if (status) {
@@ -243,7 +243,7 @@ srtp_err_status_t srtp_crypto_kernel_shutdown()
         srtp_kernel_cipher_type_t *ctype = crypto_kernel.cipher_type_list;
         crypto_kernel.cipher_type_list = ctype->next;
         debug_print(srtp_mod_crypto_kernel, "freeing memory for cipher %s",
-                    ctype->cipher_type->description);
+                    srtp_cipher_type_get_description(ctype->cipher_type));
         srtp_crypto_free(ctype);
     }
 
@@ -286,7 +286,7 @@ static inline srtp_err_status_t srtp_crypto_kernel_do_load_cipher_type(
         return srtp_err_status_bad_param;
     }
 
-    if (new_ct->id != id) {
+    if (srtp_cipher_type_get_id(new_ct) != id) {
         return srtp_err_status_bad_param;
     }
 
@@ -299,12 +299,12 @@ static inline srtp_err_status_t srtp_crypto_kernel_do_load_cipher_type(
     /* walk down list, checking if this type is in the list already  */
     ctype = crypto_kernel.cipher_type_list;
     while (ctype != NULL) {
-        if (id == ctype->id) {
+        if (id == srtp_cipher_type_get_id(ctype->cipher_type)) {
             if (!replace) {
                 return srtp_err_status_bad_param;
             }
             status =
-                srtp_cipher_type_test(new_ct, ctype->cipher_type->test_data);
+                srtp_cipher_type_test(new_ct, srtp_cipher_type_get_test_data(ctype->cipher_type));
             if (status) {
                 return status;
             }
@@ -465,7 +465,7 @@ srtp_err_status_t srtp_crypto_kernel_alloc_cipher(srtp_cipher_type_id_t id,
         return srtp_err_status_fail;
     }
 
-    return ((ct)->alloc(cp, key_len, tag_len));
+    return srtp_cipher_type_alloc(ct, cp, key_len, tag_len);
 }
 
 const srtp_auth_type_t *srtp_crypto_kernel_get_auth_type(srtp_auth_type_id_t id)

--- a/crypto/kernel/crypto_kernel.c
+++ b/crypto/kernel/crypto_kernel.c
@@ -196,7 +196,7 @@ srtp_err_status_t srtp_crypto_kernel_status()
     /* for each auth type, describe and test */
     while (atype != NULL) {
         srtp_err_report(srtp_err_level_info, "auth func: %s\n",
-                        atype->auth_type->description);
+                        srtp_auth_type_get_description(atype->auth_type));
         srtp_err_report(srtp_err_level_info, "  self-test: ");
         status = srtp_auth_type_self_test(atype->auth_type);
         if (status) {
@@ -253,7 +253,7 @@ srtp_err_status_t srtp_crypto_kernel_shutdown()
         crypto_kernel.auth_type_list = atype->next;
         debug_print(srtp_mod_crypto_kernel,
                     "freeing memory for authentication %s",
-                    atype->auth_type->description);
+                    srtp_auth_type_get_description(atype->auth_type));
         srtp_crypto_free(atype);
     }
 
@@ -364,7 +364,7 @@ srtp_err_status_t srtp_crypto_kernel_do_load_auth_type(
         return srtp_err_status_bad_param;
     }
 
-    if (new_at->id != id) {
+    if (srtp_auth_type_get_id(new_at) != id) {
         return srtp_err_status_bad_param;
     }
 
@@ -381,7 +381,7 @@ srtp_err_status_t srtp_crypto_kernel_do_load_auth_type(
             if (!replace) {
                 return srtp_err_status_bad_param;
             }
-            status = srtp_auth_type_test(new_at, atype->auth_type->test_data);
+            status = srtp_auth_type_test(new_at, srtp_auth_type_get_test_data(atype->auth_type));
             if (status) {
                 return status;
             }
@@ -505,7 +505,7 @@ srtp_err_status_t srtp_crypto_kernel_alloc_auth(srtp_auth_type_id_t id,
         return srtp_err_status_fail;
     }
 
-    return ((at)->alloc(ap, key_len, tag_len));
+    return srtp_auth_type_alloc(at, ap, key_len, tag_len);
 }
 
 srtp_err_status_t srtp_crypto_kernel_load_debug_module(

--- a/crypto/test/cipher_driver.c
+++ b/crypto/test/cipher_driver.c
@@ -318,8 +318,10 @@ void cipher_driver_test_throughput(srtp_cipher_t *c)
     int max_enc_len = 2048; /* should be a power of two */
     int num_trials = 1000000;
 
-    printf("timing %s throughput, key length %d:\n", c->type->description,
-           c->key_len);
+    const srtp_cipher_type_t *ct = srtp_cipher_get_type(c);
+    const char* description = srtp_cipher_type_get_description(ct);
+    printf("timing %s throughput, key length %d:\n", description,
+           srtp_cipher_get_key_length(c));
     fflush(stdout);
     for (i = min_enc_len; i <= max_enc_len; i = i * 2)
         printf("msg len: %d\tgigabits per second: %f\n", i,
@@ -330,7 +332,8 @@ srtp_err_status_t cipher_driver_self_test(srtp_cipher_type_t *ct)
 {
     srtp_err_status_t status;
 
-    printf("running cipher self-test for %s...", ct->description);
+    const char* description = srtp_cipher_type_get_description(ct);
+    printf("running cipher self-test for %s...", description);
     status = srtp_cipher_type_self_test(ct);
     if (status) {
         printf("failed with error code %d\n", status);
@@ -357,7 +360,9 @@ srtp_err_status_t cipher_driver_test_buffering(srtp_cipher_t *c)
                         0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x12, 0x34 };
     srtp_err_status_t status;
 
-    printf("testing output buffering for cipher %s...", c->type->description);
+    const srtp_cipher_type_t *ct = srtp_cipher_get_type(c);
+    const char* description = srtp_cipher_type_get_description(ct);
+    printf("testing output buffering for cipher %s...", description);
 
     for (i = 0; i < num_trials; i++) {
         /* set buffers to zero */
@@ -475,10 +480,6 @@ srtp_err_status_t cipher_array_alloc_init(srtp_cipher_t ***ca,
         if (status)
             return status;
 
-        /*     printf("%dth cipher is at %p\n", i, *cipher_array); */
-        /*     printf("%dth cipher description: %s\n", i,  */
-        /* 	   (*cipher_array)->type->description); */
-
         /* advance cipher array pointer */
         cipher_array++;
     }
@@ -567,8 +568,11 @@ void cipher_array_test_throughput(srtp_cipher_t *ca[], int num_cipher)
     int max_enc_len = 2048; /* should be a power of two */
     int num_trials = 1000000;
 
+    const srtp_cipher_type_t *ct = srtp_cipher_get_type(ca[0]);
+    const char* description = srtp_cipher_type_get_description(ct);
+    int key_len = srtp_cipher_get_key_length(ca[0]);
     printf("timing %s throughput with key length %d, array size %d:\n",
-           (ca[0])->type->description, (ca[0])->key_len, num_cipher);
+           description, key_len, num_cipher);
     fflush(stdout);
     for (i = min_enc_len; i <= max_enc_len; i = i * 4)
         printf("msg len: %d\tgigabits per second: %f\n", i,

--- a/srtp/srtp.c
+++ b/srtp/srtp.c
@@ -2595,7 +2595,7 @@ srtp_err_status_t srtp_unprotect_mki(srtp_ctx_t *ctx,
          * if the keystream prefix length is zero, then we know that
          * the authenticator isn't using a universal hash function
          */
-        if (session_keys->rtp_auth->prefix_len != 0) {
+        if (srtp_auth_get_prefix_length(session_keys->rtp_auth) != 0) {
             prefix_len = srtp_auth_get_prefix_length(session_keys->rtp_auth);
             status = srtp_cipher_output(session_keys->rtp_cipher, tmp_tag,
                                         &prefix_len);

--- a/test/srtp_driver.c
+++ b/test/srtp_driver.c
@@ -1449,7 +1449,9 @@ srtp_err_status_t srtp_session_print_policy(srtp_t srtp)
     srtp_stream_t stream;
     srtp_session_keys_t *session_keys = NULL;
     const srtp_cipher_type_t *rtp_cipher_type;
+    const srtp_auth_type_t *rtp_auth_type;
     const srtp_cipher_type_t *rtcp_cipher_type;
+    const srtp_auth_type_t *rtcp_auth_type;
 
     /* sanity checking */
     if (srtp == NULL) {
@@ -1461,7 +1463,9 @@ srtp_err_status_t srtp_session_print_policy(srtp_t srtp)
         stream = srtp->stream_template;
         session_keys = &stream->session_keys[0];
         rtp_cipher_type = srtp_cipher_get_type(session_keys->rtp_cipher);
+        rtp_auth_type = srtp_auth_get_type(session_keys->rtp_auth);
         rtcp_cipher_type = srtp_cipher_get_type(session_keys->rtcp_cipher);
+        rtcp_auth_type = srtp_auth_get_type(session_keys->rtcp_auth);
         printf("# SSRC:          any %s\r\n"
                "# rtp cipher:    %s\r\n"
                "# rtp auth:      %s\r\n"
@@ -1473,10 +1477,10 @@ srtp_err_status_t srtp_session_print_policy(srtp_t srtp)
                "# tx rtx allowed:%s\r\n",
                direction[stream->direction],
                srtp_cipher_type_get_description(rtp_cipher_type),
-               session_keys->rtp_auth->type->description,
+               srtp_auth_type_get_description(rtp_auth_type),
                serv_descr[stream->rtp_services],
                srtp_cipher_type_get_description(rtcp_cipher_type),
-               session_keys->rtcp_auth->type->description,
+               srtp_auth_type_get_description(rtcp_auth_type),
                serv_descr[stream->rtcp_services],
                srtp_rdbx_get_window_size(&stream->rtp_rdbx),
                stream->allow_repeat_tx ? "true" : "false");
@@ -1505,7 +1509,9 @@ srtp_err_status_t srtp_session_print_policy(srtp_t srtp)
         session_keys = &stream->session_keys[0];
 
         rtp_cipher_type = srtp_cipher_get_type(session_keys->rtp_cipher);
+        rtp_auth_type = srtp_auth_get_type(session_keys->rtp_auth);
         rtcp_cipher_type = srtp_cipher_get_type(session_keys->rtcp_cipher);
+        rtcp_auth_type = srtp_auth_get_type(session_keys->rtcp_auth);
         printf("# SSRC:          0x%08x\r\n"
                "# rtp cipher:    %s\r\n"
                "# rtp auth:      %s\r\n"
@@ -1517,10 +1523,10 @@ srtp_err_status_t srtp_session_print_policy(srtp_t srtp)
                "# tx rtx allowed:%s\r\n",
                stream->ssrc,
                srtp_cipher_type_get_description(rtp_cipher_type),
-               session_keys->rtp_auth->type->description,
+               srtp_auth_type_get_description(rtp_auth_type),
                serv_descr[stream->rtp_services],
                srtp_cipher_type_get_description(rtcp_cipher_type),
-               session_keys->rtcp_auth->type->description,
+               srtp_auth_type_get_description(rtcp_auth_type),
                serv_descr[stream->rtcp_services],
                srtp_rdbx_get_window_size(&stream->rtp_rdbx),
                stream->allow_repeat_tx ? "true" : "false");

--- a/test/srtp_driver.c
+++ b/test/srtp_driver.c
@@ -1448,6 +1448,8 @@ srtp_err_status_t srtp_session_print_policy(srtp_t srtp)
     char *direction[3] = { "unknown", "outbound", "inbound" };
     srtp_stream_t stream;
     srtp_session_keys_t *session_keys = NULL;
+    const srtp_cipher_type_t *rtp_cipher_type;
+    const srtp_cipher_type_t *rtcp_cipher_type;
 
     /* sanity checking */
     if (srtp == NULL) {
@@ -1458,6 +1460,8 @@ srtp_err_status_t srtp_session_print_policy(srtp_t srtp)
     if (srtp->stream_template != NULL) {
         stream = srtp->stream_template;
         session_keys = &stream->session_keys[0];
+        rtp_cipher_type = srtp_cipher_get_type(session_keys->rtp_cipher);
+        rtcp_cipher_type = srtp_cipher_get_type(session_keys->rtcp_cipher);
         printf("# SSRC:          any %s\r\n"
                "# rtp cipher:    %s\r\n"
                "# rtp auth:      %s\r\n"
@@ -1468,10 +1472,10 @@ srtp_err_status_t srtp_session_print_policy(srtp_t srtp)
                "# window size:   %lu\r\n"
                "# tx rtx allowed:%s\r\n",
                direction[stream->direction],
-               session_keys->rtp_cipher->type->description,
+               srtp_cipher_type_get_description(rtp_cipher_type),
                session_keys->rtp_auth->type->description,
                serv_descr[stream->rtp_services],
-               session_keys->rtcp_cipher->type->description,
+               srtp_cipher_type_get_description(rtcp_cipher_type),
                session_keys->rtcp_auth->type->description,
                serv_descr[stream->rtcp_services],
                srtp_rdbx_get_window_size(&stream->rtp_rdbx),
@@ -1500,6 +1504,8 @@ srtp_err_status_t srtp_session_print_policy(srtp_t srtp)
         }
         session_keys = &stream->session_keys[0];
 
+        rtp_cipher_type = srtp_cipher_get_type(session_keys->rtp_cipher);
+        rtcp_cipher_type = srtp_cipher_get_type(session_keys->rtcp_cipher);
         printf("# SSRC:          0x%08x\r\n"
                "# rtp cipher:    %s\r\n"
                "# rtp auth:      %s\r\n"
@@ -1509,10 +1515,11 @@ srtp_err_status_t srtp_session_print_policy(srtp_t srtp)
                "# rtcp services: %s\r\n"
                "# window size:   %lu\r\n"
                "# tx rtx allowed:%s\r\n",
-               stream->ssrc, session_keys->rtp_cipher->type->description,
+               stream->ssrc,
+               srtp_cipher_type_get_description(rtp_cipher_type),
                session_keys->rtp_auth->type->description,
                serv_descr[stream->rtp_services],
-               session_keys->rtcp_cipher->type->description,
+               srtp_cipher_type_get_description(rtcp_cipher_type),
                session_keys->rtcp_auth->type->description,
                serv_descr[stream->rtcp_services],
                srtp_rdbx_get_window_size(&stream->rtp_rdbx),


### PR DESCRIPTION
Right now, the internals of crypto structs are visible and widely used.  This PR replaces direct struct member access with accessor functions.

It is a draft right now for feedback, and because only the `cipher` side of things is done.  If folks are OK with this approach, then I will do the `auth` side as well.