### PR TITLE
Remove compatibility code for legacy OpenSSL to fix LibreSSL build

### DIFF
--- a/crypto/hash/hmac_ossl.c
+++ b/crypto/hash/hmac_ossl.c
@@ -78,26 +78,6 @@ static srtp_err_status_t srtp_hmac_alloc(srtp_auth_t **a,
         return srtp_err_status_bad_param;
     }
 
-/* OpenSSL 1.1.0 made HMAC_CTX an opaque structure, which must be allocated
-   using HMAC_CTX_new.  But this function doesn't exist in OpenSSL 1.0.x. */
-#if OPENSSL_VERSION_NUMBER < 0x10100000L || LIBRESSL_VERSION_NUMBER
-    {
-        /* allocate memory for auth and HMAC_CTX structures */
-        uint8_t *pointer;
-        HMAC_CTX *new_hmac_ctx;
-        pointer = (uint8_t *)srtp_crypto_alloc(sizeof(HMAC_CTX) +
-                                               sizeof(srtp_auth_t));
-        if (pointer == NULL) {
-            return srtp_err_status_alloc_fail;
-        }
-        *a = (srtp_auth_t *)pointer;
-        (*a)->state = pointer + sizeof(srtp_auth_t);
-        new_hmac_ctx = (HMAC_CTX *)((*a)->state);
-
-        HMAC_CTX_init(new_hmac_ctx);
-    }
-
-#else
     *a = (srtp_auth_t *)srtp_crypto_alloc(sizeof(srtp_auth_t));
     if (*a == NULL) {
         return srtp_err_status_alloc_fail;
@@ -109,7 +89,6 @@ static srtp_err_status_t srtp_hmac_alloc(srtp_auth_t **a,
         *a = NULL;
         return srtp_err_status_alloc_fail;
     }
-#endif
 
     /* set pointers */
     (*a)->type = &srtp_hmac;
@@ -126,18 +105,10 @@ static srtp_err_status_t srtp_hmac_dealloc(srtp_auth_t *a)
 
     hmac_ctx = (HMAC_CTX *)a->state;
 
-#if OPENSSL_VERSION_NUMBER < 0x10100000L || LIBRESSL_VERSION_NUMBER
-    HMAC_CTX_cleanup(hmac_ctx);
-
-    /* zeroize entire state*/
-    octet_string_set_to_zero(a, sizeof(HMAC_CTX) + sizeof(srtp_auth_t));
-
-#else
     HMAC_CTX_free(hmac_ctx);
 
     /* zeroize entire state*/
     octet_string_set_to_zero(a, sizeof(srtp_auth_t));
-#endif
 
     /* free memory */
     srtp_crypto_free(a);


### PR DESCRIPTION
In current LibreSSL, `HMAC_CTX` aka. `struct hmac_ctx_st` is an opaque
structure as of LibreSSL hmac.h revision 1.15 (14.01.2022) [0], thus
`sizeof(HMAC_CTX)` fails to compile.

The non-legacy code path should compile with LibreSSL versions as old
as 2.7.0 (21.03.2018).

Found while building https://github.com/desktop-app/tg_owt which bundles
libsrtp 2.2.0 [1] on OpenBSD 7.0 -CURRENT/with latest LibreSSL.

Suggestion to remove the legacy code from Theo Buehler, thanks.

0: http://cvsweb.openbsd.org/cgi-bin/cvsweb/src/lib/libcrypto/hmac/hmac.h?rev=1.15&content-type=text/x-cvsweb-markup
1: https://github.com/desktop-app/tg_owt/blob/6708e0d31a73e64fe12f54829bf4060c41b2658e/src/third_party/libsrtp/crypto/hash/hmac_ossl.c#L85
