### PR TITLE
Include directory should point to 'include' not to 'include/srtp2'

### DIFF
--- a/include/srtp2/meson.build
+++ b/include/srtp2/meson.build
@@ -5,4 +5,3 @@ foreach h : public_headers
     output: '@BASENAME@.h',
     copy: true)
 endforeach
-public_incs = include_directories('.')

--- a/meson.build
+++ b/meson.build
@@ -264,7 +264,8 @@ else
   libsrtp2 = libsrtp2_static
 endif
 
-subdir('include/srtp2') # copies public_headers into the builddir and sets public_incs
+subdir('include/srtp2') # copies public_headers into the builddir
+public_incs = include_directories('include') # sets public_incs
 
 libsrtp2_dep = declare_dependency(link_with: libsrtp2,
   include_directories: public_incs)


### PR DESCRIPTION
This is only affects srtp as a meson subproject, if you compile and install it stand-alone everything works fine.
test_main.c:
```c
#include <srtp2/srtp.h>
int main() { return 0; }
```
meson.build:
```meson
project('test_srtp', 'c')
# libsrtp_dep = dependency('libsrtp2') # works perfectly if libsrtp2 is installed
libsrtp = subproject('libsrtp2')
libsrtp_dep = libsrtp.get_variable('libsrtp2_dep') # this cause compilation error
executable('test_srtp', 'test_main.c', dependency: libsrtp_dep)
```
output:
```
../test_main.c:1:10: fatal error: srtp2/srtp.h: No such file or directory
```

This is because public_incs pointed to 'include/srtp2' instead of 'include'
ps: also we can throw away `public_incs` and use `srtp2_incs` instead, not sure which one solution we should to prefer