### PR TITLE
Some cipher_driver fixes

### DIFF
--- a/crypto/include/cipher.h
+++ b/crypto/include/cipher.h
@@ -153,7 +153,7 @@ typedef struct srtp_cipher_type_t {
     srtp_cipher_init_func_t init;
     srtp_cipher_set_aad_func_t set_aad;
     srtp_cipher_encrypt_func_t encrypt;
-    srtp_cipher_encrypt_func_t decrypt;
+    srtp_cipher_decrypt_func_t decrypt;
     srtp_cipher_set_iv_func_t set_iv;
     srtp_cipher_get_tag_func_t get_tag;
     const char *description;

--- a/crypto/test/cipher_driver.c
+++ b/crypto/test/cipher_driver.c
@@ -438,7 +438,7 @@ srtp_err_status_t cipher_array_alloc_init(srtp_cipher_t ***ca,
 {
     int i, j;
     srtp_err_status_t status;
-    uint8_t *key;
+    uint8_t *key = NULL;
     srtp_cipher_t **cipher_array;
     /* pad klen allocation, to handle aes_icm reading 16 bytes for the
        14-byte salt */
@@ -453,11 +453,13 @@ srtp_err_status_t cipher_array_alloc_init(srtp_cipher_t ***ca,
     /* set ca to location of cipher_array */
     *ca = cipher_array;
 
-    /* allocate key */
-    key = srtp_crypto_alloc(klen_pad);
-    if (key == NULL) {
-        srtp_crypto_free(cipher_array);
-        return srtp_err_status_alloc_fail;
+    /* allocate key , allow zero key for example null cipher */
+    if (klen_pad > 0) {
+        key = srtp_crypto_alloc(klen_pad);
+        if (key == NULL) {
+            srtp_crypto_free(cipher_array);
+            return srtp_err_status_alloc_fail;
+        }
     }
 
     /* allocate and initialize an array of ciphers */


### PR DESCRIPTION
Allow a zero length key for the null cipher and use correct function type in cipher struct.