### PR TITLE
Fix compile error due to unused variable

### DIFF
--- a/test/cutest.h
+++ b/test/cutest.h
@@ -259,16 +259,15 @@ int test_check__(int cond, const char *file, int line, const char *fmt, ...)
     }
 
     if (test_verbose_level__ >= verbose_level) {
-        size_t n = 0;
         va_list args;
 
         printf("  ");
 
         if (file != NULL)
-            n += printf("%s:%d: Check ", file, line);
+            printf("%s:%d: Check ", file, line);
 
         va_start(args, fmt);
-        n += vprintf(fmt, args);
+        vprintf(fmt, args);
         va_end(args);
 
         printf("... ");


### PR DESCRIPTION
Without this change, I see the following error:
In file included from test/test_srtp.c:54:
./test/cutest.h:262:16: warning: variable 'n' set but not used [-Wunused-but-set-variable]
        size_t n = 0;
               ^