### PR TITLE
update cmake minimal required version to 3.12

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.2)
+cmake_minimum_required(VERSION 3.12)
 
 project(libsrtp2 VERSION 2.4.0 LANGUAGES C)
 


### PR DESCRIPTION
The variable `CMAKE_PROJECT_VERSION ` used at
https://github.com/cisco/libsrtp/blob/8168ab17f4cc7cacb2db1e6f3ec0b505d6f24693/CMakeLists.txt#L5
was introduced in cmake version 3.12:
https://cmake.org/cmake/help/v3.20/variable/CMAKE_PROJECT_VERSION.html

> New in version 3.12.

If compiling with cmake version lower than 3.12, this variable will be undefined.
This commit will update `cmake_minimum_required ` to 3.12 to fix this issue.