### PR TITLE
Fix more warnings to compile with clang 15

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -120,10 +120,12 @@ endif()
 
 if(BUILD_WITH_WARNINGS)
   if(CMAKE_C_COMPILER_ID MATCHES "Clang" OR CMAKE_C_COMPILER_ID MATCHES "GNU")
-    add_compile_options(-Wall -pedantic -Wextra -Werror)
+    set(WARNINGS -Wall -pedantic -Wextra -Werror)
   elseif(MSVC)
-    add_compile_options(/W4 /WX)
+    set(WARNINGS /W4 /WX)
   endif()
+  message(STATUS "Using warnings: ${WARNINGS}")
+  add_compile_options(${WARNINGS})
 endif()
 
 set(SOURCES_C

--- a/crypto/kernel/crypto_kernel.c
+++ b/crypto/kernel/crypto_kernel.c
@@ -69,7 +69,7 @@ srtp_crypto_kernel_t crypto_kernel = {
 
 #define MAX_RNG_TRIALS 25
 
-srtp_err_status_t srtp_crypto_kernel_init()
+srtp_err_status_t srtp_crypto_kernel_init(void)
 {
     srtp_err_status_t status;
 
@@ -168,7 +168,7 @@ srtp_err_status_t srtp_crypto_kernel_init()
     return srtp_err_status_ok;
 }
 
-srtp_err_status_t srtp_crypto_kernel_status()
+srtp_err_status_t srtp_crypto_kernel_status(void)
 {
     srtp_err_status_t status;
     srtp_kernel_cipher_type_t *ctype = crypto_kernel.cipher_type_list;
@@ -209,7 +209,7 @@ srtp_err_status_t srtp_crypto_kernel_status()
     return srtp_err_status_ok;
 }
 
-srtp_err_status_t srtp_crypto_kernel_list_debug_modules()
+srtp_err_status_t srtp_crypto_kernel_list_debug_modules(void)
 {
     srtp_kernel_debug_module_t *dm = crypto_kernel.debug_module_list;
 
@@ -228,7 +228,7 @@ srtp_err_status_t srtp_crypto_kernel_list_debug_modules()
     return srtp_err_status_ok;
 }
 
-srtp_err_status_t srtp_crypto_kernel_shutdown()
+srtp_err_status_t srtp_crypto_kernel_shutdown(void)
 {
     /*
      * free dynamic memory used in crypto_kernel at present

--- a/crypto/kernel/err.c
+++ b/crypto/kernel/err.c
@@ -54,7 +54,7 @@
 
 static FILE *srtp_err_file = NULL;
 
-srtp_err_status_t srtp_err_reporting_init()
+srtp_err_status_t srtp_err_reporting_init(void)
 {
 #ifdef ERR_REPORTING_STDOUT
     srtp_err_file = stdout;

--- a/srtp/srtp.c
+++ b/srtp/srtp.c
@@ -109,7 +109,7 @@ static srtp_err_status_t srtp_validate_rtp_header(void *rtp_hdr,
     return srtp_err_status_ok;
 }
 
-const char *srtp_get_version_string()
+const char *srtp_get_version_string(void)
 {
     /*
      * Simply return the autotools generated string
@@ -117,7 +117,7 @@ const char *srtp_get_version_string()
     return SRTP_VER_STRING;
 }
 
-unsigned int srtp_get_version()
+unsigned int srtp_get_version(void)
 {
     unsigned int major = 0, minor = 0, micro = 0;
     unsigned int rv = 0;
@@ -2774,7 +2774,7 @@ srtp_err_status_t srtp_unprotect_mki(srtp_ctx_t *ctx,
     return srtp_err_status_ok;
 }
 
-srtp_err_status_t srtp_init()
+srtp_err_status_t srtp_init(void)
 {
     srtp_err_status_t status;
 
@@ -2791,7 +2791,7 @@ srtp_err_status_t srtp_init()
     return srtp_err_status_ok;
 }
 
-srtp_err_status_t srtp_shutdown()
+srtp_err_status_t srtp_shutdown(void)
 {
     srtp_err_status_t status;
 

--- a/test/replay_driver.c
+++ b/test/replay_driver.c
@@ -251,7 +251,6 @@ double rdb_check_adds_per_second(void)
     uint32_t i;
     srtp_rdb_t rdb;
     clock_t timer;
-    int failures = 0; /* count number of failures        */
 
     if (srtp_rdb_init(&rdb) != srtp_err_status_ok) {
         printf("rdb_init failed\n");
@@ -260,18 +259,12 @@ double rdb_check_adds_per_second(void)
 
     timer = clock();
     for (i = 0; i < REPLAY_NUM_TRIALS; i += 3) {
-        if (srtp_rdb_check(&rdb, i + 2) != srtp_err_status_ok)
-            ++failures;
-        if (srtp_rdb_add_index(&rdb, i + 2) != srtp_err_status_ok)
-            ++failures;
-        if (srtp_rdb_check(&rdb, i + 1) != srtp_err_status_ok)
-            ++failures;
-        if (srtp_rdb_add_index(&rdb, i + 1) != srtp_err_status_ok)
-            ++failures;
-        if (srtp_rdb_check(&rdb, i) != srtp_err_status_ok)
-            ++failures;
-        if (srtp_rdb_add_index(&rdb, i) != srtp_err_status_ok)
-            ++failures;
+        srtp_rdb_check(&rdb, i + 2);
+        srtp_rdb_add_index(&rdb, i + 2);
+        srtp_rdb_check(&rdb, i + 1);
+        srtp_rdb_add_index(&rdb, i + 1);
+        srtp_rdb_check(&rdb, i);
+        srtp_rdb_add_index(&rdb, i);
     }
     timer = clock() - timer;
 

--- a/test/replay_driver.c
+++ b/test/replay_driver.c
@@ -132,7 +132,7 @@ srtp_err_status_t rdb_check_add_unordered(srtp_rdb_t *rdb, uint32_t idx)
     return srtp_err_status_ok;
 }
 
-srtp_err_status_t test_rdb_db()
+srtp_err_status_t test_rdb_db(void)
 {
     srtp_rdb_t rdb;
     uint32_t idx, ircvd;

--- a/test/srtp_driver.c
+++ b/test/srtp_driver.c
@@ -1666,7 +1666,7 @@ double mips_estimate(int num_trials, int *ignore)
  * These packets were made with the default SRTP policy.
  */
 
-srtp_err_status_t srtp_validate()
+srtp_err_status_t srtp_validate(void)
 {
     // clang-format off
     uint8_t srtp_plaintext_ref[28] = {
@@ -1826,7 +1826,7 @@ srtp_err_status_t srtp_validate()
  * and HMAC authentication.
  */
 
-srtp_err_status_t srtp_validate_null()
+srtp_err_status_t srtp_validate_null(void)
 {
     // clang-format off
     uint8_t srtp_plaintext_ref[28] = {
@@ -1984,7 +1984,7 @@ srtp_err_status_t srtp_validate_null()
  * srtp_validate_gcm() verifies the correctness of libsrtp by comparing
  * an computed packet against the known ciphertext for the plaintext.
  */
-srtp_err_status_t srtp_validate_gcm()
+srtp_err_status_t srtp_validate_gcm(void)
 {
     // clang-format off
     uint8_t rtp_plaintext_ref[28] = {
@@ -2146,7 +2146,7 @@ srtp_err_status_t srtp_validate_gcm()
 /*
  * Test vectors taken from RFC 6904, Appendix A
  */
-srtp_err_status_t srtp_validate_encrypted_extensions_headers()
+srtp_err_status_t srtp_validate_encrypted_extensions_headers(void)
 {
     // clang-format off
     unsigned char test_key_ext_headers[30] = {
@@ -2269,7 +2269,7 @@ srtp_err_status_t srtp_validate_encrypted_extensions_headers()
 /*
  * Headers of test vectors taken from RFC 6904, Appendix A
  */
-srtp_err_status_t srtp_validate_encrypted_extensions_headers_gcm()
+srtp_err_status_t srtp_validate_encrypted_extensions_headers_gcm(void)
 {
     // clang-format off
     unsigned char test_key_ext_headers[30] = {
@@ -2392,7 +2392,7 @@ srtp_err_status_t srtp_validate_encrypted_extensions_headers_gcm()
  * These packets were made with the AES-CM-256/HMAC-SHA-1-80 policy.
  */
 
-srtp_err_status_t srtp_validate_aes_256()
+srtp_err_status_t srtp_validate_aes_256(void)
 {
     // clang-format off
     unsigned char aes_256_test_key[46] = {
@@ -2551,7 +2551,7 @@ srtp_err_status_t srtp_dealloc_big_policy(srtp_policy_t *list)
     return srtp_err_status_ok;
 }
 
-srtp_err_status_t srtp_test_empty_payload()
+srtp_err_status_t srtp_test_empty_payload(void)
 {
     srtp_t srtp_snd, srtp_recv;
     srtp_err_status_t status;
@@ -2627,7 +2627,7 @@ srtp_err_status_t srtp_test_empty_payload()
 }
 
 #ifdef GCM
-srtp_err_status_t srtp_test_empty_payload_gcm()
+srtp_err_status_t srtp_test_empty_payload_gcm(void)
 {
     srtp_t srtp_snd, srtp_recv;
     srtp_err_status_t status;
@@ -2703,7 +2703,7 @@ srtp_err_status_t srtp_test_empty_payload_gcm()
 }
 #endif // GCM
 
-srtp_err_status_t srtp_test_remove_stream()
+srtp_err_status_t srtp_test_remove_stream(void)
 {
     srtp_err_status_t status;
     srtp_policy_t *policy_list, policy;
@@ -2816,7 +2816,7 @@ unsigned char test_alt_key[46] = {
  * atempts to prove that srtp_update does not reset the ROC.
  */
 
-srtp_err_status_t srtp_test_update()
+srtp_err_status_t srtp_test_update(void)
 {
     srtp_err_status_t status;
     uint32_t ssrc = 0x12121212;
@@ -3061,7 +3061,7 @@ srtp_err_status_t srtp_test_setup_protect_trailer_streams(
     return srtp_err_status_ok;
 }
 
-srtp_err_status_t srtp_test_protect_trailer_length()
+srtp_err_status_t srtp_test_protect_trailer_length(void)
 {
     srtp_t srtp_send;
     srtp_t srtp_send_mki;
@@ -3118,7 +3118,7 @@ srtp_err_status_t srtp_test_protect_trailer_length()
     return srtp_err_status_ok;
 }
 
-srtp_err_status_t srtp_test_protect_rtcp_trailer_length()
+srtp_err_status_t srtp_test_protect_rtcp_trailer_length(void)
 {
     srtp_t srtp_send;
     srtp_t srtp_send_mki;
@@ -3176,7 +3176,7 @@ srtp_err_status_t srtp_test_protect_rtcp_trailer_length()
     return srtp_err_status_ok;
 }
 
-srtp_err_status_t srtp_test_out_of_order_after_rollover()
+srtp_err_status_t srtp_test_out_of_order_after_rollover(void)
 {
     srtp_err_status_t status;
 
@@ -3394,7 +3394,7 @@ srtp_err_status_t srtp_test_out_of_order_after_rollover()
     return srtp_err_status_ok;
 }
 
-srtp_err_status_t srtp_test_get_roc()
+srtp_err_status_t srtp_test_get_roc(void)
 {
     srtp_err_status_t status;
     srtp_policy_t policy;
@@ -3736,7 +3736,7 @@ static srtp_err_status_t test_set_sender_roc(uint16_t seq, uint32_t roc_to_set)
     return srtp_err_status_ok;
 }
 
-srtp_err_status_t srtp_test_set_receiver_roc()
+srtp_err_status_t srtp_test_set_receiver_roc(void)
 {
     int packets;
     uint32_t roc;
@@ -3800,7 +3800,7 @@ srtp_err_status_t srtp_test_set_receiver_roc()
     return srtp_err_status_ok;
 }
 
-srtp_err_status_t srtp_test_set_sender_roc()
+srtp_err_status_t srtp_test_set_sender_roc(void)
 {
     uint32_t roc;
     uint16_t seq;

--- a/test/test_srtp.c
+++ b/test/test_srtp.c
@@ -84,7 +84,7 @@ TEST_LIST = { { "srtp_calc_aead_iv_srtcp_all_zero_input_yield_zero_output()",
  * Implementation.
  */
 
-void srtp_calc_aead_iv_srtcp_all_zero_input_yield_zero_output()
+void srtp_calc_aead_iv_srtcp_all_zero_input_yield_zero_output(void)
 {
     // Preconditions
     srtp_session_keys_t session_keys;
@@ -111,7 +111,7 @@ void srtp_calc_aead_iv_srtcp_all_zero_input_yield_zero_output()
     TEST_CHECK(memcmp(&zero_vector, &init_vector, sizeof(v128_t)) == 0);
 }
 
-void srtp_calc_aead_iv_srtcp_seq_num_over_0x7FFFFFFF_bad_param()
+void srtp_calc_aead_iv_srtcp_seq_num_over_0x7FFFFFFF_bad_param(void)
 {
     // Preconditions
     srtp_session_keys_t session_keys;
@@ -143,7 +143,7 @@ void srtp_calc_aead_iv_srtcp_seq_num_over_0x7FFFFFFF_bad_param()
  * Ensure that for each valid sequence number where the most significant bit is
  * high that we get an expected and unique IV.
  */
-void srtp_calc_aead_iv_srtcp_distinct_iv_per_sequence_number()
+void srtp_calc_aead_iv_srtcp_distinct_iv_per_sequence_number(void)
 {
 #define SAMPLE_COUNT (3)
     // Preconditions


### PR DESCRIPTION
Clang 15 enables -Wstrict-prototypes by default in C .
see https://discourse.llvm.org/t/rfc-enabling-wstrict-prototypes-by-default-in-c/60521