### PR TITLE
meson.build: implement mbedtls support

### DIFF
--- a/.github/workflows/meson.yml
+++ b/.github/workflows/meson.yml
@@ -1,0 +1,110 @@
+name: Meson CI
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+  schedule:
+    - cron: '20 4 * * 1'
+
+jobs:
+  build:
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, macos-latest, windows-latest]
+        crypto: [internal, openssl, openssl3, nss, mbedtls]
+        exclude:
+          - os: windows-latest
+            crypto: openssl
+          - os: windows-latest
+            crypto: openssl3
+          - os: windows-latest
+            crypto: nss
+          - os: windows-latest
+            crypto: mbedtls
+          - os: ubuntu-latest
+            crypto: openssl3
+        include:
+          - crypto: internal
+            meson-crypto-enable: ""
+          - crypto: openssl
+            meson-crypto-enable: "-Dcrypto-library=openssl"
+          - crypto: openssl3
+            meson-crypto-enable: "-Dcrypto-library=openssl"
+          - crypto: nss
+            meson-crypto-enable: "-Dcrypto-library=nss"
+          - crypto: mbedtls
+            meson-crypto-enable: "-Dcrypto-library=mbedtls"
+
+    runs-on: ${{ matrix.os }}
+
+    env:
+      CTEST_OUTPUT_ON_FAILURE: 1
+
+    steps:
+    - name: Setup Ubuntu Meson
+      if: matrix.os == 'ubuntu-latest'
+      run: |
+        sudo apt-get update
+        sudo apt-get install meson
+
+    - name: Setup macOS Meson
+      if: matrix.os == 'macos-latest'
+      run: |
+        brew install meson
+
+    - name: Setup Windows Meson & Ninja
+      if: matrix.os == 'windows-latest'
+      run: |
+        choco install ninja
+        pip3 install meson
+
+    - name: Setup Ubuntu NSS
+      if: matrix.os == 'ubuntu-latest' && matrix.crypto == 'nss'
+      run: |
+        sudo apt-get update
+        sudo apt-get install libnss3-dev
+
+    - name: Setup Ubuntu MbedTLS
+      if:  matrix.os == 'ubuntu-latest' && matrix.crypto == 'mbedtls'
+      run: sudo apt-get install libmbedtls-dev
+
+    - name: Setup macOS OpenSSL
+      if: matrix.os == 'macos-latest' && matrix.crypto == 'openssl'
+      run: echo "pkgconfig-crypto-dir=PKG_CONFIG_PATH=$(brew --prefix openssl@1.1)/lib/pkgconfig" >> $GITHUB_ENV
+
+    - name: Setup macOS OpenSSL3
+      if: matrix.os == 'macos-latest' && matrix.crypto == 'openssl3'
+      run: |
+        brew install openssl@3
+        echo "pkgconfig-crypto-dir=PKG_CONFIG_PATH=$(brew --prefix openssl@3)/lib/pkgconfig" >> $GITHUB_ENV
+
+    - name: Setup macOS NSS
+      if:  matrix.os == 'macos-latest' && matrix.crypto == 'nss'
+      run: brew install nss
+
+    - name: Setup macOS MbedTLS
+      if:  matrix.os == 'macos-latest' && matrix.crypto == 'mbedtls'
+      run: brew install mbedtls
+
+    - uses: actions/checkout@v2
+
+    - name: Create Build Environment
+      run: meson setup ${{github.workspace}}/build
+
+    - name: Configure Meson
+      working-directory: ${{github.workspace}}/build
+      shell: bash
+      run: ${{ env.pkgconfig-crypto-dir }} meson configure ${{ matrix.meson-crypto-enable }}
+
+    - name: Build
+      working-directory: ${{github.workspace}}/build
+      shell: bash
+      run: ninja
+
+    - name: Test
+      working-directory: ${{github.workspace}}/build
+      shell: bash
+      run: meson test

--- a/crypto/test/meson.build
+++ b/crypto/test/meson.build
@@ -7,7 +7,7 @@ test_apps = [
   'env',
 ]
 
-if not use_openssl and not use_nss
+if not use_openssl and not use_nss and not use_mbedtls
   test_apps += ['sha1_driver']
 endif
 
@@ -20,7 +20,7 @@ foreach test_name : test_apps
   test(test_name, test_exe, args: ['-v'])
 endforeach
 
-if not use_openssl and not use_nss
+if not use_openssl and not use_nss and not use_mbedtls
   test_exe = executable('aes_calc',
     'aes_calc.c', '../../test/getopt_s.c', '../../test/util.c',
     include_directories: [config_incs, crypto_incs, srtp2_incs, test_incs],

--- a/meson.build
+++ b/meson.build
@@ -121,6 +121,7 @@ endif
 
 use_openssl = false
 use_nss = false
+use_mbedtls = false
 
 crypto_library = get_option('crypto-library')
 if crypto_library == 'openssl'
@@ -151,6 +152,20 @@ elif crypto_library == 'nss'
   # TODO(RLB): Use NSS for KDF
   if get_option('crypto-library-kdf').enabled()
     error('KDF support has not been implemented for NSS')
+  endif
+elif crypto_library == 'mbedtls'
+  mbedtls_dep = dependency('mbedtls', required: false)
+  if not mbedtls_dep.found()
+    mbedtls_dep = cc.find_library('mbedcrypto', has_headers: ['mbedtls/aes.h'], required: true)
+  endif
+  srtp2_deps += [mbedtls_dep]
+  cdata.set('GCM', true)
+  cdata.set('MBEDTLS', true)
+  cdata.set('USE_EXTERNAL_CRYPTO', true)
+  use_mbedtls = true
+  # TODO(RLB): Use NSS for KDF
+  if get_option('crypto-library-kdf').enabled()
+    error('KDF support has not been implemented for mbedtls')
   endif
 endif
 
@@ -189,6 +204,11 @@ elif use_nss
     'crypto/cipher/aes_icm_nss.c',
     'crypto/cipher/aes_gcm_nss.c',
   )
+elif use_mbedtls
+  ciphers_sources += files(
+    'crypto/cipher/aes_icm_mbedtls.c',
+    'crypto/cipher/aes_gcm_mbedtls.c',
+  )
 else
   ciphers_sources += files(
     'crypto/cipher/aes.c',
@@ -209,6 +229,10 @@ if use_openssl
 elif use_nss
   hashes_sources += files(
     'crypto/hash/hmac_nss.c',
+  )
+elif use_mbedtls
+  hashes_sources += files(
+    'crypto/hash/hmac_mbedtls.c',
   )
 else
   hashes_sources += files(

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -4,8 +4,8 @@ option('log-stdout', type : 'boolean', value : false,
   description : 'Redirect logging to stdout')
 option('log-file', type : 'string', value : '',
   description : 'Write logging output into this file')
-option('crypto-library', type: 'combo', choices : ['none', 'openssl', 'nss'], value : 'none',
-  description : 'What external crypto library to leverage, if any (OpenSSL or NSS)')
+option('crypto-library', type: 'combo', choices : ['none', 'openssl', 'nss', 'mbedtls'], value : 'none',
+  description : 'What external crypto library to leverage, if any (OpenSSL, NSS, or mbedtls)')
 option('crypto-library-kdf', type : 'feature', value : 'auto',
   description : 'Use the external crypto library for Key Derivation Function support')
 option('fuzzer', type : 'feature', value : 'disabled',

--- a/test/meson.build
+++ b/test/meson.build
@@ -54,7 +54,7 @@ if can_run_rtpw
   endif
 
   rtpw_test_gcm_sh = find_program('rtpw_test_gcm.sh', required: false)
-  if (use_openssl or use_nss) and rtpw_test_gcm_sh.found()
+  if (use_openssl or use_nss or use_mbedtls) and rtpw_test_gcm_sh.found()
     test('rtpw_test_gcm', rtpw_test_gcm_sh,
          args: ['-w', words_txt],
          depends: rtpw_exe,


### PR DESCRIPTION
This was pretty easy; just porting over mbedtls support that was already added from https://github.com/cisco/libsrtp/pull/512. Now it works with Meson too!