### PR TITLE
Update README.md to include NSS

### DIFF
--- a/README.md
+++ b/README.md
@@ -283,11 +283,13 @@ Option                         | Description
 -------------------------------|--------------------
 \-\-help                   \-h | Display help
 \-\-enable-debug-logging       | Enable debug logging in all modules
-\-\-enable-log-stdout          | Enable logging to stdout
 \-\-enable-openssl             | Enable OpenSSL crypto engine
+\-\-enable-nss                 | Enable NSS crypto engine
 \-\-enable-openssl-kdf         | Enable OpenSSL KDF algorithm
-\-\-with-log-file              | Use file for logging
+\-\-enable-log-stdout          | Enable logging to stdout
 \-\-with-openssl-dir           | Location of OpenSSL installation
+\-\-with-nss-dir               | Location of NSS installation
+\-\-with-log-file              | Use file for logging
 
 By default there is no log output, logging can be enabled to be output to stdout
 or a given file using the configure options.


### PR DESCRIPTION
Furthermore, I changed the order to reflect the current order of `./configure -h`.

Two notes:

1. What about removing both ‘Location of’? They are auto-detected and required only if not the system provided library should be used. Actually, the switch for OpenSSL does not work for a current version of OpenSSL, when its was build in its source tree (there is no folder called `/lib`). Did not test NSS.
2. What about adding a statement that either crypto library is used but none is leveraged on default. Some downstream maintainers like those on Debian, for example, did no enable OpenSSL for years. And now offer just NSS.