### PR TITLE
openssl 3 performance

### DIFF
--- a/crypto/cipher/aes_gcm_ossl.c
+++ b/crypto/cipher/aes_gcm_ossl.c
@@ -110,17 +110,6 @@ static srtp_err_status_t srtp_aes_gcm_openssl_alloc(srtp_cipher_t **c,
         return (srtp_err_status_alloc_fail);
     }
 
-    gcm->ctx = EVP_CIPHER_CTX_new();
-    if (gcm->ctx == NULL) {
-        srtp_crypto_free(gcm);
-        srtp_crypto_free(*c);
-        *c = NULL;
-        return srtp_err_status_alloc_fail;
-    }
-
-    /* set pointers */
-    (*c)->state = gcm;
-
     /* setup cipher attributes */
     switch (key_len) {
     case SRTP_AES_GCM_128_KEY_LEN_WSALT:
@@ -140,6 +129,32 @@ static srtp_err_status_t srtp_aes_gcm_openssl_alloc(srtp_cipher_t **c,
     /* set key size        */
     (*c)->key_len = key_len;
 
+    /* fetch cipher*/
+    if ((*c)->algorithm == SRTP_AES_GCM_128) {
+        gcm->cipher = EVP_CIPHER_fetch(NULL, "AES-128-GCM", NULL);
+    } else {
+        gcm->cipher = EVP_CIPHER_fetch(NULL, "AES-256-GCM", NULL);
+    }
+
+    if (gcm->cipher == NULL) {
+        srtp_crypto_free(gcm);
+        srtp_crypto_free(*c);
+        *c = NULL;
+        return srtp_err_status_alloc_fail;
+    }
+
+    gcm->ctx = EVP_CIPHER_CTX_new();
+    if (gcm->ctx == NULL) {
+        EVP_CIPHER_free(gcm->cipher);
+        srtp_crypto_free(gcm);
+        srtp_crypto_free(*c);
+        *c = NULL;
+        return srtp_err_status_alloc_fail;
+    }
+
+    /* set pointers */
+    (*c)->state = gcm;
+
     return (srtp_err_status_ok);
 }
 
@@ -153,6 +168,7 @@ static srtp_err_status_t srtp_aes_gcm_openssl_dealloc(srtp_cipher_t *c)
     ctx = (srtp_aes_gcm_ctx_t *)c->state;
     if (ctx) {
         EVP_CIPHER_CTX_free(ctx->ctx);
+        EVP_CIPHER_free(ctx->cipher);
         /* zeroize the key material */
         octet_string_set_to_zero(ctx, sizeof(srtp_aes_gcm_ctx_t));
         srtp_crypto_free(ctx);
@@ -174,28 +190,15 @@ static srtp_err_status_t srtp_aes_gcm_openssl_context_init(void *cv,
                                                            const uint8_t *key)
 {
     srtp_aes_gcm_ctx_t *c = (srtp_aes_gcm_ctx_t *)cv;
-    const EVP_CIPHER *evp;
 
     c->dir = srtp_direction_any;
 
     debug_print(srtp_mod_aes_gcm, "key:  %s",
                 srtp_octet_string_hex_string(key, c->key_size));
 
-    switch (c->key_size) {
-    case SRTP_AES_256_KEY_LEN:
-        evp = EVP_aes_256_gcm();
-        break;
-    case SRTP_AES_128_KEY_LEN:
-        evp = EVP_aes_128_gcm();
-        break;
-    default:
-        return (srtp_err_status_bad_param);
-        break;
-    }
-
     EVP_CIPHER_CTX_reset(c->ctx);
 
-    if (!EVP_CipherInit_ex(c->ctx, evp, NULL, key, NULL, 0)) {
+    if (!EVP_CipherInit_ex(c->ctx, c->cipher, NULL, key, NULL, 0)) {
         return (srtp_err_status_init_fail);
     }
 

--- a/crypto/include/aes_gcm.h
+++ b/crypto/include/aes_gcm.h
@@ -58,6 +58,7 @@
 typedef struct {
     int key_size;
     int tag_len;
+    EVP_CIPHER * cipher;
     EVP_CIPHER_CTX *ctx;
     srtp_cipher_direction_t dir;
 } srtp_aes_gcm_ctx_t;

--- a/crypto/include/aes_icm_ext.h
+++ b/crypto/include/aes_icm_ext.h
@@ -58,6 +58,7 @@ typedef struct {
     v128_t counter; /* holds the counter value          */
     v128_t offset;  /* initial offset value             */
     int key_size;
+    EVP_CIPHER *cipher;
     EVP_CIPHER_CTX *ctx;
 } srtp_aes_icm_ctx_t;
 


### PR DESCRIPTION
Investigate and fix reported performance issues with openssl 3 reported in #645.

Try explicit fetching once per stream, should be more efficient than implicit featuring on demand.

This is openssl 3 only so with fail to build with older version for now.