### PR TITLE
srtp_stream_hash_t

### DIFF
--- a/include/srtp_priv.h
+++ b/include/srtp_priv.h
@@ -67,6 +67,7 @@ extern "C" {
 typedef struct srtp_stream_ctx_t_ srtp_stream_ctx_t;
 typedef srtp_stream_ctx_t *srtp_stream_t;
 typedef struct srtp_stream_list_ctx_t_ *srtp_stream_list_t;
+typedef struct srtp_stream_hash_t_ *srtp_stream_hash_t;
 
 /*
  * the following declarations are libSRTP internal functions
@@ -158,7 +159,7 @@ typedef struct srtp_stream_ctx_t_ {
  * an srtp_ctx_t holds a stream list and a service description
  */
 typedef struct srtp_ctx_t_ {
-    srtp_stream_list_t stream_list;             /* linked list of streams     */
+    srtp_stream_hash_t stream_hash;             /* hash of stream lists       */
     struct srtp_stream_ctx_t_ *stream_template; /* act as template for other  */
                                                 /* streams                    */
     void *user_data;                            /* user custom data           */

--- a/include/stream_list_priv.h
+++ b/include/stream_list_priv.h
@@ -115,6 +115,55 @@ void srtp_stream_list_for_each(srtp_stream_list_t list,
                                int (*callback)(srtp_stream_t, void *),
                                void *data);
 
+/**
+ * allocate and initialize a stream hash instance
+ */
+srtp_err_status_t srtp_stream_hash_alloc(srtp_stream_hash_t *hash_ptr);
+
+/**
+ * deallocate a stream hash instance
+ *
+ * the underlying lists must be empty or else an error is returned.
+ */
+srtp_err_status_t srtp_stream_hash_dealloc(srtp_stream_hash_t hash);
+
+/**
+ * insert a stream into the hash
+ *
+ * returns srtp_err_status_alloc_fail if insertion failed due to unavailable
+ * capacity in the hash. if operation succeeds, srtp_err_status_ok is returned
+ *
+ * if another stream with the same SSRC already exists in the hash,
+ * behavior is undefined. if the SSRC field is mutated while the
+ * stream is inserted, further operations have undefined behavior
+ */
+srtp_err_status_t srtp_stream_hash_insert(srtp_stream_hash_t hash,
+                                          srtp_stream_t stream);
+
+/*
+ * look up the stream corresponding to the specified SSRC and return it.
+ * if no such SSRC is found, NULL is returned.
+ */
+srtp_stream_t srtp_stream_hash_get(srtp_stream_hash_t hash, uint32_t ssrc);
+
+/**
+ * remove the stream from the hash.
+ *
+ * The stream to be removed is referenced "by value", i.e., by the pointer to be
+ * removed from the hash. This pointer is obtained using `srtp_stream_hash_get`
+ * or as callback parameter in `srtp_stream_hash_for_each`.
+ */
+void srtp_stream_hash_remove(srtp_stream_hash_t hash, srtp_stream_t stream);
+
+/**
+ * iterate through all stored streams. while iterating, it is allowed to delete
+ * the current element; any other mutation to the hash is undefined behavior.
+ * returning non-zero from callback aborts the iteration.
+ */
+void srtp_stream_hash_for_each(srtp_stream_hash_t hash,
+                               int (*callback)(srtp_stream_t, void *),
+                               void *data);
+
 #ifdef __cplusplus
 }
 #endif

--- a/srtp/srtp.c
+++ b/srtp/srtp.c
@@ -4838,6 +4838,12 @@ srtp_err_status_t srtp_get_stream_roc(srtp_t session,
     return srtp_err_status_ok;
 }
 
+#define SRTP_STREAM_HASH_SIZE 32
+
+struct srtp_stream_hash_t_ {
+    srtp_stream_list_t *list;
+} srtp_stream_hash_t_;
+
 #ifndef SRTP_NO_STREAM_LIST
 
 /* in the default implementation, we have an intrusive doubly-linked list */
@@ -4846,12 +4852,6 @@ typedef struct srtp_stream_list_ctx_t_ {
      * list */
     srtp_stream_ctx_t data;
 } srtp_stream_list_ctx_t_;
-
-#define SRTP_STREAM_HASH_SIZE 32
-
-struct srtp_stream_hash_t_ {
-    srtp_stream_list_t *list;
-} srtp_stream_hash_t_;
 
 srtp_err_status_t srtp_stream_list_alloc(srtp_stream_list_t *list_ptr)
 {
@@ -4930,6 +4930,8 @@ void srtp_stream_list_for_each(srtp_stream_list_t list,
             break;
     }
 }
+
+#endif
 
 srtp_err_status_t srtp_stream_hash_alloc(srtp_stream_hash_t *hash_ptr)
 {
@@ -5019,5 +5021,3 @@ void srtp_stream_hash_for_each(srtp_stream_hash_t hash,
         srtp_stream_list_for_each(list, callback, data);
     }
 }
-
-#endif

--- a/srtp/srtp.c
+++ b/srtp/srtp.c
@@ -5003,7 +5003,7 @@ void srtp_stream_hash_remove(srtp_stream_hash_t hash,
     srtp_stream_list_t list =
         hash->list[stream_to_remove->ssrc & (SRTP_STREAM_HASH_SIZE - 1)];
 
-    return srtp_stream_list_remove(list, stream_to_remove);
+    srtp_stream_list_remove(list, stream_to_remove);
 }
 
 void srtp_stream_hash_for_each(srtp_stream_hash_t hash,

--- a/test/srtp_driver.c
+++ b/test/srtp_driver.c
@@ -1570,7 +1570,7 @@ srtp_err_status_t srtp_session_print_policy(srtp_t srtp)
 
     /* loop over streams in session, printing the policy of each */
     data.is_template = 0;
-    srtp_stream_list_for_each(srtp->stream_list, srtp_session_print_stream,
+    srtp_stream_hash_for_each(srtp->stream_hash, srtp_session_print_stream,
                               &data);
 
     return data.status;


### PR DESCRIPTION
Store SRTP streams in several lists rather than in a single one, making those effectively smaller (and faster to iterate) than the current single one.

Each hash entry is a `srtp_stream_list_t`, being this one where the streams are ultimately stored as they are currently. In order to select the `srtp_stream_list_t` where a stream is stored, the SSRC is masked with the hash size (the number of lists it contains).

Enhances greatly the performance derived from iterating the lists as the list to be iterated is, in average, N times smaller comparing to having a single one. N being the number of lists in the hash, which in this PR has been set to 32.

I'm aware of https://github.com/cisco/libsrtp/pull/612, and I think what I'm doing here cannot be done by rewriting the `_list` methods from the outside. These changes perfectly fit with the mentioned PR anyway.

EDIT:

* It adds little to no performance penalty as, in order to know in which list a stream is stored, it only performs a binary mask operation.
* It adds little to no performance gain to scenarios with a low number of streams/SSRCs.
* It adds a huge performance gain to scenarios with a high number of streams/SSRCs. 32 times faster in average with the current defined constant `SRTP_STREAM_HASH_SIZE 32`.