### PR TITLE
Count blocks instead of bytes in AES-ICM limit computation

### DIFF
--- a/crypto/cipher/aes_icm.c
+++ b/crypto/cipher/aes_icm.c
@@ -302,7 +302,9 @@ static srtp_err_status_t srtp_aes_icm_encrypt(void *cv,
     uint32_t *b;
 
     /* check that there's enough segment left*/
-    if ((bytes_to_encr + htons(c->counter.v16[7])) > 0xffff) {
+    unsigned int bytes_of_new_keystream = bytes_to_encr - c->bytes_in_buffer;
+    unsigned int blocks_of_new_keystream = (bytes_of_new_keystream + 15) >> 4;
+    if ((blocks_of_new_keystream + htons(c->counter.v16[7])) > 0xffff) {
         return srtp_err_status_terminus;
     }
 


### PR DESCRIPTION
As noted in #509, the current AES-ICM implementation incorrectly computes the number of bytes it can encrypt.  The block counter counts in units of 16-byte AES blocks, but it is added to the number bytes to be encrypted.  This PR changes the computation to compute how many new blocks of keystream are required, and compare that with the counter to ensure that enough counter space remains.

Fixes #509 