### PR TITLE
Call `set_aad` and `get_tag` in AEAD performance tests

### DIFF
--- a/crypto/cipher/cipher.c
+++ b/crypto/cipher/cipher.c
@@ -667,8 +667,8 @@ uint64_t srtp_cipher_bits_per_second(srtp_cipher_t *c,
 
         // Get tag if supported by the cipher
         if (c->type->get_tag) {
-            if (srtp_cipher_get_tag(c, (uint8_t *)(enc_buf + len),
-                                    &tag_len) != srtp_err_status_ok) {
+            if (srtp_cipher_get_tag(c, (uint8_t *)(enc_buf + len), &tag_len) !=
+                srtp_err_status_ok) {
                 srtp_crypto_free(enc_buf);
                 return 0;
             }

--- a/crypto/cipher/cipher.c
+++ b/crypto/cipher/cipher.c
@@ -632,7 +632,7 @@ uint64_t srtp_cipher_bits_per_second(srtp_cipher_t *c,
     clock_t timer;
     unsigned char *enc_buf;
     unsigned int len = octets_in_buffer;
-    uint32_t tag_len = 32;
+    uint32_t tag_len = SRTP_MAX_TAG_LEN;
     unsigned char aad[4] = { 0, 0, 0, 0 };
     uint32_t aad_len = 4;
 
@@ -667,7 +667,7 @@ uint64_t srtp_cipher_bits_per_second(srtp_cipher_t *c,
 
         // Get tag if supported by the cipher
         if (c->type->get_tag) {
-            if (srtp_cipher_get_tag(c, (uint8_t *)(enc_buf + octets_in_buffer),
+            if (srtp_cipher_get_tag(c, (uint8_t *)(enc_buf + len),
                                     &tag_len) != srtp_err_status_ok) {
                 srtp_crypto_free(enc_buf);
                 return 0;

--- a/crypto/cipher/cipher.c
+++ b/crypto/cipher/cipher.c
@@ -633,7 +633,7 @@ uint64_t srtp_cipher_bits_per_second(srtp_cipher_t *c,
     unsigned char *enc_buf;
     unsigned int len = octets_in_buffer;
     uint32_t tag_len = 32;
-    unsigned char aad[4] = {0, 0, 0, 0};
+    unsigned char aad[4] = { 0, 0, 0, 0 };
     uint32_t aad_len = 4;
 
     enc_buf = (unsigned char *)srtp_crypto_alloc(octets_in_buffer + tag_len);
@@ -667,11 +667,11 @@ uint64_t srtp_cipher_bits_per_second(srtp_cipher_t *c,
 
         // Get tag if supported by the cipher
         if (c->type->get_tag) {
-           if (srtp_cipher_get_tag(c, (uint8_t*)(enc_buf + octets_in_buffer), &tag_len) !=
-               srtp_err_status_ok) {
-               srtp_crypto_free(enc_buf);
-               return 0;
-           }
+            if (srtp_cipher_get_tag(c, (uint8_t *)(enc_buf + octets_in_buffer),
+                                    &tag_len) != srtp_err_status_ok) {
+                srtp_crypto_free(enc_buf);
+                return 0;
+            }
         }
     }
     timer = clock() - timer;


### PR DESCRIPTION
Right now, the cipher speed test in `srtp_cipher_bits_per_second` only calls `set_iv` and `encrypt`.  In reality, when an AEAD cipher is used, there are also calls to `set_aad` and `get_tag`.  This PR adds those calls to `srtp_cipher_bits_per_second` so that it more accurately reflects AEAD performance.