### PR TITLE
start using const on internal arguments

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -120,7 +120,7 @@ endif()
 
 if(BUILD_WITH_WARNINGS)
   if(CMAKE_C_COMPILER_ID MATCHES "Clang" OR CMAKE_C_COMPILER_ID MATCHES "GNU")
-    set(WARNINGS -Wall -pedantic -Wextra -Werror)
+    set(WARNINGS -Wall -pedantic -Wextra -Wcast-qual -Werror)
   elseif(MSVC)
     set(WARNINGS /W4 /WX)
   endif()

--- a/crypto/cipher/aes_gcm_nss.c
+++ b/crypto/cipher/aes_gcm_nss.c
@@ -212,7 +212,9 @@ static srtp_err_status_t srtp_aes_gcm_nss_context_init(void *cv,
         return (srtp_err_status_cipher_fail);
     }
 
-    SECItem key_item = { siBuffer, (unsigned char *)key, c->key_size };
+    /* explicitly cast away const of key */
+    SECItem key_item = { siBuffer, (unsigned char *)(uintptr_t)key,
+                         c->key_size };
     c->key = PK11_ImportSymKey(slot, CKM_AES_GCM, PK11_OriginUnwrap,
                                CKA_ENCRYPT, &key_item, NULL);
     PK11_FreeSlot(slot);

--- a/crypto/cipher/aes_icm_nss.c
+++ b/crypto/cipher/aes_icm_nss.c
@@ -254,7 +254,9 @@ static srtp_err_status_t srtp_aes_icm_nss_context_init(void *cv,
         return srtp_err_status_bad_param;
     }
 
-    SECItem keyItem = { siBuffer, (unsigned char *)key, c->key_size };
+    /* explicitly cast away const of key */
+    SECItem keyItem = { siBuffer, (unsigned char *)(uintptr_t)key,
+                        c->key_size };
     c->key = PK11_ImportSymKey(slot, CKM_AES_CTR, PK11_OriginUnwrap,
                                CKA_ENCRYPT, &keyItem, NULL);
     PK11_FreeSlot(slot);

--- a/crypto/hash/hmac_nss.c
+++ b/crypto/hash/hmac_nss.c
@@ -187,7 +187,8 @@ static srtp_err_status_t srtp_hmac_init(void *statev,
         return srtp_err_status_bad_param;
     }
 
-    SECItem key_item = { siBuffer, (unsigned char *)key, key_len };
+    /* explicitly cast away const of key */
+    SECItem key_item = { siBuffer, (unsigned char *)(uintptr_t)key, key_len };
     sym_key = PK11_ImportSymKey(slot, CKM_SHA_1_HMAC, PK11_OriginUnwrap,
                                 CKA_SIGN, &key_item, NULL);
     PK11_FreeSlot(slot);

--- a/crypto/include/datatypes.h
+++ b/crypto/include/datatypes.h
@@ -163,7 +163,7 @@ void v128_left_shift(v128_t *x, int shift_index);
  * verifying authentication tags.
  */
 
-int srtp_octet_string_is_eq(uint8_t *a, uint8_t *b, int len);
+int srtp_octet_string_is_eq(const uint8_t *a, const uint8_t *b, int len);
 
 /*
  * A portable way to zero out memory as recommended by

--- a/crypto/math/datatypes.c
+++ b/crypto/math/datatypes.c
@@ -397,14 +397,14 @@ void bitvector_left_shift(bitvector_t *x, int shift)
 
 #endif /* defined(__SSSE3__) */
 
-int srtp_octet_string_is_eq(uint8_t *a, uint8_t *b, int len)
+int srtp_octet_string_is_eq(const uint8_t *a, const uint8_t *b, int len)
 {
     /*
      * We use this somewhat obscure implementation to try to ensure the running
      * time only depends on len, even accounting for compiler optimizations.
      * The accumulator ends up zero iff the strings are equal.
      */
-    uint8_t *end = b + len;
+    const uint8_t *end = b + len;
     uint32_t accumulator = 0;
 
 #if defined(__SSE2__)


### PR DESCRIPTION
Add const cast warnings.
Add const when the arguments do not need to be modified.