### PR TITLE
test: Use pkill(1) not killall(1)

### DIFF
--- a/test/rtpw_test.sh
+++ b/test/rtpw_test.sh
@@ -66,13 +66,13 @@ key=Ky7cUDT2GnI0XKWYbXv9AYmqbcLsqzL9mvdN9t/G
 
 ARGS="-b $key -a -e 128"
 
-# First, we run "killall" to get rid of all existing rtpw processes.
+# First, we run "pkill" to get rid of all existing rtpw processes.
 # This step also enables this script to clean up after itself; if this
 # script is interrupted after the rtpw processes are started but before
 # they are killed, those processes will linger.  Re-running the script
 # will get rid of them.
 
-killall rtpw 2>/dev/null
+pkill -x rtpw 2>/dev/null
 
 if test -n $MESON_EXE_WRAPPER || test -x $RTPW; then
 

--- a/test/rtpw_test_gcm.sh
+++ b/test/rtpw_test_gcm.sh
@@ -62,13 +62,13 @@ RTPW=./rtpw$EXE
 DEST_PORT=9999
 DURATION=3
 
-# First, we run "killall" to get rid of all existing rtpw processes.
+# First, we run "pkill" to get rid of all existing rtpw processes.
 # This step also enables this script to clean up after itself; if this
 # script is interrupted after the rtpw processes are started but before
 # they are killed, those processes will linger.  Re-running the script
 # will get rid of them.
 
-killall rtpw 2>/dev/null
+pkill -x rtpw 2>/dev/null
 
 if test -n $MESON_EXE_WRAPPER || test -x $RTPW; then
 


### PR DESCRIPTION
Not all operating systems, e.g. OpenBSD, have killall;  pkill(1) however
should be available on all OSes shipping killall(1).

This makes tests pass on OpenBSD without further changes.
