### PR TITLE
Treat warnings as errors when building with cmake

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -116,6 +116,12 @@ if(BUILD_WITH_SANITIZERS AND NOT WIN32)
   set(CMAKE_MODULE_LINKER_FLAGS "${CMAKE_MODULE_LINKER_FLAGS} -fno-omit-frame-pointer -fsanitize=${SANITIZERS}")
 endif()
 
+if(CMAKE_C_COMPILER_ID MATCHES "Clang" OR CMAKE_C_COMPILER_ID MATCHES "GNU")
+  add_compile_options(-Wall -pedantic -Wextra -Werror)
+elseif(MSVC)
+  add_compile_options(/W4 /WX)
+endif()
+
 set(SOURCES_C
   srtp/srtp.c
 )

--- a/crypto/cipher/aes_gcm_ossl.c
+++ b/crypto/cipher/aes_gcm_ossl.c
@@ -280,7 +280,7 @@ static srtp_err_status_t srtp_aes_gcm_openssl_set_aad(void *cv,
     }
 
     rv = EVP_Cipher(c->ctx, NULL, aad, aad_len);
-    if (rv != aad_len) {
+    if (rv < 0 || (uint32_t)rv != aad_len) {
         return (srtp_err_status_algo_fail);
     } else {
         return (srtp_err_status_ok);

--- a/crypto/cipher/aes_icm_ossl.c
+++ b/crypto/cipher/aes_icm_ossl.c
@@ -112,6 +112,7 @@ static srtp_err_status_t srtp_aes_icm_openssl_alloc(srtp_cipher_t **c,
                                                     int tlen)
 {
     srtp_aes_icm_ctx_t *icm;
+    (void)tlen;
 
     debug_print(srtp_mod_aes_icm, "allocating cipher with key length %d",
                 key_len);
@@ -275,6 +276,7 @@ static srtp_err_status_t srtp_aes_icm_openssl_set_iv(
 {
     srtp_aes_icm_ctx_t *c = (srtp_aes_icm_ctx_t *)cv;
     v128_t nonce;
+    (void)dir;
 
     /* set nonce (for alignment) */
     v128_copy_octet_string(&nonce, iv);

--- a/crypto/cipher/null_cipher.c
+++ b/crypto/cipher/null_cipher.c
@@ -59,6 +59,7 @@ static srtp_err_status_t srtp_null_cipher_alloc(srtp_cipher_t **c,
                                                 int tlen)
 {
     extern const srtp_cipher_type_t srtp_null_cipher;
+    (void)tlen;
 
     debug_print(srtp_mod_cipher, "allocating cipher with key length %d",
                 key_len);
@@ -96,7 +97,8 @@ static srtp_err_status_t srtp_null_cipher_dealloc(srtp_cipher_t *c)
 static srtp_err_status_t srtp_null_cipher_init(void *cv, const uint8_t *key)
 {
     /* srtp_null_cipher_ctx_t *c = (srtp_null_cipher_ctx_t *)cv; */
-
+    (void)cv;
+    (void)key;
     debug_print0(srtp_mod_cipher, "initializing null cipher");
 
     return srtp_err_status_ok;
@@ -107,6 +109,9 @@ static srtp_err_status_t srtp_null_cipher_set_iv(void *cv,
                                                  srtp_cipher_direction_t dir)
 {
     /* srtp_null_cipher_ctx_t *c = (srtp_null_cipher_ctx_t *)cv; */
+    (void)cv;
+    (void)iv;
+    (void)dir;
     return srtp_err_status_ok;
 }
 
@@ -115,6 +120,9 @@ static srtp_err_status_t srtp_null_cipher_encrypt(void *cv,
                                                   unsigned int *bytes_to_encr)
 {
     /* srtp_null_cipher_ctx_t *c = (srtp_null_cipher_ctx_t *)cv; */
+    (void)cv;
+    (void)buf;
+    (void)bytes_to_encr;
     return srtp_err_status_ok;
 }
 

--- a/crypto/hash/hmac_ossl.c
+++ b/crypto/hash/hmac_ossl.c
@@ -179,7 +179,7 @@ static srtp_err_status_t srtp_hmac_compute(void *statev,
     if (HMAC_Final(state, hash_value, &len) == 0)
         return srtp_err_status_auth_fail;
 
-    if (len < tag_len)
+    if (tag_len < 0 || len < (unsigned int)tag_len)
         return srtp_err_status_auth_fail;
 
     /* copy hash_value to *result */

--- a/crypto/hash/null_auth.c
+++ b/crypto/hash/null_auth.c
@@ -102,6 +102,10 @@ static srtp_err_status_t srtp_null_auth_init(void *statev,
                                              int key_len)
 {
     /* srtp_null_auth_ctx_t *state = (srtp_null_auth_ctx_t *)statev; */
+    (void)statev;
+    (void)key;
+    (void)key_len;
+
     /* accept any length of key, and do nothing */
 
     return srtp_err_status_ok;
@@ -114,6 +118,11 @@ static srtp_err_status_t srtp_null_auth_compute(void *statev,
                                                 uint8_t *result)
 {
     /* srtp_null_auth_ctx_t *state = (srtp_null_auth_ctx_t *)statev; */
+    (void)statev;
+    (void)message;
+    (void)msg_octets;
+    (void)tag_len;
+    (void)result;
 
     return srtp_err_status_ok;
 }
@@ -123,6 +132,9 @@ static srtp_err_status_t srtp_null_auth_update(void *statev,
                                                int msg_octets)
 {
     /* srtp_null_auth_ctx_t *state = (srtp_null_auth_ctx_t *)statev; */
+    (void)statev;
+    (void)message;
+    (void)msg_octets;
 
     return srtp_err_status_ok;
 }
@@ -130,6 +142,7 @@ static srtp_err_status_t srtp_null_auth_update(void *statev,
 static srtp_err_status_t srtp_null_auth_start(void *statev)
 {
     /* srtp_null_auth_ctx_t *state = (srtp_null_auth_ctx_t *)statev; */
+    (void)statev;
 
     return srtp_err_status_ok;
 }

--- a/crypto/test/datatypes_driver.c
+++ b/crypto/test/datatypes_driver.c
@@ -139,7 +139,7 @@ int main(void)
 
 void byte_order(void)
 {
-    int i;
+    size_t i;
     v128_t e;
 
     printf("byte ordering of crypto/math datatypes:\n");

--- a/srtp/srtp.c
+++ b/srtp/srtp.c
@@ -3552,7 +3552,6 @@ static srtp_err_status_t srtp_calc_aead_iv_srtcp(
  * AES-GCM mode with 128 or 256 bit keys.
  */
 static srtp_err_status_t srtp_protect_rtcp_aead(
-    srtp_t ctx,
     srtp_stream_ctx_t *stream,
     void *rtcp_hdr,
     unsigned int *pkt_octet_len,
@@ -4004,7 +4003,7 @@ srtp_err_status_t srtp_protect_rtcp_mki(srtp_t ctx,
      */
     if (session_keys->rtp_cipher->algorithm == SRTP_AES_GCM_128 ||
         session_keys->rtp_cipher->algorithm == SRTP_AES_GCM_256) {
-        return srtp_protect_rtcp_aead(ctx, stream, rtcp_hdr,
+        return srtp_protect_rtcp_aead(stream, rtcp_hdr,
                                       (unsigned int *)pkt_octet_len,
                                       session_keys, use_mki);
     }

--- a/test/rtp_decoder.c
+++ b/test/rtp_decoder.c
@@ -135,6 +135,7 @@ void rtp_decoder_srtp_log_handler(srtp_log_level_t level,
                                   const char *msg,
                                   void *data)
 {
+    (void)data;
     char level_char = '?';
     switch (level) {
     case srtp_log_level_error:
@@ -173,9 +174,9 @@ int main(int argc, char *argv[])
     struct bpf_program fp;
     char filter_exp[MAX_FILTER] = "";
     char pcap_file[MAX_FILE] = "-";
-    int rtp_packet_offset = DEFAULT_RTP_OFFSET;
+    size_t rtp_packet_offset = DEFAULT_RTP_OFFSET;
     rtp_decoder_t dec;
-    srtp_policy_t policy = { { 0 } };
+    srtp_policy_t policy = { 0 };
     rtp_decoder_mode_t mode = mode_rtp;
     srtp_ssrc_t ssrc = { ssrc_any_inbound, 0 };
     uint32_t roc = 0;
@@ -555,7 +556,7 @@ int main(int argc, char *argv[])
                     expected_len, len);
             exit(1);
         }
-        if (strlen(input_key) > policy.rtp.cipher_key_len * 2) {
+        if (strlen(input_key) > (size_t)policy.rtp.cipher_key_len * 2) {
             fprintf(stderr,
                     "error: too many digits in key/salt "
                     "(should be %d hexadecimal digits, found %u)\n",
@@ -684,7 +685,7 @@ int rtp_decoder_deinit(rtp_decoder_t decoder)
 int rtp_decoder_init(rtp_decoder_t dcdr,
                      srtp_policy_t policy,
                      rtp_decoder_mode_t mode,
-                     int rtp_packet_offset,
+                     size_t rtp_packet_offset,
                      uint32_t roc)
 {
     dcdr->rtp_offset = rtp_packet_offset;
@@ -716,11 +717,11 @@ int rtp_decoder_init(rtp_decoder_t dcdr,
 
 void hexdump(const void *ptr, size_t size)
 {
-    int i, j;
+    size_t i, j;
     const unsigned char *cptr = ptr;
 
     for (i = 0; i < size; i += 16) {
-        fprintf(stdout, "%04x ", i);
+        fprintf(stdout, "%04x ", (unsigned int)i);
         for (j = 0; j < 16 && i + j < size; j++) {
             fprintf(stdout, "%02x ", cptr[i + j]);
         }

--- a/test/rtp_decoder.h
+++ b/test/rtp_decoder.h
@@ -62,7 +62,7 @@ typedef struct rtp_decoder_ctx_t {
     srtp_policy_t policy;
     srtp_ctx_t *srtp_ctx;
     rtp_decoder_mode_t mode;
-    int rtp_offset;
+    size_t rtp_offset;
     struct timeval start_tv;
     int frame_nr;
     int error_cnt;
@@ -102,7 +102,7 @@ void rtp_decoder_dealloc(rtp_decoder_t rtp_ctx);
 int rtp_decoder_init(rtp_decoder_t dcdr,
                      srtp_policy_t policy,
                      rtp_decoder_mode_t mode,
-                     int rtp_packet_offset,
+                     size_t rtp_packet_offset,
                      uint32_t roc);
 
 int rtp_decoder_deinit(rtp_decoder_t decoder);

--- a/test/srtp_driver.c
+++ b/test/srtp_driver.c
@@ -168,6 +168,7 @@ void usage(char *prog_name)
 void log_handler(srtp_log_level_t level, const char *msg, void *data)
 {
     char level_char = '?';
+    (void)data;
     switch (level) {
     case srtp_log_level_error:
         level_char = 'e';
@@ -3181,7 +3182,7 @@ srtp_err_status_t srtp_test_out_of_order_after_rollover()
     srtp_policy_t receiver_policy;
     srtp_t receiver_session;
 
-    const int num_pkts = 5;
+    const uint32_t num_pkts = 5;
     srtp_hdr_t *pkts[5];
     int pkt_len_octets[5];
 

--- a/test/ut_sim.c
+++ b/test/ut_sim.c
@@ -54,6 +54,8 @@
 int ut_compar(const void *a, const void *b)
 {
     uint8_t r;
+    (void)a;
+    (void)b;
     srtp_cipher_rand_for_tests(&r, sizeof(r));
     return r > (UINT8_MAX / 2) ? -1 : 1;
 }


### PR DESCRIPTION
Adds a strict mode for warnings that is enable by defualt for now.
Can make it optional later if needed.

Fix up the warnings that where found.