### PR TITLE
Improve OpenSSL KDF check

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -133,7 +133,7 @@ if crypto_library == 'openssl'
   # forks of OpenSSL: https://github.com/cisco/libsrtp/issues/458
   if (
     openssl_dep.type_name() != 'internal' and
-    get_option('crypto-library-kdf').disabled() != true and
+    not get_option('crypto-library-kdf').disabled() and
     cc.has_function('kdf_srtp', dependencies: openssl_dep)
   )
     cdata.set('OPENSSL_KDF', true)

--- a/meson.build
+++ b/meson.build
@@ -131,7 +131,11 @@ if crypto_library == 'openssl'
   use_openssl = true
   # NOTE: This is not available in upstream OpenSSL yet. It's only in 'certain'
   # forks of OpenSSL: https://github.com/cisco/libsrtp/issues/458
-  if cc.has_function('kdf_srtp', dependencies: openssl_dep)
+  if (
+    openssl_dep.type_name() != 'internal' and
+    get_option('crypto-library-kdf').disabled() != true and
+    cc.has_function('kdf_srtp', dependencies: openssl_dep)
+  )
     cdata.set('OPENSSL_KDF', true)
   elif get_option('crypto-library-kdf').enabled()
     error('KDF support has been enabled, but OpenSSL does not provide it')


### PR DESCRIPTION
Without this change libsrtp2 usage with OpenSSL as subproject will fail with:
> subprojects/libsrtp2/meson.build:134:10: ERROR: Dependencies must be external dependencies

I had to include 2 additional conditions:
* make sure dependency is not internal, otherwise we know `cc.has_function()` will fail as error above suggests
* check if user explicitly disabled `crypto-library-kdf` option (in which case there is no need to check anything and configuration incorrectly didn't take that into account)

P.S. OpenSSL as subproject/wrap will hopefully soon be a thing, see https://github.com/mesonbuild/wrapdb/pull/113