### PR TITLE
Correct null cipher key sizes and be more defensive

### DIFF
--- a/srtp/srtp.c
+++ b/srtp/srtp.c
@@ -937,6 +937,16 @@ srtp_err_status_t srtp_stream_init_keys(srtp_stream_ctx_t *srtp,
         base_key_length(session_keys->rtp_cipher->type, rtp_keylen);
     rtp_salt_len = rtp_keylen - rtp_base_key_len;
 
+    /*
+     * We assume that the `key` buffer provided by the caller has a length
+     * equal to the greater of `rtp_keylen` and `rtcp_keylen`.  Since we are
+     * about to read `input_keylen` bytes from it, we need to check that we will
+     * not overrun.
+     */
+    if ((rtp_keylen < input_keylen) && (rtcp_keylen < input_keylen)) {
+      return srtp_err_status_bad_param;
+    }
+
     if (rtp_keylen > kdf_keylen) {
         kdf_keylen = 46; /* AES-CTR mode is always used for KDF */
     }

--- a/srtp/srtp.c
+++ b/srtp/srtp.c
@@ -3277,7 +3277,8 @@ void srtp_crypto_policy_set_null_cipher_hmac_sha1_80(srtp_crypto_policy_t *p)
      */
 
     p->cipher_type = SRTP_NULL_CIPHER;
-    p->cipher_key_len = 16;
+    p->cipher_key_len =
+        SRTP_AES_ICM_128_KEY_LEN_WSALT; /* 128 bit key, 112 bit salt */;
     p->auth_type = SRTP_HMAC_SHA1;
     p->auth_key_len = 20;
     p->auth_tag_len = 10;
@@ -3291,7 +3292,8 @@ void srtp_crypto_policy_set_null_cipher_hmac_null(srtp_crypto_policy_t *p)
      */
 
     p->cipher_type = SRTP_NULL_CIPHER;
-    p->cipher_key_len = 16;
+    p->cipher_key_len =
+        SRTP_AES_ICM_128_KEY_LEN_WSALT; /* 128 bit key, 112 bit salt */;
     p->auth_type = SRTP_NULL_AUTH;
     p->auth_key_len = 0;
     p->auth_tag_len = 0;

--- a/srtp/srtp.c
+++ b/srtp/srtp.c
@@ -944,7 +944,7 @@ srtp_err_status_t srtp_stream_init_keys(srtp_stream_ctx_t *srtp,
      * not overrun.
      */
     if ((rtp_keylen < input_keylen) && (rtcp_keylen < input_keylen)) {
-      return srtp_err_status_bad_param;
+        return srtp_err_status_bad_param;
     }
 
     if (rtp_keylen > kdf_keylen) {
@@ -3288,7 +3288,7 @@ void srtp_crypto_policy_set_null_cipher_hmac_sha1_80(srtp_crypto_policy_t *p)
 
     p->cipher_type = SRTP_NULL_CIPHER;
     p->cipher_key_len =
-        SRTP_AES_ICM_128_KEY_LEN_WSALT; /* 128 bit key, 112 bit salt */;
+        SRTP_AES_ICM_128_KEY_LEN_WSALT; /* 128 bit key, 112 bit salt */
     p->auth_type = SRTP_HMAC_SHA1;
     p->auth_key_len = 20;
     p->auth_tag_len = 10;
@@ -3303,7 +3303,7 @@ void srtp_crypto_policy_set_null_cipher_hmac_null(srtp_crypto_policy_t *p)
 
     p->cipher_type = SRTP_NULL_CIPHER;
     p->cipher_key_len =
-        SRTP_AES_ICM_128_KEY_LEN_WSALT; /* 128 bit key, 112 bit salt */;
+        SRTP_AES_ICM_128_KEY_LEN_WSALT; /* 128 bit key, 112 bit salt */
     p->auth_type = SRTP_NULL_AUTH;
     p->auth_key_len = 0;
     p->auth_tag_len = 0;

--- a/test/srtp_driver.c
+++ b/test/srtp_driver.c
@@ -3883,20 +3883,20 @@ const srtp_policy_t aes_only_policy = {
 const srtp_policy_t hmac_only_policy = {
     { ssrc_any_outbound, 0 }, /* SSRC */
     {
-        SRTP_NULL_CIPHER, /* cipher type                 */
-        0,                /* cipher key length in octets */
-        SRTP_HMAC_SHA1,   /* authentication func type    */
-        20,               /* auth key length in octets   */
-        4,                /* auth tag length in octets   */
-        sec_serv_auth     /* security services flag      */
+        SRTP_NULL_CIPHER,               /* cipher type                 */
+        SRTP_AES_ICM_128_KEY_LEN_WSALT, /* cipher key length in octets */
+        SRTP_HMAC_SHA1,                 /* authentication func type    */
+        20,                             /* auth key length in octets   */
+        4,                              /* auth tag length in octets   */
+        sec_serv_auth                   /* security services flag      */
     },
     {
-        SRTP_NULL_CIPHER, /* cipher type                 */
-        0,                /* cipher key length in octets */
-        SRTP_HMAC_SHA1,   /* authentication func type    */
-        20,               /* auth key length in octets   */
-        4,                /* auth tag length in octets   */
-        sec_serv_auth     /* security services flag      */
+        SRTP_NULL_CIPHER,               /* cipher type                 */
+        SRTP_AES_ICM_128_KEY_LEN_WSALT, /* cipher key length in octets */
+        SRTP_HMAC_SHA1,                 /* authentication func type    */
+        20,                             /* auth key length in octets   */
+        4,                              /* auth tag length in octets   */
+        sec_serv_auth                   /* security services flag      */
     },
     NULL,
     (srtp_master_key_t **)test_keys,
@@ -4038,20 +4038,20 @@ const srtp_policy_t aes256_gcm_8_cauth_policy = {
 const srtp_policy_t null_policy = {
     { ssrc_any_outbound, 0 }, /* SSRC */
     {
-        SRTP_NULL_CIPHER, /* cipher type                 */
-        0,                /* cipher key length in octets */
-        SRTP_NULL_AUTH,   /* authentication func type    */
-        0,                /* auth key length in octets   */
-        0,                /* auth tag length in octets   */
-        sec_serv_none     /* security services flag      */
+        SRTP_NULL_CIPHER,               /* cipher type                 */
+        SRTP_AES_GCM_256_KEY_LEN_WSALT, /* cipher key length in octets */
+        SRTP_NULL_AUTH,                 /* authentication func type    */
+        0,                              /* auth key length in octets   */
+        0,                              /* auth tag length in octets   */
+        sec_serv_none                   /* security services flag      */
     },
     {
-        SRTP_NULL_CIPHER, /* cipher type                 */
-        0,                /* cipher key length in octets */
-        SRTP_NULL_AUTH,   /* authentication func type    */
-        0,                /* auth key length in octets   */
-        0,                /* auth tag length in octets   */
-        sec_serv_none     /* security services flag      */
+        SRTP_NULL_CIPHER,               /* cipher type                 */
+        SRTP_AES_GCM_256_KEY_LEN_WSALT, /* cipher key length in octets */
+        SRTP_NULL_AUTH,                 /* authentication func type    */
+        0,                              /* auth key length in octets   */
+        0,                              /* auth tag length in octets   */
+        sec_serv_none                   /* security services flag      */
     },
     NULL,
     (srtp_master_key_t **)test_keys,


### PR DESCRIPTION
There are two major changes here:

1. Fix a bug introduced in #559: While `full_key_length` correctly returned `AES_ICM_128_KEYLEN_W_SALT` for the key size of a null cipher, the policy setting methods set the key size to `16`.  As a result, a caller using a null cipher and providing a key of the length recommended by the crypto policy would experience a 14-byte over-read of the buffer.

2. In general, be more cautious about key lengths to avoid over-reads.  Unfortunately, the existing API doesn't provide an explicit length from the key, so we are left to presume that this length is reflected in the RTP / RTCP crypto policies.  However, these are settable by the caller, so we need to check that the provided values are correct for the cipher types in use.

The PR also includes fixes to the `srtp_driver` test, which provided incorrect key lengths for its policies that use null ciphers.  The null cipher validation test did not need updating because the key buffer provided actually had enough data, so there was no over-read.