### PR TITLE
remove comma from srtp_profile_t enum value.

### DIFF
--- a/include/srtp.h
+++ b/include/srtp.h
@@ -1167,7 +1167,7 @@ typedef enum {
     srtp_profile_null_sha1_80 = 5,
     srtp_profile_null_sha1_32 = 6,
     srtp_profile_aead_aes_128_gcm = 7,
-    srtp_profile_aead_aes_256_gcm = 8,
+    srtp_profile_aead_aes_256_gcm = 8
 } srtp_profile_t;
 
 /**


### PR DESCRIPTION
remove comma from srtp_profile_t enum value.

comma have error old compiler on end of enum.