### PR TITLE
Build without versioned soname on Android.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -250,6 +250,9 @@ add_library(srtp2
 )
 
 set_target_properties(srtp2 PROPERTIES VERSION ${CMAKE_PROJECT_VERSION})
+if(${CMAKE_C_COMPILER_TARGET} MATCHES ".*-linux-android.*")
+  set_target_properties(srtp2 PROPERTIES NO_SONAME ON)
+endif()
 
 target_include_directories(srtp2 PUBLIC
   $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/crypto/include>


### PR DESCRIPTION
I'm building for Android with CMake. This produces the shared library `libsrtp2.so.2.4.2` and a symbolic link to it `libsrtp2.so`.

I would like to just drop the library into the `jniLibs` directory, but Android Studio recognizes libraries by file name (ignores file names that don't match *.so), so I need to build libsrtp without a versioned soname, i.e. no linker flag `-Wl,-soname,...`.

This can be done by setting the CMake target property [NO_SONAME](https://cmake.org/cmake/help/latest/prop_tgt/NO_SONAME.html).