### PR TITLE
Fix library version in Doxygen docs

### DIFF
--- a/doc/Makefile.in
+++ b/doc/Makefile.in
@@ -14,7 +14,7 @@ VPATH = @srcdir@
 
 # Determine the version of the library
 
-version = $(shell cat $(top_srcdir)/VERSION)
+version = @PACKAGE_VERSION@
 
 .PHONY: libsrtpdoc clean
 libsrtpdoc:


### PR DESCRIPTION
Replace parsing (nonexistant) `VERSION` file with the version set by `configure` script.