### PR TITLE
Use inet_pton() when available

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -37,6 +37,7 @@ check_include_file(winsock2.h HAVE_WINSOCK2_H)
 
 check_function_exists(sigaction HAVE_SIGACTION)
 check_function_exists(inet_aton HAVE_INET_ATON)
+check_function_exists(inet_pton HAVE_INET_PTON)
 check_function_exists(usleep HAVE_USLEEP)
 
 check_type_size(uint8_t UINT8_T)

--- a/config_in.h
+++ b/config_in.h
@@ -30,6 +30,9 @@
 /* Define to 1 if you have the `inet_aton' function. */
 #undef HAVE_INET_ATON
 
+/* Define to 1 if you have the `inet_pton' function. */
+#undef HAVE_INET_PTON
+
 /* Define to 1 if the system has the type `int16_t'. */
 #undef HAVE_INT16_T
 

--- a/config_in_cmake.h
+++ b/config_in_cmake.h
@@ -82,6 +82,9 @@
 /* Define to 1 if you have the `inet_aton' function. */
 #cmakedefine HAVE_INET_ATON 1
 
+/* Define to 1 if you have the `inet_pton' function. */
+#cmakedefine HAVE_INET_PTON 1
+
 /* Define to 1 if you have the `sigaction' function. */
 #cmakedefine HAVE_SIGACTION 1
 

--- a/configure
+++ b/configure
@@ -5195,7 +5195,7 @@ _ACEOF
 fi
 
 
-for ac_func in socket inet_aton usleep sigaction
+for ac_func in socket inet_aton inet_pton usleep sigaction
 do :
   as_ac_var=`$as_echo "ac_cv_func_$ac_func" | $as_tr_sh`
 ac_fn_c_check_func "$LINENO" "$ac_func" "$as_ac_var"

--- a/configure.ac
+++ b/configure.ac
@@ -166,7 +166,7 @@ AC_C_INLINE
 AC_TYPE_SIZE_T
 
 dnl Checks for library functions.
-AC_CHECK_FUNCS([socket inet_aton usleep sigaction])
+AC_CHECK_FUNCS([socket inet_aton inet_pton usleep sigaction])
 
 dnl Find socket function if not found yet.
 if test "x$ac_cv_func_socket" = "xno"; then

--- a/meson.build
+++ b/meson.build
@@ -46,6 +46,7 @@ endforeach
 check_functions = [
   'sigaction',
   'inet_aton',
+  'inet_pton',
   'usleep',
   'socket',
 ]

--- a/test/rtpw.c
+++ b/test/rtpw.c
@@ -285,7 +285,17 @@ int main(int argc, char *argv[])
     port = atoi(argv[optind_s++]);
 
 /* set address */
-#ifdef HAVE_INET_ATON
+#ifdef HAVE_INET_PTON
+    if (0 == inet_pton(AF_INET, address, &rcvr_addr)) {
+        fprintf(stderr, "%s: cannot parse IP v4 address %s\n", argv[0],
+                address);
+        exit(1);
+    }
+    if (rcvr_addr.s_addr == INADDR_NONE) {
+        fprintf(stderr, "%s: address error", argv[0]);
+        exit(1);
+    }
+#elif HAVE_INET_ATON
     if (0 == inet_aton(address, &rcvr_addr)) {
         fprintf(stderr, "%s: cannot parse IP v4 address %s\n", argv[0],
                 address);


### PR DESCRIPTION
`inet_aton()` and `inet_ntoa()` are considered deprecated, and can even
show up under certain scanners. Use the replacement `inet_pton()`
instead.