### PR TITLE
Adjust .pc file not to expose used crypto library

### DIFF
--- a/libsrtp2.pc.in
+++ b/libsrtp2.pc.in
@@ -7,5 +7,6 @@ Name: @PACKAGE_NAME@
 Version: @PACKAGE_VERSION@
 Description: Library for SRTP (Secure Realtime Transport Protocol)
 
-Libs: -L${libdir} -lsrtp2 @LIBS@
+Libs: -L${libdir} -lsrtp2
+Libs.private: @LIBS@
 Cflags: -I${includedir}


### PR DESCRIPTION
srtp headers are not directly including openssl headers. The srtp (shared)
library already has links to libcrypto and so -lcrypto is at best only needed
for static linking, but that must go into a the field called "private".