### PR TITLE
Fix typo introduced by PR 559

### DIFF
--- a/srtp/srtp.c
+++ b/srtp/srtp.c
@@ -788,7 +788,7 @@ static inline int full_key_length(const srtp_cipher_type_t *cipher)
     case SRTP_AES_GCM_128:
         return SRTP_AES_GCM_128_KEY_LEN_WSALT;
     case SRTP_AES_GCM_256:
-        return SRTP_AES_ICM_256_KEY_LEN_WSALT;
+        return SRTP_AES_GCM_256_KEY_LEN_WSALT;
     default:
         return 0;
     }


### PR DESCRIPTION
This PR fixes a typo introduced by #559, where for `SRTP_AES_GCM_256` the returned length is `SRTP_AES_ICM_256_KEY_LEN_WSALT` instead of `SRTP_AES_GCM_256_KEY_LEN_WSALT`, which causes problems when SRTP sessions are created using AES-GCM-256.