### PR TITLE
add compile time check of format arguments to srtp_err_report()

### DIFF
--- a/crypto/include/err.h
+++ b/crypto/include/err.h
@@ -49,6 +49,17 @@
 #include <stdarg.h>
 #include "srtp.h"
 
+#if defined(__clang__) || (defined(__GNUC__) && defined(__has_attribute))
+#if __has_attribute(format)
+#define LIBSRTP_FORMAT_PRINTF(fmt, args)                                       \
+    __attribute__((format(__printf__, fmt, args)))
+#else
+#define LIBSRTP_FORMAT_PRINTF(fmt, args)
+#endif
+#else
+#define LIBSRTP_FORMAT_PRINTF(fmt, args)
+#endif
+
 #ifdef __cplusplus
 extern "C" {
 #endif
@@ -96,7 +107,8 @@ srtp_err_status_t srtp_install_err_report_handler(
  *
  */
 
-void srtp_err_report(srtp_err_reporting_level_t level, const char *format, ...);
+void srtp_err_report(srtp_err_reporting_level_t level, const char *format, ...)
+    LIBSRTP_FORMAT_PRINTF(2, 3);
 
 /*
  * debug_module_t defines a debug module


### PR DESCRIPTION
This is the patch suggested in issue #576, have verified that it will find format errors.