### PR TITLE
add CIFuzz Github action to workflows

### DIFF
--- a/.github/workflows/cifuzz.yml
+++ b/.github/workflows/cifuzz.yml
@@ -1,5 +1,11 @@
 name: CIFuzz
-on: [ push, pull_request ]
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+
 jobs:
   Fuzzing:
     runs-on: ubuntu-latest

--- a/.github/workflows/cifuzz.yml
+++ b/.github/workflows/cifuzz.yml
@@ -1,5 +1,5 @@
 name: CIFuzz
-on: [pull_request]
+on: [ push, pull_request ]
 jobs:
   Fuzzing:
     runs-on: ubuntu-latest
@@ -9,14 +9,12 @@ jobs:
       uses: google/oss-fuzz/infra/cifuzz/actions/build_fuzzers@master
       with:
         oss-fuzz-project-name: 'libsrtp'
-        dry-run: false
         language: c++
     - name: Run Fuzzers
       uses: google/oss-fuzz/infra/cifuzz/actions/run_fuzzers@master
       with:
         oss-fuzz-project-name: 'libsrtp'
         fuzz-seconds: 300
-        dry-run: false
         language: c++
     - name: Upload Crash
       uses: actions/upload-artifact@v3

--- a/.github/workflows/cifuzz.yml
+++ b/.github/workflows/cifuzz.yml
@@ -1,0 +1,26 @@
+name: CIFuzz
+on: [pull_request]
+jobs:
+  Fuzzing:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Build Fuzzers
+      id: build
+      uses: google/oss-fuzz/infra/cifuzz/actions/build_fuzzers@master
+      with:
+        oss-fuzz-project-name: 'libsrtp'
+        dry-run: false
+        language: c++
+    - name: Run Fuzzers
+      uses: google/oss-fuzz/infra/cifuzz/actions/run_fuzzers@master
+      with:
+        oss-fuzz-project-name: 'libsrtp'
+        fuzz-seconds: 300
+        dry-run: false
+        language: c++
+    - name: Upload Crash
+      uses: actions/upload-artifact@v3
+      if: failure() && steps.build.outcome == 'success'
+      with:
+        name: artifacts
+        path: ./out/artifacts


### PR DESCRIPTION
Add [CIFuzz](https://google.github.io/oss-fuzz/getting-started/continuous-integration/) workflow action to have fuzzers build and run on each PR. This is a service offered by OSS-Fuzz where libsrtp already runs. In the current PR the fuzzers gets build on a pull request and will run for 300 seconds.

I noticed the CI already has a fuzz action so this is an alternative suggestion in case you're interested -- CIFuzz has a set of features that are useful e.g. only highlighting issues only if they are introduced by the given PR, using of OSS-Fuzz code corpus and more. Let me know what you think!