### PR TITLE
Set OpenSSL api compat to 1.1.x for hamc

### DIFF
--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -12,18 +12,24 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        crypto: [internal, openssl, nss, mbedtls]
+        crypto: [internal, openssl, openssl3, nss, mbedtls]
         exclude:
           - os: windows-latest
             crypto: openssl
           - os: windows-latest
+            crypto: openssl3
+          - os: windows-latest
             crypto: nss
           - os: windows-latest
             crypto: mbedtls
+          - os: ubuntu-latest
+            crypto: openssl3
         include:
           - crypto: internal
             cmake-crypto-enable: ""
           - crypto: openssl
+            cmake-crypto-enable: "-DENABLE_OPENSSL=ON"
+          - crypto: openssl3
             cmake-crypto-enable: "-DENABLE_OPENSSL=ON"
           - crypto: nss
             cmake-crypto-enable: "-DENABLE_NSS=ON"
@@ -31,7 +37,7 @@ jobs:
             cmake-crypto-enable: "-DENABLE_MBEDTLS=ON"
 
     runs-on: ${{ matrix.os }}
-    
+
     env:
       CTEST_OUTPUT_ON_FAILURE: 1
 
@@ -41,23 +47,29 @@ jobs:
       run: |
         sudo apt-get update
         sudo apt-get install libnss3-dev
-      
+
     - name: Setup Ubuntu MbedTLS
       if:  matrix.os == 'ubuntu-latest' && matrix.crypto == 'mbedtls'
       run: sudo apt-get install libmbedtls-dev
-    
+
     - name: Setup macOS OpenSSL
       if: matrix.os == 'macos-latest' && matrix.crypto == 'openssl'
       run: echo "cmake-crypto-dir=-DOPENSSL_ROOT_DIR=$(brew --prefix openssl@1.1)" >> $GITHUB_ENV
-      
+
+    - name: Setup macOS OpenSSL3
+      if: matrix.os == 'macos-latest' && matrix.crypto == 'openssl3'
+      run: |
+        brew install openssl@3
+        echo "cmake-crypto-dir=-DOPENSSL_ROOT_DIR=$(brew --prefix openssl@3)" >> $GITHUB_ENV
+
     - name: Setup macOS NSS
       if:  matrix.os == 'macos-latest' && matrix.crypto == 'nss'
       run: brew install nss
-      
+
     - name: Setup macOS MbedTLS
       if:  matrix.os == 'macos-latest' && matrix.crypto == 'mbedtls'
       run: brew install mbedtls
-      
+
     - uses: actions/checkout@v2
 
     - name: Create Build Environment

--- a/crypto/hash/hmac_ossl.c
+++ b/crypto/hash/hmac_ossl.c
@@ -50,6 +50,7 @@
 #include "alloc.h"
 #include "err.h" /* for srtp_debug */
 #include "auth_test_cases.h"
+#define OPENSSL_API_COMPAT 0x10100000L
 #include <openssl/evp.h>
 #include <openssl/hmac.h>
 


### PR DESCRIPTION
An alternative to #602 as a solution to #599.
Since the EVP_MAC_xxx api has some reinitialization issues pre 3.0.3 and the workaround in #603
introduces a performance hit this is probably the best solution until OpenSSL 3.0.3 is released and widely adopted.
