### PR TITLE
Add void to function declarations for EVP_EncryptInit check

### DIFF
--- a/configure
+++ b/configure
@@ -5882,9 +5882,9 @@ cat confdefs.h - <<_ACEOF >conftest.$ac_ext
 #ifdef __cplusplus
 extern "C"
 #endif
-char EVP_EncryptInit ();
+char EVP_EncryptInit (void);
 int
-main ()
+main (void)
 {
 return EVP_EncryptInit ();
   ;


### PR DESCRIPTION
gcc 11.1.1 complains about not having strict function prototypes
(-Wstrict-prototypes) when attempting to test for linkage with openssl.

This warning was added in PR #284. Why it started acting up now is
unknown. It may be that gcc 11.1.1 have changed how and when they emit
this warning.

Adding void to the function declarations seems to silence this warning
and allow the test to run to completion.