### PR TITLE
Openssl EVP MAC

### DIFF
--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -12,18 +12,24 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-20.04, macos-latest, windows-latest]
-        crypto: [internal, openssl, nss, mbedtls]
+        crypto: [internal, openssl, openssl3, nss, mbedtls]
         exclude:
           - os: windows-latest
             crypto: openssl
           - os: windows-latest
+            crypto: openssl3
+          - os: windows-latest
             crypto: nss
           - os: windows-latest
             crypto: mbedtls
+          - os: ubuntu-latest
+            crypto: openssl3
         include:
           - crypto: internal
             cmake-crypto-enable: ""
           - crypto: openssl
+            cmake-crypto-enable: "-DENABLE_OPENSSL=ON"
+          - crypto: openssl3
             cmake-crypto-enable: "-DENABLE_OPENSSL=ON"
           - crypto: nss
             cmake-crypto-enable: "-DENABLE_NSS=ON"
@@ -31,7 +37,7 @@ jobs:
             cmake-crypto-enable: "-DENABLE_MBEDTLS=ON"
 
     runs-on: ${{ matrix.os }}
-    
+
     env:
       CTEST_OUTPUT_ON_FAILURE: 1
 
@@ -41,23 +47,29 @@ jobs:
       run: |
         sudo apt-get update
         sudo apt-get install libnss3-dev
-      
+
     - name: Setup Ubuntu MbedTLS
       if:  matrix.os == 'ubuntu-20.04' && matrix.crypto == 'mbedtls'
       run: sudo apt-get install libmbedtls-dev
-    
+
     - name: Setup macOS OpenSSL
       if: matrix.os == 'macos-latest' && matrix.crypto == 'openssl'
       run: echo "cmake-crypto-dir=-DOPENSSL_ROOT_DIR=$(brew --prefix openssl@1.1)" >> $GITHUB_ENV
-      
+
+    - name: Setup macOS OpenSSL3
+      if: matrix.os == 'macos-latest' && matrix.crypto == 'openssl3'
+      run: |
+        brew install openssl@3
+        echo "cmake-crypto-dir=-DOPENSSL_ROOT_DIR=$(brew --prefix openssl@3)" >> $GITHUB_ENV
+
     - name: Setup macOS NSS
       if:  matrix.os == 'macos-latest' && matrix.crypto == 'nss'
       run: brew install nss
-      
+
     - name: Setup macOS MbedTLS
       if:  matrix.os == 'macos-latest' && matrix.crypto == 'mbedtls'
       run: brew install mbedtls
-      
+
     - uses: actions/checkout@v2
 
     - name: Create Build Environment

--- a/crypto/hash/hmac_ossl.c
+++ b/crypto/hash/hmac_ossl.c
@@ -72,6 +72,19 @@ srtp_debug_module_t srtp_mod_hmac = {
     "hmac sha-1 openssl" /* printable name for module   */
 };
 
+/*
+ * There are three different behaviors of OpenSSL HMAC for different versions.
+ *
+ * 1. Pre-3.0 - Use HMAC API
+ * 2. 3.0.0 - 3.0.2 - EVP API is required, but doesn't support reinitialization,
+ *    so we have to use EVP_MAC_CTX_dup
+ * 3. 3.0.3 and later - EVP API is required and supports reinitialization
+ *
+ * The distingtion between cases 2 & 3 needs to be made at runtime, because in a
+ * shared library context you might end up building against 3.0.3 and running
+ * against 3.0.2.
+ */
+
 typedef struct {
 #ifdef SRTP_OSSL_USE_EVP_MAC
     EVP_MAC *mac;

--- a/crypto/hash/hmac_ossl.c
+++ b/crypto/hash/hmac_ossl.c
@@ -131,6 +131,7 @@ static srtp_err_status_t srtp_hmac_alloc(srtp_auth_t **a,
 #else
     hmac->ctx = HMAC_CTX_new();
 #endif
+
     if (hmac->ctx == NULL) {
 #ifdef SRTP_OSSL_USE_EVP_MAC
         EVP_MAC_free(hmac->mac);
@@ -196,8 +197,9 @@ static srtp_err_status_t srtp_hmac_start(void *statev)
             return srtp_err_status_alloc_fail;
         }
     } else {
-        if (EVP_MAC_init(hmac->ctx, NULL, 0, NULL) == 0)
+        if (EVP_MAC_init(hmac->ctx, NULL, 0, NULL) == 0) {
             return srtp_err_status_auth_fail;
+        }
     }
 #else
     if (HMAC_Init_ex(hmac->ctx, NULL, 0, NULL, NULL) == 0)

--- a/crypto/hash/hmac_ossl.c
+++ b/crypto/hash/hmac_ossl.c
@@ -112,7 +112,6 @@ static srtp_err_status_t srtp_hmac_alloc(srtp_auth_t **a,
         *a = NULL;
         return srtp_err_status_alloc_fail;
     }
-    memset(hmac, 0, sizeof(srtp_hmac_ossl_ctx_t));
 
 #ifdef SRTP_OSSL_USE_EVP_MAC
     hmac->mac = EVP_MAC_fetch(NULL, "HMAC", NULL);

--- a/crypto/hash/hmac_ossl.c
+++ b/crypto/hash/hmac_ossl.c
@@ -178,12 +178,8 @@ static srtp_err_status_t srtp_hmac_dealloc(srtp_auth_t *a)
 
     if (hmac) {
 #ifdef SRTP_OSSL_USE_EVP_MAC
-        if (hmac->ctx != NULL) {
-            EVP_MAC_CTX_free(hmac->ctx);
-        }
-        if (hmac->ctx_dup != NULL) {
-            EVP_MAC_CTX_free(hmac->ctx_dup);
-        }
+        EVP_MAC_CTX_free(hmac->ctx);
+        EVP_MAC_CTX_free(hmac->ctx_dup);
         EVP_MAC_free(hmac->mac);
 #else
         HMAC_CTX_free(hmac->ctx);
@@ -209,9 +205,7 @@ static srtp_err_status_t srtp_hmac_start(void *statev)
 
 #ifdef SRTP_OSSL_USE_EVP_MAC
     if (hmac->use_dup) {
-        if (hmac->ctx != NULL) {
-            EVP_MAC_CTX_free(hmac->ctx);
-        }
+        EVP_MAC_CTX_free(hmac->ctx);
         hmac->ctx = EVP_MAC_CTX_dup(hmac->ctx_dup);
         if (hmac->ctx == NULL) {
             return srtp_err_status_alloc_fail;


### PR DESCRIPTION
This is a fix for issue #599 .

With OpenSSL 3 the HAMC CTX api has been deprecated and
EVP MAC should be used instead. This change adds a compile
time check on OpeenSSL version and will use the new api if the
version is greater than or equal to 3 .

As part of this change cmake CI build now has warnings as errors
in order to catch the deprecated api warning. There will be a follow
up PR that also adds warnings as errors to windows as well as enabling
more warnings.   