### PR TITLE
Create alias for srtp2 as libSRTP::srtp2

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -248,6 +248,7 @@ add_library(srtp2
   ${REPLAY_SOURCES_C}
   ${SOURCES_H}
 )
+add_library(libSRTP::srtp2 ALIAS srtp2)
 
 set_target_properties(srtp2 PROPERTIES VERSION ${CMAKE_PROJECT_VERSION})
 


### PR DESCRIPTION
This will add an alias for the srtp2 library so that when using CMake with either `find_library` or `FetchContent`, the use of `target_link_libraries()` can always follow the form `libSRTP::srtp2`.  Without this, using `FetchContent` will allow only the name `srtp2`.