### PR TITLE
Make mbedtls hmac less restrictive in line with RFC and library capabilities

### DIFF
--- a/crypto/hash/hmac_mbedtls.c
+++ b/crypto/hash/hmac_mbedtls.c
@@ -72,10 +72,6 @@ static srtp_err_status_t srtp_hmac_mbedtls_alloc(srtp_auth_t **a,
                 out_len);
 
     /* check output length - should be less than 20 bytes */
-    if (key_len > SHA1_DIGEST_SIZE) {
-        return srtp_err_status_bad_param;
-    }
-    /* check output length - should be less than 20 bytes */
     if (out_len > SHA1_DIGEST_SIZE) {
         return srtp_err_status_bad_param;
     }


### PR DESCRIPTION
Libsrtp is unnecessarily restrictive with what keys it allows for HMAC with mbedtls . The [HMAC RFC permits](https://www.rfc-editor.org/rfc/rfc2104#section-3) for keys here to have length between the `SHA1_DIGEST_SIZE` 20 and the block size of 64.

Unlike libsrtp's internal implementation, mbedtls has no limitations on the key that can be used, as seen in [its hmac functions](https://github.com/Mbed-TLS/mbedtls/blob/development/library/md.c#L640). As far as I can see this is also true historically in mbedtls.
The same is true of openssl, for which [libsrtp doesn't enforce the key length check](https://github.com/cisco/libsrtp/blob/main/crypto/hash/hmac_ossl.c#L111). It seems sensible that mbedtls should get the same behaviour.