### PR TITLE
iv length is constant so set only once

### DIFF
--- a/crypto/cipher/aes_gcm_ossl.c
+++ b/crypto/cipher/aes_gcm_ossl.c
@@ -199,6 +199,10 @@ static srtp_err_status_t srtp_aes_gcm_openssl_context_init(void *cv,
         return (srtp_err_status_init_fail);
     }
 
+    if (!EVP_CIPHER_CTX_ctrl(c->ctx, EVP_CTRL_GCM_SET_IVLEN, 12, 0)) {
+        return (srtp_err_status_init_fail);
+    }
+
     return (srtp_err_status_ok);
 }
 
@@ -221,10 +225,6 @@ static srtp_err_status_t srtp_aes_gcm_openssl_set_iv(
 
     debug_print(srtp_mod_aes_gcm, "setting iv: %s",
                 srtp_octet_string_hex_string(iv, 12));
-
-    if (!EVP_CIPHER_CTX_ctrl(c->ctx, EVP_CTRL_GCM_SET_IVLEN, 12, 0)) {
-        return (srtp_err_status_init_fail);
-    }
 
     if (!EVP_CipherInit_ex(c->ctx, NULL, NULL, NULL, iv,
                            (c->dir == srtp_direction_encrypt ? 1 : 0))) {


### PR DESCRIPTION
The iv length is preserved inside the EVP_CIPHER_CTX so no need to set more than once.
This is especially important with OpenSSL 3 where setting the iv len is a expensive operation due to param lookup code inside of OpenSSL.

This should help performance issue with OpenSSL 3 and libsrtp with #645 in the case of GCM but does not fix all of the performance issues.