### PR TITLE
EVP_CIPHER_CTX_cleanup() is deprecated in OpenSSL 1.1.0

### DIFF
--- a/crypto/cipher/aes_gcm_ossl.c
+++ b/crypto/cipher/aes_gcm_ossl.c
@@ -193,7 +193,12 @@ static srtp_err_status_t srtp_aes_gcm_openssl_context_init(void *cv,
         break;
     }
 
+#if OPENSSL_VERSION_NUMBER < 0x10100000L
     EVP_CIPHER_CTX_cleanup(c->ctx);
+#else
+    EVP_CIPHER_CTX_reset(c->ctx);
+#endif
+
     if (!EVP_CipherInit_ex(c->ctx, evp, NULL, key, NULL, 0)) {
         return (srtp_err_status_init_fail);
     }

--- a/crypto/cipher/aes_icm_ossl.c
+++ b/crypto/cipher/aes_icm_ossl.c
@@ -249,7 +249,12 @@ static srtp_err_status_t srtp_aes_icm_openssl_context_init(void *cv,
         break;
     }
 
+#if OPENSSL_VERSION_NUMBER < 0x10100000L
     EVP_CIPHER_CTX_cleanup(c->ctx);
+#else
+    EVP_CIPHER_CTX_reset(c->ctx);
+#endif
+
     if (!EVP_EncryptInit_ex(c->ctx, evp, NULL, key, NULL)) {
         return srtp_err_status_fail;
     } else {


### PR DESCRIPTION
Starting from OpenSSL 1.1.0, EVP_CIPHER_CTX_cleanup()
and EVP_CIPHER_CTX_init() are deprecated, and not
available when OpenSSL is built with "no-deprecated"
option (aka. OPENSSL_NO_DEPRECATED).

Use EVP_CIPHER_CTX_reset() instead:

 "EVP_CIPHER_CTX was made opaque in OpenSSL 1.1.0.
  As a result, EVP_CIPHER_CTX_reset() appeared and
  EVP_CIPHER_CTX_cleanup() disappeared."

https://www.openssl.org/docs/man1.1.1/man3/EVP_CIPHER_CTX_reset.html