### PR TITLE
update to clang-format-12

### DIFF
--- a/.github/workflows/format_check.yml
+++ b/.github/workflows/format_check.yml
@@ -12,6 +12,6 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - name: Install Clang Format
-        run: sudo apt install clang-format-10
+        run: sudo apt install clang-format-12
       - name: Run clang format
         run: ./format.sh -d

--- a/format.sh
+++ b/format.sh
@@ -7,7 +7,7 @@
 # assumes git tree is clean when reporting status
 
 if [ -z "${CLANG_FORMAT}" ]; then
-    CLANG_FORMAT=clang-format-10
+    CLANG_FORMAT=clang-format-12
 fi
 
 a=`git ls-files '*.h' '*.c'`

--- a/test/rtp.c
+++ b/test/rtp.c
@@ -131,10 +131,9 @@ int rtp_recvfrom(rtp_receiver_t receiver, void *msg, int *len)
     if (stat) {
         fprintf(stderr, "error: srtp unprotection failed with code %d%s\n",
                 stat,
-                stat == srtp_err_status_replay_fail
-                    ? " (replay check failed)"
-                    : stat == srtp_err_status_auth_fail ? " (auth check failed)"
-                                                        : "");
+                stat == srtp_err_status_replay_fail ? " (replay check failed)"
+                : stat == srtp_err_status_auth_fail ? " (auth check failed)"
+                                                    : "");
         return -1;
     }
     strncpy(msg, receiver->message.body, octets_recvd);


### PR DESCRIPTION
For CI this will  work on both Ubuntu 20.04 & 22.04 . This will allow CI to move to ubuntu-latest, see #622