### PR TITLE
schedule cmake CI once a week

### DIFF
--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -5,6 +5,8 @@ on:
     branches: [ main ]
   pull_request:
     branches: [ main ]
+  schedule:
+    - cron: '20 4 * * 1'
 
 jobs:
   build:


### PR DESCRIPTION
A few times now CI builds have broken due to changes in the CI environment, but these are not picked up before the next PR / commit. This will try to detect CI breakage early so it can be fix independently of any other code change.