### PR TITLE
rtp_decoder support for MKI and RCCm3 ROC field

### DIFF
--- a/test/rtp_decoder.c
+++ b/test/rtp_decoder.c
@@ -590,7 +590,8 @@ int main(int argc, char *argv[])
                 octet_string_hex_string(key + key_octets, salt_octets));
 
         /* Extract MKI */
-        mki_size = hex_string_to_octet_string(mki, input_mki, strlen(input_mki));
+        mki_size =
+            hex_string_to_octet_string(mki, input_mki, strlen(input_mki));
         mki_size /= 2;
         master_key.mki_id = (unsigned char *)mki;
         master_key.mki_size = mki_size;
@@ -598,7 +599,8 @@ int main(int argc, char *argv[])
                 octet_string_hex_string(mki, mki_size), mki_size);
 
         if (rccm_n > 0) {
-            fprintf(stderr, "set ROC transmission rate to %d (RCCm3, RFC4771)\n",
+            fprintf(stderr,
+                    "set ROC transmission rate to %d (RCCm3, RFC4771)\n",
                     rccm_n);
         }
     } else {
@@ -637,7 +639,8 @@ int main(int argc, char *argv[])
         exit(1);
     }
     fprintf(stderr, "Starting decoder\n");
-    if (rtp_decoder_init(dec, policy, mode, rtp_packet_offset, (mki_size != 0), roc, rccm_n)) {
+    if (rtp_decoder_init(dec, policy, mode, rtp_packet_offset, (mki_size != 0),
+                         roc, rccm_n)) {
         fprintf(stderr, "error: init failed\n");
         exit(1);
     }
@@ -825,7 +828,8 @@ void rtp_decoder_handle_pkt(u_char *arg,
 
                 /* Packet with ROC; extract unauthenticated (RCCm3) ROC value */
                 octets_recvd -= 4;
-                roc = ntohl(*(uint32_t *)(((uint8_t *)rtp_packet) + octets_recvd));
+                roc = ntohl(
+                    *(uint32_t *)(((uint8_t *)rtp_packet) + octets_recvd));
                 ssrc = ntohl(message.header.ssrc);
 
                 /* Apply extracted ROC to stream */
@@ -833,14 +837,16 @@ void rtp_decoder_handle_pkt(u_char *arg,
             }
         }
 
-        status = srtp_unprotect_mki(dcdr->srtp_ctx, &message, &octets_recvd, dcdr->mki_on);
+        status = srtp_unprotect_mki(dcdr->srtp_ctx, &message, &octets_recvd,
+                                    dcdr->mki_on);
         if (status) {
             dcdr->error_cnt++;
             return;
         }
         dcdr->rtp_cnt++;
     } else {
-        status = srtp_unprotect_rtcp_mki(dcdr->srtp_ctx, &message, &octets_recvd, dcdr->mki_on);
+        status = srtp_unprotect_rtcp_mki(dcdr->srtp_ctx, &message,
+                                         &octets_recvd, dcdr->mki_on);
         if (status) {
             dcdr->error_cnt++;
             return;

--- a/test/rtp_decoder.h
+++ b/test/rtp_decoder.h
@@ -63,6 +63,8 @@ typedef struct rtp_decoder_ctx_t {
     srtp_ctx_t *srtp_ctx;
     rtp_decoder_mode_t mode;
     int rtp_offset;
+    int mki_on;
+    int rccm_n;
     struct timeval start_tv;
     int frame_nr;
     int error_cnt;
@@ -103,7 +105,9 @@ int rtp_decoder_init(rtp_decoder_t dcdr,
                      srtp_policy_t policy,
                      rtp_decoder_mode_t mode,
                      int rtp_packet_offset,
-                     uint32_t roc);
+                     int mki_on,
+                     uint32_t roc,
+                     int rccm3_n);
 
 int rtp_decoder_deinit(rtp_decoder_t decoder);
 

--- a/test/rtp_decoder.h
+++ b/test/rtp_decoder.h
@@ -107,7 +107,7 @@ int rtp_decoder_init(rtp_decoder_t dcdr,
                      int rtp_packet_offset,
                      int mki_on,
                      uint32_t roc,
-                     int rccm3_n);
+                     int rccm_n);
 
 int rtp_decoder_deinit(rtp_decoder_t decoder);
 


### PR DESCRIPTION
MKI: support for MKI was added to libsrtp in 2.1.0, however the support wasn't extended to rtp_decder. These changes update rtp_decoder to use the srtp_unprotect_mki() and srtp_unprotect_rtcp_mki() APIs and to accept a new argument for specifying the MKI of the master key passed in the stream policy provided to libsrtp.

RCCm3: is one of the three integrity transforms specified in RFC4771 to support synchronisation of sender and receiver ROC by inclusion of the sender's ROC value in the optional authentication field at the end of the SRTP packet. RCCm3 is the only unauthenticated transform of the three, and therefore the only one that is supported without changes within libsrtp itself. A new rtp_decoder argument is introduced to specify the ROC transmission rate parameter. Any future support for RCCm1 and RCCm2 would be compatible with this argument.

New arguments introduced:
       -i <mki>  sets the MKI given in hexadecimal
       -n <rate> RFC4771 ROC transmission rate (assumes RCCm3)
