### PR TITLE
Fix set ROC functionality with gcm

### DIFF
--- a/srtp/srtp.c
+++ b/srtp/srtp.c
@@ -1740,13 +1740,23 @@ static srtp_err_status_t srtp_protect_aead(srtp_ctx_t *ctx,
      * estimate the packet index using the start of the replay window
      * and the sequence number from the header
      */
-    delta = srtp_rdbx_estimate_index(&stream->rtp_rdbx, &est, ntohs(hdr->seq));
-    status = srtp_rdbx_check(&stream->rtp_rdbx, delta);
-    if (status) {
-        if (status != srtp_err_status_replay_fail || !stream->allow_repeat_tx) {
-            return status; /* we've been asked to reuse an index */
-        }
+    status = srtp_get_est_pkt_index(hdr, stream, &est, &delta);
+
+    if (status && (status != srtp_err_status_pkt_idx_adv))
+        return status;
+
+    if (status == srtp_err_status_pkt_idx_adv) {
+        srtp_rdbx_set_roc_seq(&stream->rtp_rdbx, (uint32_t)(est >> 16),
+                              (uint16_t)(est & 0xFFFF));
+        stream->pending_roc = 0;
+        srtp_rdbx_add_index(&stream->rtp_rdbx, 0);
     } else {
+        status = srtp_rdbx_check(&stream->rtp_rdbx, delta);
+        if (status) {
+            if (status != srtp_err_status_replay_fail ||
+                !stream->allow_repeat_tx)
+                return status; /* we've been asked to reuse an index */
+        }
         srtp_rdbx_add_index(&stream->rtp_rdbx, delta);
     }
 
@@ -2064,7 +2074,6 @@ srtp_err_status_t srtp_protect_mki(srtp_ctx_t *ctx,
     unsigned int mki_size = 0;
     srtp_session_keys_t *session_keys = NULL;
     uint8_t *mki_location = NULL;
-    int advance_packet_index = 0;
 
     debug_print0(mod_srtp, "function srtp_protect");
 
@@ -2215,10 +2224,7 @@ srtp_err_status_t srtp_protect_mki(srtp_ctx_t *ctx,
     if (status && (status != srtp_err_status_pkt_idx_adv))
         return status;
 
-    if (status == srtp_err_status_pkt_idx_adv)
-        advance_packet_index = 1;
-
-    if (advance_packet_index) {
+    if (status == srtp_err_status_pkt_idx_adv) {
         srtp_rdbx_set_roc_seq(&stream->rtp_rdbx, (uint32_t)(est >> 16),
                               (uint16_t)(est & 0xFFFF));
         stream->pending_roc = 0;

--- a/test/srtp_driver.c
+++ b/test/srtp_driver.c
@@ -3091,11 +3091,17 @@ static srtp_err_status_t test_set_receiver_roc(uint32_t packets,
 
     /* Create sender */
     memset(&sender_policy, 0, sizeof(sender_policy));
+#ifdef GCM
+    srtp_crypto_policy_set_aes_gcm_128_16_auth(&sender_policy.rtp);
+    srtp_crypto_policy_set_aes_gcm_128_16_auth(&sender_policy.rtcp);
+    sender_policy.key = test_key_gcm;
+#else
     srtp_crypto_policy_set_rtp_default(&sender_policy.rtp);
     srtp_crypto_policy_set_rtcp_default(&sender_policy.rtcp);
+    sender_policy.key = test_key;
+#endif
     sender_policy.ssrc.type = ssrc_specific;
     sender_policy.ssrc.value = 0xcafebabe;
-    sender_policy.key = test_key;
     sender_policy.window_size = 128;
 
     status = srtp_create(&sender_session, &sender_policy);
@@ -3144,11 +3150,17 @@ static srtp_err_status_t test_set_receiver_roc(uint32_t packets,
 
     /* Create the receiver */
     memset(&receiver_policy, 0, sizeof(receiver_policy));
+#ifdef GCM
+    srtp_crypto_policy_set_aes_gcm_128_16_auth(&receiver_policy.rtp);
+    srtp_crypto_policy_set_aes_gcm_128_16_auth(&receiver_policy.rtcp);
+    receiver_policy.key = test_key_gcm;
+#else
     srtp_crypto_policy_set_rtp_default(&receiver_policy.rtp);
     srtp_crypto_policy_set_rtcp_default(&receiver_policy.rtcp);
+    receiver_policy.key = test_key;
+#endif
     receiver_policy.ssrc.type = ssrc_specific;
     receiver_policy.ssrc.value = sender_policy.ssrc.value;
-    receiver_policy.key = test_key;
     receiver_policy.window_size = 128;
 
     status = srtp_create(&receiver_session, &receiver_policy);
@@ -3230,11 +3242,17 @@ static srtp_err_status_t test_set_sender_roc(uint16_t seq, uint32_t roc_to_set)
 
     /* Create sender */
     memset(&sender_policy, 0, sizeof(sender_policy));
+#ifdef GCM
+    srtp_crypto_policy_set_aes_gcm_128_16_auth(&sender_policy.rtp);
+    srtp_crypto_policy_set_aes_gcm_128_16_auth(&sender_policy.rtcp);
+    sender_policy.key = test_key_gcm;
+#else
     srtp_crypto_policy_set_rtp_default(&sender_policy.rtp);
     srtp_crypto_policy_set_rtcp_default(&sender_policy.rtcp);
+    sender_policy.key = test_key;
+#endif
     sender_policy.ssrc.type = ssrc_specific;
     sender_policy.ssrc.value = 0xcafebabe;
-    sender_policy.key = test_key;
     sender_policy.window_size = 128;
 
     status = srtp_create(&sender_session, &sender_policy);
@@ -3261,11 +3279,17 @@ static srtp_err_status_t test_set_sender_roc(uint16_t seq, uint32_t roc_to_set)
 
     /* Create the receiver */
     memset(&receiver_policy, 0, sizeof(receiver_policy));
+#ifdef GCM
+    srtp_crypto_policy_set_aes_gcm_128_16_auth(&receiver_policy.rtp);
+    srtp_crypto_policy_set_aes_gcm_128_16_auth(&receiver_policy.rtcp);
+    receiver_policy.key = test_key_gcm;
+#else
     srtp_crypto_policy_set_rtp_default(&receiver_policy.rtp);
     srtp_crypto_policy_set_rtcp_default(&receiver_policy.rtcp);
+    receiver_policy.key = test_key;
+#endif
     receiver_policy.ssrc.type = ssrc_specific;
     receiver_policy.ssrc.value = sender_policy.ssrc.value;
-    receiver_policy.key = test_key;
     receiver_policy.window_size = 128;
 
     status = srtp_create(&receiver_session, &receiver_policy);

--- a/test/srtp_driver.c
+++ b/test/srtp_driver.c
@@ -95,6 +95,8 @@ srtp_err_status_t srtp_test_get_roc(void);
 
 srtp_err_status_t srtp_test_set_receiver_roc(void);
 
+srtp_err_status_t srtp_test_set_receiver_roc_then_rollover(void);
+
 srtp_err_status_t srtp_test_set_sender_roc(void);
 
 double srtp_bits_per_second(int msg_len_octets, const srtp_policy_t *policy);
@@ -126,6 +128,7 @@ extern uint8_t test_key[46];
 extern uint8_t test_key_2[46];
 extern uint8_t test_mki_id[TEST_MKI_ID_SIZE];
 extern uint8_t test_mki_id_2[TEST_MKI_ID_SIZE];
+extern uint8_t test_key_gcm[28];
 
 // clang-format off
 srtp_master_key_t master_key_1 = {
@@ -558,6 +561,14 @@ int main(int argc, char *argv[])
 
         printf("testing srtp_test_set_receiver_roc()...");
         if (srtp_test_set_receiver_roc() == srtp_err_status_ok) {
+            printf("passed\n");
+        } else {
+            printf("failed\n");
+            exit(1);
+        }
+
+        printf("testing srtp_test_set_receiver_roc_then_rollover()...");
+        if (srtp_test_set_receiver_roc_then_rollover() == srtp_err_status_ok) {
             printf("passed\n");
         } else {
             printf("failed\n");
@@ -1803,12 +1814,6 @@ srtp_err_status_t srtp_validate()
 srtp_err_status_t srtp_validate_gcm()
 {
     // clang-format off
-    unsigned char test_key_gcm[28] = {
-        0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07,
-        0x08, 0x09, 0x0a, 0x0b, 0x0c, 0x0d, 0x0e, 0x0f,
-        0xa0, 0xa1, 0xa2, 0xa3, 0xa4, 0xa5, 0xa6, 0xa7,
-        0xa8, 0xa9, 0xaa, 0xab
-    };
     uint8_t rtp_plaintext_ref[28] = {
         0x80, 0x0f, 0x12, 0x34, 0xde, 0xca, 0xfb, 0xad,
         0xca, 0xfe, 0xba, 0xbe, 0xab, 0xab, 0xab, 0xab,
@@ -3364,6 +3369,183 @@ srtp_err_status_t srtp_test_set_receiver_roc()
     return srtp_err_status_ok;
 }
 
+srtp_err_status_t srtp_test_set_receiver_roc_then_rollover()
+{
+    srtp_err_status_t status;
+
+    srtp_policy_t sender_policy;
+    srtp_t sender_session;
+
+    srtp_policy_t receiver_policy;
+    srtp_t receiver_session;
+
+    srtp_hdr_t *pkt_1;
+    unsigned char *recv_pkt_1;
+
+    srtp_hdr_t *pkt_2;
+    unsigned char *recv_pkt_2;
+
+    uint32_t i;
+    uint32_t ts;
+    uint16_t seq;
+    uint32_t sender_roc;
+
+    int msg_len_octets = 32;
+    int protected_msg_len_octets_1;
+    int protected_msg_len_octets_2;
+
+    /* Create sender */
+    memset(&sender_policy, 0, sizeof(sender_policy));
+#ifdef GCM
+    srtp_crypto_policy_set_aes_gcm_128_16_auth(&sender_policy.rtp);
+    srtp_crypto_policy_set_aes_gcm_128_16_auth(&sender_policy.rtcp);
+    sender_policy.key = test_key_gcm;
+#else
+    srtp_crypto_policy_set_rtp_default(&sender_policy.rtp);
+    srtp_crypto_policy_set_rtcp_default(&sender_policy.rtcp);
+    sender_policy.key = test_key;
+#endif
+    sender_policy.ssrc.type = ssrc_specific;
+    sender_policy.ssrc.value = 0xcafebabe;
+    sender_policy.window_size = 128;
+
+    status = srtp_create(&sender_session, &sender_policy);
+    if (status) {
+        return status;
+    }
+
+    /* Create and protect packets to get to seq 65536 and roc == 1 */
+    seq = 65535;
+    ts = 0;
+    for (i = 0; i < 65535; i++) {
+        srtp_hdr_t *tmp_pkt;
+        int tmp_len;
+
+        tmp_pkt = srtp_create_test_packet_extended(
+            msg_len_octets, sender_policy.ssrc.value, seq, ts, &tmp_len);
+        status = srtp_protect(sender_session, tmp_pkt, &tmp_len);
+        free(tmp_pkt);
+        if (status) {
+            return status;
+        }
+
+        seq++;
+        ts++;
+    }
+
+    status = srtp_get_stream_roc(sender_session, sender_policy.ssrc.value,
+                                 &sender_roc);
+    if (status) {
+        return status;
+    }
+
+    if (sender_roc != 1) {
+        return srtp_err_status_fail;
+    }
+
+    /* Create the first packet to decrypt and test for ROC change */
+    pkt_1 = srtp_create_test_packet_extended(msg_len_octets,
+                                             sender_policy.ssrc.value, 65535,
+                                             ts, &protected_msg_len_octets_1);
+    status = srtp_protect(sender_session, pkt_1, &protected_msg_len_octets_1);
+    if (status) {
+        return status;
+    }
+
+    /* Create the second packet to decrypt and test for ROC change */
+    ts++;
+    pkt_2 = srtp_create_test_packet_extended(msg_len_octets,
+                                             sender_policy.ssrc.value, 0, ts,
+                                             &protected_msg_len_octets_2);
+    status = srtp_protect(sender_session, pkt_2, &protected_msg_len_octets_2);
+    if (status) {
+        return status;
+    }
+
+    status = srtp_get_stream_roc(sender_session, sender_policy.ssrc.value,
+                                 &sender_roc);
+    if (status) {
+        return status;
+    }
+
+    if (sender_roc != 2) {
+        return srtp_err_status_fail;
+    }
+
+    /* Create the receiver */
+    memset(&receiver_policy, 0, sizeof(receiver_policy));
+#ifdef GCM
+    srtp_crypto_policy_set_aes_gcm_128_16_auth(&receiver_policy.rtp);
+    srtp_crypto_policy_set_aes_gcm_128_16_auth(&receiver_policy.rtcp);
+    receiver_policy.key = test_key_gcm;
+#else
+    srtp_crypto_policy_set_rtp_default(&receiver_policy.rtp);
+    srtp_crypto_policy_set_rtcp_default(&receiver_policy.rtcp);
+    receiver_policy.key = test_key;
+#endif
+    receiver_policy.ssrc.type = ssrc_specific;
+    receiver_policy.ssrc.value = sender_policy.ssrc.value;
+    receiver_policy.window_size = 128;
+
+    status = srtp_create(&receiver_session, &receiver_policy);
+    if (status) {
+        return status;
+    }
+
+    /* Make a copy of the first sent protected packet */
+    recv_pkt_1 = malloc(protected_msg_len_octets_1);
+    if (recv_pkt_1 == NULL) {
+        return srtp_err_status_fail;
+    }
+    memcpy(recv_pkt_1, pkt_1, protected_msg_len_octets_1);
+
+    /* Make a copy of the second sent protected packet */
+    recv_pkt_2 = malloc(protected_msg_len_octets_2);
+    if (recv_pkt_2 == NULL) {
+        return srtp_err_status_fail;
+    }
+    memcpy(recv_pkt_2, pkt_2, protected_msg_len_octets_2);
+
+    /* Set the ROC to the wanted value */
+    status =
+        srtp_set_stream_roc(receiver_session, receiver_policy.ssrc.value, 1);
+    if (status) {
+        return status;
+    }
+
+    /* Unprotect the first packet */
+    status = srtp_unprotect(receiver_session, recv_pkt_1,
+                            &protected_msg_len_octets_1);
+    if (status) {
+        return status;
+    }
+
+    /* Unprotect the second packet */
+    status = srtp_unprotect(receiver_session, recv_pkt_2,
+                            &protected_msg_len_octets_2);
+    if (status) {
+        return status;
+    }
+
+    /* Cleanup */
+    status = srtp_dealloc(sender_session);
+    if (status) {
+        return status;
+    }
+
+    status = srtp_dealloc(receiver_session);
+    if (status) {
+        return status;
+    }
+
+    free(pkt_1);
+    free(recv_pkt_1);
+    free(pkt_2);
+    free(recv_pkt_2);
+
+    return srtp_err_status_ok;
+}
+
 srtp_err_status_t srtp_test_set_sender_roc()
 {
     uint32_t roc;
@@ -3425,6 +3607,13 @@ unsigned char test_key_2[46] = {
     0xe6, 0x22, 0xa0, 0xe3, 0x32, 0xb9, 0xf1, 0xb6,
     0xc3, 0x17, 0xf2, 0xda, 0xbe, 0x35, 0x77, 0x93,
     0xb6, 0x96, 0x0b, 0x3a, 0xab, 0xe6
+};
+
+unsigned char test_key_gcm[28] = {
+    0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07,
+    0x08, 0x09, 0x0a, 0x0b, 0x0c, 0x0d, 0x0e, 0x0f,
+    0xa0, 0xa1, 0xa2, 0xa3, 0xa4, 0xa5, 0xa6, 0xa7,
+    0xa8, 0xa9, 0xaa, 0xab
 };
 
 unsigned char test_mki_id[TEST_MKI_ID_SIZE] = {


### PR DESCRIPTION
The srtp_set_stream_roc()  functionality does not work as expected with AEAD ciphers.
The issue is that the internal protect & unprotect functions for AEAD duplicate some of the functionality from the standard protect & unprotect functions but did not get updated when  srtp_set_stream_roc() was added.
This PR just ensure the behavior is the same, ideally these functions should not be duplicating code.