### PR TITLE
use size_t for all memory length variables

### DIFF
--- a/crypto/cipher/aes.c
+++ b/crypto/cipher/aes.c
@@ -1503,7 +1503,7 @@ static void aes_256_expand_encryption_key(const unsigned char *key,
 
 srtp_err_status_t srtp_aes_expand_encryption_key(
     const uint8_t *key,
-    int key_len,
+    size_t key_len,
     srtp_aes_expanded_key_t *expanded_key)
 {
     if (key_len == 16) {
@@ -1522,7 +1522,7 @@ srtp_err_status_t srtp_aes_expand_encryption_key(
 
 srtp_err_status_t srtp_aes_expand_decryption_key(
     const uint8_t *key,
-    int key_len,
+    size_t key_len,
     srtp_aes_expanded_key_t *expanded_key)
 {
     int i;

--- a/crypto/cipher/aes_gcm_mbedtls.c
+++ b/crypto/cipher/aes_gcm_mbedtls.c
@@ -98,15 +98,16 @@ srtp_debug_module_t srtp_mod_aes_gcm = {
  * initializing the KDF.
  */
 static srtp_err_status_t srtp_aes_gcm_mbedtls_alloc(srtp_cipher_t **c,
-                                                    int key_len,
-                                                    int tlen)
+                                                    size_t key_len,
+                                                    size_t tlen)
 {
     FUNC_ENTRY();
     srtp_aes_gcm_ctx_t *gcm;
 
-    debug_print(srtp_mod_aes_gcm, "allocating cipher with key length %d",
+    debug_print(srtp_mod_aes_gcm, "allocating cipher with key length %zu",
                 key_len);
-    debug_print(srtp_mod_aes_gcm, "allocating cipher with tag length %d", tlen);
+    debug_print(srtp_mod_aes_gcm, "allocating cipher with tag length %zu",
+                tlen);
 
     /*
      * Verify the key_len is valid for one of: AES-128/256
@@ -253,7 +254,7 @@ static srtp_err_status_t srtp_aes_gcm_mbedtls_set_iv(
  */
 static srtp_err_status_t srtp_aes_gcm_mbedtls_set_aad(void *cv,
                                                       const uint8_t *aad,
-                                                      uint32_t aad_len)
+                                                      size_t aad_len)
 {
     FUNC_ENTRY();
     srtp_aes_gcm_ctx_t *c = (srtp_aes_gcm_ctx_t *)cv;
@@ -281,7 +282,7 @@ static srtp_err_status_t srtp_aes_gcm_mbedtls_set_aad(void *cv,
  */
 static srtp_err_status_t srtp_aes_gcm_mbedtls_encrypt(void *cv,
                                                       unsigned char *buf,
-                                                      unsigned int *enc_len)
+                                                      size_t *enc_len)
 {
     FUNC_ENTRY();
     srtp_aes_gcm_ctx_t *c = (srtp_aes_gcm_ctx_t *)cv;
@@ -317,11 +318,11 @@ static srtp_err_status_t srtp_aes_gcm_mbedtls_encrypt(void *cv,
  */
 static srtp_err_status_t srtp_aes_gcm_mbedtls_get_tag(void *cv,
                                                       uint8_t *buf,
-                                                      uint32_t *len)
+                                                      size_t *len)
 {
     FUNC_ENTRY();
     srtp_aes_gcm_ctx_t *c = (srtp_aes_gcm_ctx_t *)cv;
-    debug_print(srtp_mod_aes_gcm, "appended tag size:  %d", c->tag_len);
+    debug_print(srtp_mod_aes_gcm, "appended tag size:  %zu", c->tag_len);
     *len = c->tag_len;
     memcpy(buf, c->tag, c->tag_len);
     return (srtp_err_status_ok);
@@ -337,7 +338,7 @@ static srtp_err_status_t srtp_aes_gcm_mbedtls_get_tag(void *cv,
  */
 static srtp_err_status_t srtp_aes_gcm_mbedtls_decrypt(void *cv,
                                                       unsigned char *buf,
-                                                      unsigned int *enc_len)
+                                                      size_t *enc_len)
 {
     FUNC_ENTRY();
     srtp_aes_gcm_ctx_t *c = (srtp_aes_gcm_ctx_t *)cv;

--- a/crypto/cipher/aes_gcm_ossl.c
+++ b/crypto/cipher/aes_gcm_ossl.c
@@ -76,14 +76,15 @@ srtp_debug_module_t srtp_mod_aes_gcm = {
  * initializing the KDF.
  */
 static srtp_err_status_t srtp_aes_gcm_openssl_alloc(srtp_cipher_t **c,
-                                                    int key_len,
-                                                    int tlen)
+                                                    size_t key_len,
+                                                    size_t tlen)
 {
     srtp_aes_gcm_ctx_t *gcm;
 
-    debug_print(srtp_mod_aes_gcm, "allocating cipher with key length %d",
+    debug_print(srtp_mod_aes_gcm, "allocating cipher with key length %zu",
                 key_len);
-    debug_print(srtp_mod_aes_gcm, "allocating cipher with tag length %d", tlen);
+    debug_print(srtp_mod_aes_gcm, "allocating cipher with tag length %zu",
+                tlen);
 
     /*
      * Verify the key_len is valid for one of: AES-128/256
@@ -244,7 +245,7 @@ static srtp_err_status_t srtp_aes_gcm_openssl_set_iv(
  */
 static srtp_err_status_t srtp_aes_gcm_openssl_set_aad(void *cv,
                                                       const uint8_t *aad,
-                                                      uint32_t aad_len)
+                                                      size_t aad_len)
 {
     srtp_aes_gcm_ctx_t *c = (srtp_aes_gcm_ctx_t *)cv;
     int rv;
@@ -293,7 +294,7 @@ static srtp_err_status_t srtp_aes_gcm_openssl_set_aad(void *cv,
  */
 static srtp_err_status_t srtp_aes_gcm_openssl_encrypt(void *cv,
                                                       unsigned char *buf,
-                                                      unsigned int *enc_len)
+                                                      size_t *enc_len)
 {
     srtp_aes_gcm_ctx_t *c = (srtp_aes_gcm_ctx_t *)cv;
     if (c->dir != srtp_direction_encrypt && c->dir != srtp_direction_decrypt) {
@@ -321,7 +322,7 @@ static srtp_err_status_t srtp_aes_gcm_openssl_encrypt(void *cv,
  */
 static srtp_err_status_t srtp_aes_gcm_openssl_get_tag(void *cv,
                                                       uint8_t *buf,
-                                                      uint32_t *len)
+                                                      size_t *len)
 {
     srtp_aes_gcm_ctx_t *c = (srtp_aes_gcm_ctx_t *)cv;
     /*
@@ -354,7 +355,7 @@ static srtp_err_status_t srtp_aes_gcm_openssl_get_tag(void *cv,
  */
 static srtp_err_status_t srtp_aes_gcm_openssl_decrypt(void *cv,
                                                       unsigned char *buf,
-                                                      unsigned int *enc_len)
+                                                      size_t *enc_len)
 {
     srtp_aes_gcm_ctx_t *c = (srtp_aes_gcm_ctx_t *)cv;
     if (c->dir != srtp_direction_encrypt && c->dir != srtp_direction_decrypt) {

--- a/crypto/cipher/aes_icm.c
+++ b/crypto/cipher/aes_icm.c
@@ -94,13 +94,13 @@ srtp_debug_module_t srtp_mod_aes_icm = {
  */
 
 static srtp_err_status_t srtp_aes_icm_alloc(srtp_cipher_t **c,
-                                            int key_len,
-                                            int tlen)
+                                            size_t key_len,
+                                            size_t tlen)
 {
     srtp_aes_icm_ctx_t *icm;
     (void)tlen;
 
-    debug_print(srtp_mod_aes_icm, "allocating cipher with key length %d",
+    debug_print(srtp_mod_aes_icm, "allocating cipher with key length %zu",
                 key_len);
 
     /*
@@ -183,7 +183,7 @@ static srtp_err_status_t srtp_aes_icm_context_init(void *cv, const uint8_t *key)
 {
     srtp_aes_icm_ctx_t *c = (srtp_aes_icm_ctx_t *)cv;
     srtp_err_status_t status;
-    int base_key_len, copy_len;
+    size_t base_key_len, copy_len;
 
     if (c->key_size == SRTP_AES_ICM_128_KEY_LEN_WSALT ||
         c->key_size == SRTP_AES_ICM_256_KEY_LEN_WSALT) {
@@ -296,10 +296,10 @@ static void srtp_aes_icm_advance(srtp_aes_icm_ctx_t *c)
 
 static srtp_err_status_t srtp_aes_icm_encrypt(void *cv,
                                               unsigned char *buf,
-                                              unsigned int *enc_len)
+                                              size_t *enc_len)
 {
     srtp_aes_icm_ctx_t *c = (srtp_aes_icm_ctx_t *)cv;
-    unsigned int bytes_to_encr = *enc_len;
+    unsigned int bytes_to_encr = (unsigned int)*enc_len;
     unsigned int i;
     uint32_t *b;
 

--- a/crypto/cipher/aes_icm_mbedtls.c
+++ b/crypto/cipher/aes_icm_mbedtls.c
@@ -114,13 +114,13 @@ srtp_debug_module_t srtp_mod_aes_icm = {
  * isn't used in counter mode.
  */
 static srtp_err_status_t srtp_aes_icm_mbedtls_alloc(srtp_cipher_t **c,
-                                                    int key_len,
-                                                    int tlen)
+                                                    size_t key_len,
+                                                    size_t tlen)
 {
     srtp_aes_icm_ctx_t *icm;
     (void)tlen;
 
-    debug_print(srtp_mod_aes_icm, "allocating cipher with key length %d",
+    debug_print(srtp_mod_aes_icm, "allocating cipher with key length %zu",
                 key_len);
 
     /*
@@ -291,7 +291,7 @@ static srtp_err_status_t srtp_aes_icm_mbedtls_set_iv(
  */
 static srtp_err_status_t srtp_aes_icm_mbedtls_encrypt(void *cv,
                                                       unsigned char *buf,
-                                                      unsigned int *enc_len)
+                                                      size_t *enc_len)
 {
     srtp_aes_icm_ctx_t *c = (srtp_aes_icm_ctx_t *)cv;
 

--- a/crypto/cipher/aes_icm_nss.c
+++ b/crypto/cipher/aes_icm_nss.c
@@ -102,14 +102,14 @@ srtp_debug_module_t srtp_mod_aes_icm = {
  * isn't used in counter mode.
  */
 static srtp_err_status_t srtp_aes_icm_nss_alloc(srtp_cipher_t **c,
-                                                int key_len,
-                                                int tlen)
+                                                size_t key_len,
+                                                size_t tlen)
 {
     srtp_aes_icm_ctx_t *icm;
     NSSInitContext *nss;
     (void)tlen;
 
-    debug_print(srtp_mod_aes_icm, "allocating cipher with key length %d",
+    debug_print(srtp_mod_aes_icm, "allocating cipher with key length %zu",
                 key_len);
 
     /*
@@ -324,7 +324,7 @@ static srtp_err_status_t srtp_aes_icm_nss_set_iv(void *cv,
  */
 static srtp_err_status_t srtp_aes_icm_nss_encrypt(void *cv,
                                                   unsigned char *buf,
-                                                  unsigned int *enc_len)
+                                                  size_t *enc_len)
 {
     srtp_aes_icm_ctx_t *c = (srtp_aes_icm_ctx_t *)cv;
 
@@ -332,9 +332,9 @@ static srtp_err_status_t srtp_aes_icm_nss_encrypt(void *cv,
         return srtp_err_status_bad_param;
     }
 
-    int rv =
-        PK11_CipherOp(c->ctx, buf, (int *)enc_len, *enc_len, buf, *enc_len);
-
+    int out_len = 0;
+    int rv = PK11_CipherOp(c->ctx, buf, &out_len, *enc_len, buf, *enc_len);
+    *enc_len = out_len;
     srtp_err_status_t status = (srtp_err_status_ok);
     if (rv != SECSuccess) {
         status = (srtp_err_status_cipher_fail);

--- a/crypto/cipher/aes_icm_ossl.c
+++ b/crypto/cipher/aes_icm_ossl.c
@@ -108,13 +108,13 @@ srtp_debug_module_t srtp_mod_aes_icm = {
  * isn't used in counter mode.
  */
 static srtp_err_status_t srtp_aes_icm_openssl_alloc(srtp_cipher_t **c,
-                                                    int key_len,
-                                                    int tlen)
+                                                    size_t key_len,
+                                                    size_t tlen)
 {
     srtp_aes_icm_ctx_t *icm;
     (void)tlen;
 
-    debug_print(srtp_mod_aes_icm, "allocating cipher with key length %d",
+    debug_print(srtp_mod_aes_icm, "allocating cipher with key length %zu",
                 key_len);
 
     /*
@@ -299,7 +299,7 @@ static srtp_err_status_t srtp_aes_icm_openssl_set_iv(
  */
 static srtp_err_status_t srtp_aes_icm_openssl_encrypt(void *cv,
                                                       unsigned char *buf,
-                                                      unsigned int *enc_len)
+                                                      size_t *enc_len)
 {
     srtp_aes_icm_ctx_t *c = (srtp_aes_icm_ctx_t *)cv;
     int len = 0;

--- a/crypto/cipher/cipher.c
+++ b/crypto/cipher/cipher.c
@@ -61,8 +61,8 @@ srtp_debug_module_t srtp_mod_cipher = {
 
 srtp_err_status_t srtp_cipher_type_alloc(const srtp_cipher_type_t *ct,
                                          srtp_cipher_t **c,
-                                         int key_len,
-                                         int tlen)
+                                         size_t key_len,
+                                         size_t tlen)
 {
     if (!ct || !ct->alloc) {
         return (srtp_err_status_bad_param);
@@ -99,7 +99,7 @@ srtp_err_status_t srtp_cipher_set_iv(srtp_cipher_t *c,
 
 srtp_err_status_t srtp_cipher_output(srtp_cipher_t *c,
                                      uint8_t *buffer,
-                                     uint32_t *num_octets_to_output)
+                                     size_t *num_octets_to_output)
 {
     /* zeroize the buffer */
     octet_string_set_to_zero(buffer, *num_octets_to_output);
@@ -110,7 +110,7 @@ srtp_err_status_t srtp_cipher_output(srtp_cipher_t *c,
 
 srtp_err_status_t srtp_cipher_encrypt(srtp_cipher_t *c,
                                       uint8_t *buffer,
-                                      uint32_t *num_octets_to_output)
+                                      size_t *num_octets_to_output)
 {
     if (!c || !c->type || !c->state) {
         return (srtp_err_status_bad_param);
@@ -121,7 +121,7 @@ srtp_err_status_t srtp_cipher_encrypt(srtp_cipher_t *c,
 
 srtp_err_status_t srtp_cipher_decrypt(srtp_cipher_t *c,
                                       uint8_t *buffer,
-                                      uint32_t *num_octets_to_output)
+                                      size_t *num_octets_to_output)
 {
     if (!c || !c->type || !c->state) {
         return (srtp_err_status_bad_param);
@@ -132,7 +132,7 @@ srtp_err_status_t srtp_cipher_decrypt(srtp_cipher_t *c,
 
 srtp_err_status_t srtp_cipher_get_tag(srtp_cipher_t *c,
                                       uint8_t *buffer,
-                                      uint32_t *tag_len)
+                                      size_t *tag_len)
 {
     if (!c || !c->type || !c->state) {
         return (srtp_err_status_bad_param);
@@ -146,7 +146,7 @@ srtp_err_status_t srtp_cipher_get_tag(srtp_cipher_t *c,
 
 srtp_err_status_t srtp_cipher_set_aad(srtp_cipher_t *c,
                                       const uint8_t *aad,
-                                      uint32_t aad_len)
+                                      size_t aad_len)
 {
     if (!c || !c->type || !c->state) {
         return (srtp_err_status_bad_param);
@@ -160,7 +160,7 @@ srtp_err_status_t srtp_cipher_set_aad(srtp_cipher_t *c,
 
 /* some bookkeeping functions */
 
-int srtp_cipher_get_key_length(const srtp_cipher_t *c)
+size_t srtp_cipher_get_key_length(const srtp_cipher_t *c)
 {
     return c->key_len;
 }
@@ -169,7 +169,7 @@ int srtp_cipher_get_key_length(const srtp_cipher_t *c)
  * A trivial platform independent random source.
  * For use in test only.
  */
-void srtp_cipher_rand_for_tests(void *dest, uint32_t len)
+void srtp_cipher_rand_for_tests(void *dest, size_t len)
 {
     /* Generic C-library (rand()) version */
     /* This is a random source of last resort */
@@ -212,8 +212,8 @@ srtp_err_status_t srtp_cipher_type_test(
     srtp_err_status_t status;
     uint8_t buffer[SELF_TEST_BUF_OCTETS];
     uint8_t buffer2[SELF_TEST_BUF_OCTETS];
-    uint32_t tag_len;
-    unsigned int len;
+    size_t tag_len;
+    size_t len;
     int i, j, case_num = 0;
     unsigned k = 0;
 
@@ -456,14 +456,14 @@ srtp_err_status_t srtp_cipher_type_test(
     }
 
     for (j = 0; j < NUM_RAND_TESTS; j++) {
-        unsigned int length;
-        unsigned int plaintext_len;
+        size_t length;
+        size_t plaintext_len;
         uint8_t key[MAX_KEY_LEN];
         uint8_t iv[MAX_KEY_LEN];
 
         /* choose a length at random (leaving room for IV and padding) */
         length = srtp_cipher_rand_u32_for_tests() % (SELF_TEST_BUF_OCTETS - 64);
-        debug_print(srtp_mod_cipher, "random plaintext length %d\n", length);
+        debug_print(srtp_mod_cipher, "random plaintext length %zu\n", length);
         srtp_cipher_rand_for_tests(buffer, length);
 
         debug_print(srtp_mod_cipher, "plaintext:    %s",
@@ -624,17 +624,17 @@ srtp_err_status_t srtp_cipher_type_self_test(const srtp_cipher_type_t *ct)
  * if an error is encountered, the value 0 is returned
  */
 uint64_t srtp_cipher_bits_per_second(srtp_cipher_t *c,
-                                     int octets_in_buffer,
+                                     size_t octets_in_buffer,
                                      int num_trials)
 {
     int i;
     v128_t nonce;
     clock_t timer;
     unsigned char *enc_buf;
-    unsigned int len = octets_in_buffer;
-    uint32_t tag_len = SRTP_MAX_TAG_LEN;
+    size_t len = octets_in_buffer;
+    size_t tag_len = SRTP_MAX_TAG_LEN;
     unsigned char aad[4] = { 0, 0, 0, 0 };
-    uint32_t aad_len = 4;
+    size_t aad_len = 4;
 
     enc_buf = (unsigned char *)srtp_crypto_alloc(octets_in_buffer + tag_len);
     if (enc_buf == NULL) {

--- a/crypto/cipher/null_cipher.c
+++ b/crypto/cipher/null_cipher.c
@@ -55,13 +55,13 @@
 #include "cipher_types.h"
 
 static srtp_err_status_t srtp_null_cipher_alloc(srtp_cipher_t **c,
-                                                int key_len,
-                                                int tlen)
+                                                size_t key_len,
+                                                size_t tlen)
 {
     extern const srtp_cipher_type_t srtp_null_cipher;
     (void)tlen;
 
-    debug_print(srtp_mod_cipher, "allocating cipher with key length %d",
+    debug_print(srtp_mod_cipher, "allocating cipher with key length %zu",
                 key_len);
 
     /* allocate memory a cipher of type null_cipher */
@@ -117,7 +117,7 @@ static srtp_err_status_t srtp_null_cipher_set_iv(void *cv,
 
 static srtp_err_status_t srtp_null_cipher_encrypt(void *cv,
                                                   unsigned char *buf,
-                                                  unsigned int *bytes_to_encr)
+                                                  size_t *bytes_to_encr)
 {
     /* srtp_null_cipher_ctx_t *c = (srtp_null_cipher_ctx_t *)cv; */
     (void)cv;

--- a/crypto/hash/auth.c
+++ b/crypto/hash/auth.c
@@ -58,17 +58,17 @@ srtp_debug_module_t srtp_mod_auth = {
     "auth func" /* printable name for module   */
 };
 
-int srtp_auth_get_key_length(const srtp_auth_t *a)
+size_t srtp_auth_get_key_length(const srtp_auth_t *a)
 {
     return a->key_len;
 }
 
-int srtp_auth_get_tag_length(const srtp_auth_t *a)
+size_t srtp_auth_get_tag_length(const srtp_auth_t *a)
 {
     return a->out_len;
 }
 
-int srtp_auth_get_prefix_length(const srtp_auth_t *a)
+size_t srtp_auth_get_prefix_length(const srtp_auth_t *a)
 {
     return a->prefix_len;
 }
@@ -89,7 +89,8 @@ srtp_err_status_t srtp_auth_type_test(const srtp_auth_type_t *at,
     srtp_auth_t *a;
     srtp_err_status_t status;
     uint8_t tag[SELF_TEST_TAG_BUF_OCTETS];
-    int i, case_num = 0;
+    size_t i = 0;
+    unsigned int case_num = 0;
 
     debug_print(srtp_mod_auth, "running self-test for auth function %s",
                 at->description);
@@ -157,7 +158,7 @@ srtp_err_status_t srtp_auth_type_test(const srtp_auth_type_t *at,
             if (tag[i] != test_case->tag[i]) {
                 status = srtp_err_status_algo_fail;
                 debug_print(srtp_mod_auth, "test case %d failed", case_num);
-                debug_print(srtp_mod_auth, "  (mismatch at octet %d)", i);
+                debug_print(srtp_mod_auth, "  (mismatch at octet %zu)", i);
             }
         }
         if (status) {

--- a/crypto/hash/hmac.c
+++ b/crypto/hash/hmac.c
@@ -59,15 +59,15 @@ srtp_debug_module_t srtp_mod_hmac = {
 };
 
 static srtp_err_status_t srtp_hmac_alloc(srtp_auth_t **a,
-                                         int key_len,
-                                         int out_len)
+                                         size_t key_len,
+                                         size_t out_len)
 {
     extern const srtp_auth_type_t srtp_hmac;
     uint8_t *pointer;
 
-    debug_print(srtp_mod_hmac, "allocating auth func with key length %d",
+    debug_print(srtp_mod_hmac, "allocating auth func with key length %zu",
                 key_len);
-    debug_print(srtp_mod_hmac, "                          tag length %d",
+    debug_print(srtp_mod_hmac, "                          tag length %zu",
                 out_len);
 
     /*
@@ -114,10 +114,10 @@ static srtp_err_status_t srtp_hmac_dealloc(srtp_auth_t *a)
 
 static srtp_err_status_t srtp_hmac_init(void *statev,
                                         const uint8_t *key,
-                                        int key_len)
+                                        size_t key_len)
 {
     srtp_hmac_ctx_t *state = (srtp_hmac_ctx_t *)statev;
-    int i;
+    size_t i;
     uint8_t ipad[64];
 
     /*
@@ -166,7 +166,7 @@ static srtp_err_status_t srtp_hmac_start(void *statev)
 
 static srtp_err_status_t srtp_hmac_update(void *statev,
                                           const uint8_t *message,
-                                          int msg_octets)
+                                          size_t msg_octets)
 {
     srtp_hmac_ctx_t *state = (srtp_hmac_ctx_t *)statev;
 
@@ -181,14 +181,14 @@ static srtp_err_status_t srtp_hmac_update(void *statev,
 
 static srtp_err_status_t srtp_hmac_compute(void *statev,
                                            const uint8_t *message,
-                                           int msg_octets,
-                                           int tag_len,
+                                           size_t msg_octets,
+                                           size_t tag_len,
                                            uint8_t *result)
 {
     srtp_hmac_ctx_t *state = (srtp_hmac_ctx_t *)statev;
     uint32_t hash_value[5];
     uint32_t H[5];
-    int i;
+    size_t i;
 
     /* check tag length, return error if we can't provide the value expected */
     if (tag_len > 20) {

--- a/crypto/hash/hmac_mbedtls.c
+++ b/crypto/hash/hmac_mbedtls.c
@@ -61,14 +61,14 @@ srtp_debug_module_t srtp_mod_hmac = {
 };
 
 static srtp_err_status_t srtp_hmac_mbedtls_alloc(srtp_auth_t **a,
-                                                 int key_len,
-                                                 int out_len)
+                                                 size_t key_len,
+                                                 size_t out_len)
 {
     extern const srtp_auth_type_t srtp_hmac;
 
-    debug_print(srtp_mod_hmac, "allocating auth func with key length %d",
+    debug_print(srtp_mod_hmac, "allocating auth func with key length %zu",
                 key_len);
-    debug_print(srtp_mod_hmac, "                          tag length %d",
+    debug_print(srtp_mod_hmac, "                          tag length %zu",
                 out_len);
 
     /* check output length - should be less than 20 bytes */
@@ -124,7 +124,7 @@ static srtp_err_status_t srtp_hmac_mbedtls_start(void *statev)
 
 static srtp_err_status_t srtp_hmac_mbedtls_init(void *statev,
                                                 const uint8_t *key,
-                                                int key_len)
+                                                size_t key_len)
 {
     mbedtls_md_context_t *state = (mbedtls_md_context_t *)statev;
     const mbedtls_md_info_t *info = NULL;
@@ -149,7 +149,7 @@ static srtp_err_status_t srtp_hmac_mbedtls_init(void *statev,
 
 static srtp_err_status_t srtp_hmac_mbedtls_update(void *statev,
                                                   const uint8_t *message,
-                                                  int msg_octets)
+                                                  size_t msg_octets)
 {
     mbedtls_md_context_t *state = (mbedtls_md_context_t *)statev;
 
@@ -164,13 +164,13 @@ static srtp_err_status_t srtp_hmac_mbedtls_update(void *statev,
 
 static srtp_err_status_t srtp_hmac_mbedtls_compute(void *statev,
                                                    const uint8_t *message,
-                                                   int msg_octets,
-                                                   int tag_len,
+                                                   size_t msg_octets,
+                                                   size_t tag_len,
                                                    uint8_t *result)
 {
     mbedtls_md_context_t *state = (mbedtls_md_context_t *)statev;
     uint8_t hash_value[SHA1_DIGEST_SIZE];
-    int i;
+    size_t i;
 
     /* check tag length, return error if we can't provide the value expected */
     if (tag_len > SHA1_DIGEST_SIZE) {

--- a/crypto/hash/hmac_nss.c
+++ b/crypto/hash/hmac_nss.c
@@ -64,16 +64,16 @@ typedef struct {
 } srtp_hmac_nss_ctx_t;
 
 static srtp_err_status_t srtp_hmac_alloc(srtp_auth_t **a,
-                                         int key_len,
-                                         int out_len)
+                                         size_t key_len,
+                                         size_t out_len)
 {
     extern const srtp_auth_type_t srtp_hmac;
     srtp_hmac_nss_ctx_t *hmac;
     NSSInitContext *nss;
 
-    debug_print(srtp_mod_hmac, "allocating auth func with key length %d",
+    debug_print(srtp_mod_hmac, "allocating auth func with key length %zu",
                 key_len);
-    debug_print(srtp_mod_hmac, "                          tag length %d",
+    debug_print(srtp_mod_hmac, "                          tag length %zu",
                 out_len);
 
     /* check output length - should be less than 20 bytes */
@@ -165,7 +165,7 @@ static srtp_err_status_t srtp_hmac_start(void *statev)
 
 static srtp_err_status_t srtp_hmac_init(void *statev,
                                         const uint8_t *key,
-                                        int key_len)
+                                        size_t key_len)
 {
     srtp_hmac_nss_ctx_t *hmac;
     hmac = (srtp_hmac_nss_ctx_t *)statev;
@@ -213,7 +213,7 @@ static srtp_err_status_t srtp_hmac_init(void *statev,
 
 static srtp_err_status_t srtp_hmac_update(void *statev,
                                           const uint8_t *message,
-                                          int msg_octets)
+                                          size_t msg_octets)
 {
     srtp_hmac_nss_ctx_t *hmac;
     hmac = (srtp_hmac_nss_ctx_t *)statev;
@@ -230,14 +230,14 @@ static srtp_err_status_t srtp_hmac_update(void *statev,
 
 static srtp_err_status_t srtp_hmac_compute(void *statev,
                                            const uint8_t *message,
-                                           int msg_octets,
-                                           int tag_len,
+                                           size_t msg_octets,
+                                           size_t tag_len,
                                            uint8_t *result)
 {
     srtp_hmac_nss_ctx_t *hmac;
     hmac = (srtp_hmac_nss_ctx_t *)statev;
     uint8_t hash_value[SHA1_DIGEST_SIZE];
-    int i;
+    size_t i;
     unsigned int len;
 
     debug_print(srtp_mod_hmac, "input: %s",
@@ -257,7 +257,7 @@ static srtp_err_status_t srtp_hmac_compute(void *statev,
         return srtp_err_status_auth_fail;
     }
 
-    if (tag_len < 0 || len < (unsigned int)tag_len)
+    if (len < (unsigned int)tag_len)
         return srtp_err_status_auth_fail;
 
     /* copy hash_value to *result */

--- a/crypto/hash/hmac_ossl.c
+++ b/crypto/hash/hmac_ossl.c
@@ -97,15 +97,15 @@ typedef struct {
 } srtp_hmac_ossl_ctx_t;
 
 static srtp_err_status_t srtp_hmac_alloc(srtp_auth_t **a,
-                                         int key_len,
-                                         int out_len)
+                                         size_t key_len,
+                                         size_t out_len)
 {
     extern const srtp_auth_type_t srtp_hmac;
     srtp_hmac_ossl_ctx_t *hmac;
 
-    debug_print(srtp_mod_hmac, "allocating auth func with key length %d",
+    debug_print(srtp_mod_hmac, "allocating auth func with key length %zu",
                 key_len);
-    debug_print(srtp_mod_hmac, "                          tag length %d",
+    debug_print(srtp_mod_hmac, "                          tag length %zu",
                 out_len);
 
     /* check output length - should be less than 20 bytes */
@@ -224,7 +224,7 @@ static srtp_err_status_t srtp_hmac_start(void *statev)
 
 static srtp_err_status_t srtp_hmac_init(void *statev,
                                         const uint8_t *key,
-                                        int key_len)
+                                        size_t key_len)
 {
     srtp_hmac_ossl_ctx_t *hmac = (srtp_hmac_ossl_ctx_t *)statev;
 
@@ -247,7 +247,7 @@ static srtp_err_status_t srtp_hmac_init(void *statev,
 
 static srtp_err_status_t srtp_hmac_update(void *statev,
                                           const uint8_t *message,
-                                          int msg_octets)
+                                          size_t msg_octets)
 {
     srtp_hmac_ossl_ctx_t *hmac = (srtp_hmac_ossl_ctx_t *)statev;
 
@@ -267,13 +267,13 @@ static srtp_err_status_t srtp_hmac_update(void *statev,
 
 static srtp_err_status_t srtp_hmac_compute(void *statev,
                                            const uint8_t *message,
-                                           int msg_octets,
-                                           int tag_len,
+                                           size_t msg_octets,
+                                           size_t tag_len,
                                            uint8_t *result)
 {
     srtp_hmac_ossl_ctx_t *hmac = (srtp_hmac_ossl_ctx_t *)statev;
     uint8_t hash_value[SHA1_DIGEST_SIZE];
-    int i;
+    size_t i;
 #ifdef SRTP_OSSL_USE_EVP_MAC
     size_t len;
 #else
@@ -304,7 +304,7 @@ static srtp_err_status_t srtp_hmac_compute(void *statev,
     if (HMAC_Final(hmac->ctx, hash_value, &len) == 0)
         return srtp_err_status_auth_fail;
 #endif
-    if (tag_len < 0 || len < (unsigned int)tag_len)
+    if (len < tag_len)
         return srtp_err_status_auth_fail;
 
     /* copy hash_value to *result */

--- a/crypto/hash/null_auth.c
+++ b/crypto/hash/null_auth.c
@@ -54,15 +54,15 @@
 #include "cipher_types.h"
 
 static srtp_err_status_t srtp_null_auth_alloc(srtp_auth_t **a,
-                                              int key_len,
-                                              int out_len)
+                                              size_t key_len,
+                                              size_t out_len)
 {
     extern const srtp_auth_type_t srtp_null_auth;
     uint8_t *pointer;
 
-    debug_print(srtp_mod_auth, "allocating auth func with key length %d",
+    debug_print(srtp_mod_auth, "allocating auth func with key length %zu",
                 key_len);
-    debug_print(srtp_mod_auth, "                          tag length %d",
+    debug_print(srtp_mod_auth, "                          tag length %zu",
                 out_len);
 
     /* allocate memory for auth and srtp_null_auth_ctx_t structures */
@@ -99,7 +99,7 @@ static srtp_err_status_t srtp_null_auth_dealloc(srtp_auth_t *a)
 
 static srtp_err_status_t srtp_null_auth_init(void *statev,
                                              const uint8_t *key,
-                                             int key_len)
+                                             size_t key_len)
 {
     /* srtp_null_auth_ctx_t *state = (srtp_null_auth_ctx_t *)statev; */
     (void)statev;
@@ -113,8 +113,8 @@ static srtp_err_status_t srtp_null_auth_init(void *statev,
 
 static srtp_err_status_t srtp_null_auth_compute(void *statev,
                                                 const uint8_t *message,
-                                                int msg_octets,
-                                                int tag_len,
+                                                size_t msg_octets,
+                                                size_t tag_len,
                                                 uint8_t *result)
 {
     /* srtp_null_auth_ctx_t *state = (srtp_null_auth_ctx_t *)statev; */
@@ -129,7 +129,7 @@ static srtp_err_status_t srtp_null_auth_compute(void *statev,
 
 static srtp_err_status_t srtp_null_auth_update(void *statev,
                                                const uint8_t *message,
-                                               int msg_octets)
+                                               size_t msg_octets)
 {
     /* srtp_null_auth_ctx_t *state = (srtp_null_auth_ctx_t *)statev; */
     (void)statev;

--- a/crypto/hash/sha1.c
+++ b/crypto/hash/sha1.c
@@ -229,13 +229,13 @@ void srtp_sha1_init(srtp_sha1_ctx_t *ctx)
 
 void srtp_sha1_update(srtp_sha1_ctx_t *ctx,
                       const uint8_t *msg,
-                      int octets_in_msg)
+                      size_t octets_in_msg)
 {
-    int i;
+    size_t i;
     uint8_t *buf = (uint8_t *)ctx->M;
 
     /* update message bit-count */
-    ctx->num_bits_in_msg += octets_in_msg * 8;
+    ctx->num_bits_in_msg += (uint32_t)octets_in_msg * 8;
 
     /* loop over 16-word blocks of M */
     while (octets_in_msg > 0) {
@@ -279,7 +279,7 @@ void srtp_sha1_final(srtp_sha1_ctx_t *ctx, uint32_t output[5])
 {
     uint32_t A, B, C, D, E, TEMP;
     uint32_t W[80];
-    int i, t;
+    size_t i, t;
 
     /*
      * process the remaining octets_in_buffer, padding and terminating as

--- a/crypto/include/aes.h
+++ b/crypto/include/aes.h
@@ -62,12 +62,12 @@ typedef struct {
 
 srtp_err_status_t srtp_aes_expand_encryption_key(
     const uint8_t *key,
-    int key_len,
+    size_t key_len,
     srtp_aes_expanded_key_t *expanded_key);
 
 srtp_err_status_t srtp_aes_expand_decryption_key(
     const uint8_t *key,
-    int key_len,
+    size_t key_len,
     srtp_aes_expanded_key_t *expanded_key);
 
 void srtp_aes_encrypt(v128_t *plaintext,

--- a/crypto/include/aes_gcm.h
+++ b/crypto/include/aes_gcm.h
@@ -56,8 +56,8 @@
 #include <openssl/aes.h>
 
 typedef struct {
-    int key_size;
-    int tag_len;
+    size_t key_size;
+    size_t tag_len;
     EVP_CIPHER_CTX *ctx;
     srtp_cipher_direction_t dir;
 } srtp_aes_gcm_ctx_t;
@@ -70,10 +70,10 @@ typedef struct {
 #include <mbedtls/gcm.h>
 
 typedef struct {
-    int key_size;
-    int tag_len;
-    int aad_size;
-    int iv_len;
+    size_t key_size;
+    size_t tag_len;
+    size_t aad_size;
+    size_t iv_len;
     uint8_t iv[12];
     uint8_t tag[16];
     uint8_t aad[MAX_AD_SIZE];
@@ -93,14 +93,14 @@ typedef struct {
 #define MAX_AD_SIZE 2048
 
 typedef struct {
-    int key_size;
-    int tag_size;
+    size_t key_size;
+    size_t tag_size;
     srtp_cipher_direction_t dir;
     NSSInitContext *nss;
     PK11SymKey *key;
     uint8_t iv[12];
     uint8_t aad[MAX_AD_SIZE];
-    int aad_size;
+    size_t aad_size;
     CK_GCM_PARAMS params;
     uint8_t tag[16];
 } srtp_aes_gcm_ctx_t;

--- a/crypto/include/aes_icm.h
+++ b/crypto/include/aes_icm.h
@@ -56,7 +56,7 @@ typedef struct {
     v128_t keystream_buffer;              /* buffers bytes of keystream       */
     srtp_aes_expanded_key_t expanded_key; /* the cipher key                   */
     int bytes_in_buffer;                  /* number of unused bytes in buffer */
-    int key_size;                         /* AES key size + 14 byte SALT */
+    size_t key_size;                      /* AES key size + 14 byte SALT */
 } srtp_aes_icm_ctx_t;
 
 #endif /* AES_ICM_H */

--- a/crypto/include/aes_icm_ext.h
+++ b/crypto/include/aes_icm_ext.h
@@ -57,7 +57,7 @@
 typedef struct {
     v128_t counter; /* holds the counter value          */
     v128_t offset;  /* initial offset value             */
-    int key_size;
+    size_t key_size;
     EVP_CIPHER_CTX *ctx;
 } srtp_aes_icm_ctx_t;
 
@@ -71,7 +71,7 @@ typedef struct {
     v128_t offset;  /* initial offset value             */
     v128_t stream_block;
     size_t nc_off;
-    int key_size;
+    size_t key_size;
     mbedtls_aes_context *ctx;
 } srtp_aes_icm_ctx_t;
 
@@ -87,7 +87,7 @@ typedef struct {
 typedef struct {
     v128_t counter;
     v128_t offset;
-    int key_size;
+    size_t key_size;
     uint8_t iv[16];
     NSSInitContext *nss;
     PK11SymKey *key;

--- a/crypto/include/auth.h
+++ b/crypto/include/auth.h
@@ -57,24 +57,24 @@ typedef const struct srtp_auth_type_t *srtp_auth_type_pointer;
 typedef struct srtp_auth_t *srtp_auth_pointer_t;
 
 typedef srtp_err_status_t (*srtp_auth_alloc_func)(srtp_auth_pointer_t *ap,
-                                                  int key_len,
-                                                  int out_len);
+                                                  size_t key_len,
+                                                  size_t out_len);
 
 typedef srtp_err_status_t (*srtp_auth_init_func)(void *state,
                                                  const uint8_t *key,
-                                                 int key_len);
+                                                 size_t key_len);
 
 typedef srtp_err_status_t (*srtp_auth_dealloc_func)(srtp_auth_pointer_t ap);
 
 typedef srtp_err_status_t (*srtp_auth_compute_func)(void *state,
                                                     const uint8_t *buffer,
-                                                    int octets_to_auth,
-                                                    int tag_len,
+                                                    size_t octets_to_auth,
+                                                    size_t tag_len,
                                                     uint8_t *tag);
 
 typedef srtp_err_status_t (*srtp_auth_update_func)(void *state,
                                                    const uint8_t *buffer,
-                                                   int octets_to_auth);
+                                                   size_t octets_to_auth);
 
 typedef srtp_err_status_t (*srtp_auth_start_func)(void *state);
 
@@ -96,11 +96,11 @@ typedef srtp_err_status_t (*srtp_auth_start_func)(void *state);
 #define srtp_auth_dealloc(c) (((c)->type)->dealloc(c))
 
 /* functions to get information about a particular auth_t */
-int srtp_auth_get_key_length(const struct srtp_auth_t *a);
+size_t srtp_auth_get_key_length(const struct srtp_auth_t *a);
 
-int srtp_auth_get_tag_length(const struct srtp_auth_t *a);
+size_t srtp_auth_get_tag_length(const struct srtp_auth_t *a);
 
-int srtp_auth_get_prefix_length(const struct srtp_auth_t *a);
+size_t srtp_auth_get_prefix_length(const struct srtp_auth_t *a);
 
 /*
  * srtp_auth_test_case_t is a (list of) key/message/tag values that are
@@ -110,12 +110,12 @@ int srtp_auth_get_prefix_length(const struct srtp_auth_t *a);
  * function below)
  */
 typedef struct srtp_auth_test_case_t {
-    int key_length_octets;  /* octets in key            */
-    const uint8_t *key;     /* key                      */
-    int data_length_octets; /* octets in data           */
-    const uint8_t *data;    /* data                     */
-    int tag_length_octets;  /* octets in tag            */
-    const uint8_t *tag;     /* tag                      */
+    size_t key_length_octets;  /* octets in key            */
+    const uint8_t *key;        /* key                      */
+    size_t data_length_octets; /* octets in data           */
+    const uint8_t *data;       /* data                     */
+    size_t tag_length_octets;  /* octets in tag            */
+    const uint8_t *tag;        /* tag                      */
     const struct srtp_auth_test_case_t
         *next_test_case; /* pointer to next testcase */
 } srtp_auth_test_case_t;
@@ -136,9 +136,9 @@ typedef struct srtp_auth_type_t {
 typedef struct srtp_auth_t {
     const srtp_auth_type_t *type;
     void *state;
-    int out_len;    /* length of output tag in octets */
-    int key_len;    /* length of key in octets        */
-    int prefix_len; /* length of keystream prefix     */
+    size_t out_len;    /* length of output tag in octets */
+    size_t key_len;    /* length of key in octets        */
+    size_t prefix_len; /* length of keystream prefix     */
 } srtp_auth_t;
 
 /*

--- a/crypto/include/cipher.h
+++ b/crypto/include/cipher.h
@@ -76,8 +76,8 @@ typedef struct srtp_cipher_t *srtp_cipher_pointer_t;
  * srtp_cipher_t
  */
 typedef srtp_err_status_t (*srtp_cipher_alloc_func_t)(srtp_cipher_pointer_t *cp,
-                                                      int key_len,
-                                                      int tag_len);
+                                                      size_t key_len,
+                                                      size_t tag_len);
 
 /*
  * a srtp_cipher_init_func_t [re-]initializes a cipher_t with a given key
@@ -94,19 +94,19 @@ typedef srtp_err_status_t (*srtp_cipher_dealloc_func_t)(
  */
 typedef srtp_err_status_t (*srtp_cipher_set_aad_func_t)(void *state,
                                                         const uint8_t *aad,
-                                                        uint32_t aad_len);
+                                                        size_t aad_len);
 
 /* a srtp_cipher_encrypt_func_t encrypts data in-place */
 typedef srtp_err_status_t (*srtp_cipher_encrypt_func_t)(
     void *state,
     uint8_t *buffer,
-    unsigned int *octets_to_encrypt);
+    size_t *octets_to_encrypt);
 
 /* a srtp_cipher_decrypt_func_t decrypts data in-place */
 typedef srtp_err_status_t (*srtp_cipher_decrypt_func_t)(
     void *state,
     uint8_t *buffer,
-    unsigned int *octets_to_decrypt);
+    size_t *octets_to_decrypt);
 
 /*
  * a srtp_cipher_set_iv_func_t function sets the current initialization vector
@@ -122,7 +122,7 @@ typedef srtp_err_status_t (*srtp_cipher_set_iv_func_t)(
  */
 typedef srtp_err_status_t (*srtp_cipher_get_tag_func_t)(void *state,
                                                         uint8_t *tag,
-                                                        uint32_t *len);
+                                                        size_t *len);
 
 /*
  * srtp_cipher_test_case_t is a (list of) key, salt, plaintext, ciphertext,
@@ -132,16 +132,16 @@ typedef srtp_err_status_t (*srtp_cipher_get_tag_func_t)(void *state,
  * (see the srtp_cipher_type_self_test() function below)
  */
 typedef struct srtp_cipher_test_case_t {
-    int key_length_octets;                 /* octets in key            */
-    const uint8_t *key;                    /* key                      */
-    uint8_t *idx;                          /* packet index             */
-    unsigned int plaintext_length_octets;  /* octets in plaintext      */
-    const uint8_t *plaintext;              /* plaintext                */
-    unsigned int ciphertext_length_octets; /* octets in plaintext      */
-    const uint8_t *ciphertext;             /* ciphertext               */
-    int aad_length_octets;                 /* octets in AAD            */
-    const uint8_t *aad;                    /* AAD                      */
-    int tag_length_octets;                 /* Length of AEAD tag       */
+    size_t key_length_octets;        /* octets in key            */
+    const uint8_t *key;              /* key                      */
+    uint8_t *idx;                    /* packet index             */
+    size_t plaintext_length_octets;  /* octets in plaintext      */
+    const uint8_t *plaintext;        /* plaintext                */
+    size_t ciphertext_length_octets; /* octets in plaintext      */
+    const uint8_t *ciphertext;       /* ciphertext               */
+    size_t aad_length_octets;        /* octets in AAD            */
+    const uint8_t *aad;              /* AAD                      */
+    size_t tag_length_octets;        /* Length of AEAD tag       */
     const struct srtp_cipher_test_case_t
         *next_test_case; /* pointer to next testcase */
 } srtp_cipher_test_case_t;
@@ -168,12 +168,12 @@ typedef struct srtp_cipher_type_t {
 typedef struct srtp_cipher_t {
     const srtp_cipher_type_t *type;
     void *state;
-    int key_len;
+    size_t key_len;
     int algorithm;
 } srtp_cipher_t;
 
 /* some bookkeeping functions */
-int srtp_cipher_get_key_length(const srtp_cipher_t *c);
+size_t srtp_cipher_get_key_length(const srtp_cipher_t *c);
 
 /*
  * srtp_cipher_type_self_test() tests a cipher against test cases provided in
@@ -203,13 +203,13 @@ srtp_err_status_t srtp_cipher_type_test(
  * if an error is encountered, then the value 0 is returned
  */
 uint64_t srtp_cipher_bits_per_second(srtp_cipher_t *c,
-                                     int octets_in_buffer,
+                                     size_t octets_in_buffer,
                                      int num_trials);
 
 srtp_err_status_t srtp_cipher_type_alloc(const srtp_cipher_type_t *ct,
                                          srtp_cipher_t **c,
-                                         int key_len,
-                                         int tlen);
+                                         size_t key_len,
+                                         size_t tlen);
 srtp_err_status_t srtp_cipher_dealloc(srtp_cipher_t *c);
 srtp_err_status_t srtp_cipher_init(srtp_cipher_t *c, const uint8_t *key);
 srtp_err_status_t srtp_cipher_set_iv(srtp_cipher_t *c,
@@ -217,19 +217,19 @@ srtp_err_status_t srtp_cipher_set_iv(srtp_cipher_t *c,
                                      int direction);
 srtp_err_status_t srtp_cipher_output(srtp_cipher_t *c,
                                      uint8_t *buffer,
-                                     uint32_t *num_octets_to_output);
+                                     size_t *num_octets_to_output);
 srtp_err_status_t srtp_cipher_encrypt(srtp_cipher_t *c,
                                       uint8_t *buffer,
-                                      uint32_t *num_octets_to_output);
+                                      size_t *num_octets_to_output);
 srtp_err_status_t srtp_cipher_decrypt(srtp_cipher_t *c,
                                       uint8_t *buffer,
-                                      uint32_t *num_octets_to_output);
+                                      size_t *num_octets_to_output);
 srtp_err_status_t srtp_cipher_get_tag(srtp_cipher_t *c,
                                       uint8_t *buffer,
-                                      uint32_t *tag_len);
+                                      size_t *tag_len);
 srtp_err_status_t srtp_cipher_set_aad(srtp_cipher_t *c,
                                       const uint8_t *aad,
-                                      uint32_t aad_len);
+                                      size_t aad_len);
 
 /*
  * srtp_replace_cipher_type(ct, id)

--- a/crypto/include/cipher_priv.h
+++ b/crypto/include/cipher_priv.h
@@ -47,7 +47,7 @@ extern "C" {
  * A trivial platform independent random source.
  * For use in test only.
  */
-void srtp_cipher_rand_for_tests(void *dest, uint32_t len);
+void srtp_cipher_rand_for_tests(void *dest, size_t len);
 
 /*
  * A trivial platform independent 32 bit random number.

--- a/crypto/include/crypto_kernel.h
+++ b/crypto/include/crypto_kernel.h
@@ -178,8 +178,8 @@ srtp_err_status_t srtp_crypto_kernel_load_debug_module(
  */
 srtp_err_status_t srtp_crypto_kernel_alloc_cipher(srtp_cipher_type_id_t id,
                                                   srtp_cipher_pointer_t *cp,
-                                                  int key_len,
-                                                  int tag_len);
+                                                  size_t key_len,
+                                                  size_t tag_len);
 
 /*
  * srtp_crypto_kernel_alloc_auth(id, ap, key_len, tag_len);
@@ -194,8 +194,8 @@ srtp_err_status_t srtp_crypto_kernel_alloc_cipher(srtp_cipher_type_id_t id,
  */
 srtp_err_status_t srtp_crypto_kernel_alloc_auth(srtp_auth_type_id_t id,
                                                 srtp_auth_pointer_t *ap,
-                                                int key_len,
-                                                int tag_len);
+                                                size_t key_len,
+                                                size_t tag_len);
 
 /*
  * srtp_crypto_kernel_set_debug_module(mod_name, v)

--- a/crypto/include/datatypes.h
+++ b/crypto/include/datatypes.h
@@ -79,7 +79,7 @@ typedef union {
 
 #define MAX_PRINT_STRING_LEN 1024
 
-char *srtp_octet_string_hex_string(const void *str, int length);
+char *srtp_octet_string_hex_string(const void *str, size_t length);
 
 char *v128_bit_string(v128_t *x);
 
@@ -163,7 +163,7 @@ void v128_left_shift(v128_t *x, int shift_index);
  * verifying authentication tags.
  */
 
-int srtp_octet_string_is_eq(const uint8_t *a, const uint8_t *b, int len);
+int srtp_octet_string_is_eq(const uint8_t *a, const uint8_t *b, size_t len);
 
 /*
  * A portable way to zero out memory as recommended by

--- a/crypto/include/sha1.h
+++ b/crypto/include/sha1.h
@@ -61,7 +61,7 @@ extern "C" {
 typedef struct {
     uint32_t H[5];            /* state vector                    */
     uint32_t M[16];           /* message buffer                  */
-    int octets_in_buffer;     /* octets of message in buffer     */
+    size_t octets_in_buffer;  /* octets of message in buffer     */
     uint32_t num_bits_in_msg; /* total number of bits in message */
 } srtp_sha1_ctx_t;
 
@@ -79,7 +79,7 @@ void srtp_sha1_init(srtp_sha1_ctx_t *ctx);
 
 void srtp_sha1_update(srtp_sha1_ctx_t *ctx,
                       const uint8_t *M,
-                      int octets_in_msg);
+                      size_t octets_in_msg);
 
 void srtp_sha1_final(srtp_sha1_ctx_t *ctx, uint32_t output[5]);
 

--- a/crypto/kernel/crypto_kernel.c
+++ b/crypto/kernel/crypto_kernel.c
@@ -443,8 +443,8 @@ const srtp_cipher_type_t *srtp_crypto_kernel_get_cipher_type(
 
 srtp_err_status_t srtp_crypto_kernel_alloc_cipher(srtp_cipher_type_id_t id,
                                                   srtp_cipher_pointer_t *cp,
-                                                  int key_len,
-                                                  int tag_len)
+                                                  size_t key_len,
+                                                  size_t tag_len)
 {
     const srtp_cipher_type_t *ct;
 
@@ -483,8 +483,8 @@ const srtp_auth_type_t *srtp_crypto_kernel_get_auth_type(srtp_auth_type_id_t id)
 
 srtp_err_status_t srtp_crypto_kernel_alloc_auth(srtp_auth_type_id_t id,
                                                 srtp_auth_pointer_t *ap,
-                                                int key_len,
-                                                int tag_len)
+                                                size_t key_len,
+                                                size_t tag_len)
 {
     const srtp_auth_type_t *at;
 

--- a/crypto/math/datatypes.c
+++ b/crypto/math/datatypes.c
@@ -79,10 +79,10 @@ static uint8_t srtp_nibble_to_hex_char(uint8_t nibble)
     return buf[nibble & 0xF];
 }
 
-char *srtp_octet_string_hex_string(const void *s, int length)
+char *srtp_octet_string_hex_string(const void *s, size_t length)
 {
     const uint8_t *str = (const uint8_t *)s;
-    int i;
+    size_t i;
 
     /* double length, since one octet takes two hex characters */
     length *= 2;
@@ -397,7 +397,7 @@ void bitvector_left_shift(bitvector_t *x, int shift)
 
 #endif /* defined(__SSSE3__) */
 
-int srtp_octet_string_is_eq(const uint8_t *a, const uint8_t *b, int len)
+int srtp_octet_string_is_eq(const uint8_t *a, const uint8_t *b, size_t len)
 {
     /*
      * We use this somewhat obscure implementation to try to ensure the running
@@ -410,7 +410,7 @@ int srtp_octet_string_is_eq(const uint8_t *a, const uint8_t *b, int len)
 #if defined(__SSE2__)
     __m128i mm_accumulator1 = _mm_setzero_si128();
     __m128i mm_accumulator2 = _mm_setzero_si128();
-    for (int i = 0, n = len >> 5; i < n; ++i, a += 32, b += 32) {
+    for (size_t i = 0, n = len >> 5; i < n; ++i, a += 32, b += 32) {
         __m128i mm_a1 = _mm_loadu_si128((const __m128i *)a);
         __m128i mm_b1 = _mm_loadu_si128((const __m128i *)b);
         __m128i mm_a2 = _mm_loadu_si128((const __m128i *)(a + 16));

--- a/crypto/test/aes_calc.c
+++ b/crypto/test/aes_calc.c
@@ -80,7 +80,7 @@ int main(int argc, char *argv[])
     v128_t data;
     uint8_t key[AES_MAX_KEY_LEN];
     srtp_aes_expanded_key_t exp_key;
-    int key_len, len;
+    size_t key_len, len;
     int verbose = 0;
     srtp_err_status_t status;
 
@@ -117,7 +117,7 @@ int main(int argc, char *argv[])
     if (len != 32 && len != 48 && len != 64) {
         fprintf(stderr,
                 "error: bad number of digits in key "
-                "(should be 32/48/64 hexadecimal digits, found %d)\n",
+                "(should be 32/48/64 hexadecimal digits, found %zu)\n",
                 len);
         exit(1);
     }
@@ -136,7 +136,7 @@ int main(int argc, char *argv[])
     if (len < 16 * 2) {
         fprintf(stderr,
                 "error: too few digits in plaintext "
-                "(should be %d hexadecimal digits, found %d)\n",
+                "(should be %d hexadecimal digits, found %zu)\n",
                 16 * 2, len);
         exit(1);
     }

--- a/crypto/test/cipher_driver.c
+++ b/crypto/test/cipher_driver.c
@@ -318,7 +318,7 @@ void cipher_driver_test_throughput(srtp_cipher_t *c)
     int max_enc_len = 2048; /* should be a power of two */
     int num_trials = 1000000;
 
-    printf("timing %s throughput, key length %d:\n", c->type->description,
+    printf("timing %s throughput, key length %zu:\n", c->type->description,
            c->key_len);
     fflush(stdout);
     for (i = min_enc_len; i <= max_enc_len; i = i * 2)
@@ -350,8 +350,9 @@ srtp_err_status_t cipher_driver_self_test(srtp_cipher_type_t *ct)
 #define INITIAL_BUFLEN 1024
 srtp_err_status_t cipher_driver_test_buffering(srtp_cipher_t *c)
 {
-    int i, j, num_trials = 1000;
-    unsigned len, buflen = INITIAL_BUFLEN;
+    int i, num_trials = 1000;
+    size_t j;
+    size_t len, buflen = INITIAL_BUFLEN;
     uint8_t buffer0[INITIAL_BUFLEN], buffer1[INITIAL_BUFLEN], *current, *end;
     uint8_t idx[16] = { 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
                         0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x12, 0x34 };
@@ -361,7 +362,7 @@ srtp_err_status_t cipher_driver_test_buffering(srtp_cipher_t *c)
 
     for (i = 0; i < num_trials; i++) {
         /* set buffers to zero */
-        for (j = 0; j < (int)buflen; j++) {
+        for (j = 0; j < buflen; j++) {
             buffer0[j] = buffer1[j] = 0;
         }
 
@@ -389,7 +390,7 @@ srtp_err_status_t cipher_driver_test_buffering(srtp_cipher_t *c)
 
             /* make sure that len doesn't cause us to overreach the buffer */
             if (current + len > end)
-                len = (unsigned)(end - current);
+                len = end - current;
 
             status = srtp_cipher_encrypt(c, current, &len);
             if (status)
@@ -404,10 +405,10 @@ srtp_err_status_t cipher_driver_test_buffering(srtp_cipher_t *c)
         }
 
         /* compare buffers */
-        for (j = 0; j < (int)buflen; j++) {
+        for (j = 0; j < buflen; j++) {
             if (buffer0[j] != buffer1[j]) {
 #if PRINT_DEBUG
-                printf("test case %d failed at byte %d\n", i, j);
+                printf("test case %d failed at byte %zu\n", i, j);
                 printf("computed: %s\n",
                        octet_string_hex_string(buffer1, buflen));
                 printf("expected: %s\n",
@@ -539,7 +540,7 @@ uint64_t cipher_array_bits_per_second(srtp_cipher_t *cipher_array[],
         /* length parameter to srtp_cipher_encrypt is in/out -- out is total,
          * padded
          * length -- so reset it each time. */
-        unsigned octets_to_encrypt = octets_in_buffer;
+        size_t octets_to_encrypt = octets_in_buffer;
 
         /* encrypt buffer with cipher */
         srtp_cipher_set_iv(cipher_array[cipher_index], (uint8_t *)&nonce,
@@ -569,7 +570,7 @@ void cipher_array_test_throughput(srtp_cipher_t *ca[], int num_cipher)
     int max_enc_len = 2048; /* should be a power of two */
     int num_trials = 1000000;
 
-    printf("timing %s throughput with key length %d, array size %d:\n",
+    printf("timing %s throughput with key length %zu, array size %d:\n",
            (ca[0])->type->description, (ca[0])->key_len, num_cipher);
     fflush(stdout);
     for (i = min_enc_len; i <= max_enc_len; i = i * 4)

--- a/crypto/test/datatypes_driver.c
+++ b/crypto/test/datatypes_driver.c
@@ -153,15 +153,15 @@ void test_hex_string_funcs(void)
     char hex1[] = "abadcafe";
     char hex2[] = "0123456789abcdefqqqqq";
     char raw[10];
-    int len;
+    size_t len;
 
-    len = hex_string_to_octet_string(raw, hex1, (int)strlen(hex1));
-    printf("computed length: %d\tstring: %s\n", len,
+    len = hex_string_to_octet_string(raw, hex1, strlen(hex1));
+    printf("computed length: %zu\tstring: %s\n", len,
            octet_string_hex_string(raw, len / 2));
-    printf("expected length: %u\tstring: %s\n", (unsigned)strlen(hex1), hex1);
+    printf("expected length: %zu\tstring: %s\n", strlen(hex1), hex1);
 
-    len = hex_string_to_octet_string(raw, hex2, (int)strlen(hex2));
-    printf("computed length: %d\tstring: %s\n", len,
+    len = hex_string_to_octet_string(raw, hex2, strlen(hex2));
+    printf("computed length: %zu\tstring: %s\n", len,
            octet_string_hex_string(raw, len / 2));
     printf("expected length: %d\tstring: %s\n", 16, "0123456789abcdef");
 }

--- a/crypto/test/sha1_driver.c
+++ b/crypto/test/sha1_driver.c
@@ -76,7 +76,7 @@ srtp_err_status_t hash_test_case_add(hash_test_case_t **list_ptr,
 {
     hash_test_case_t *list_head = *list_ptr;
     hash_test_case_t *test_case;
-    unsigned tmp_len;
+    size_t tmp_len;
 
     test_case = malloc(sizeof(hash_test_case_t));
     if (test_case == NULL)

--- a/fuzzer/fuzzer.c
+++ b/fuzzer/fuzzer.c
@@ -184,7 +184,7 @@ void fuzz_free(void *ptr)
 
 static srtp_err_status_t fuzz_srtp_protect(srtp_t srtp_sender,
                                            void *hdr,
-                                           int *len,
+                                           size_t *len,
                                            uint8_t use_mki,
                                            unsigned int mki)
 {
@@ -193,7 +193,7 @@ static srtp_err_status_t fuzz_srtp_protect(srtp_t srtp_sender,
 
 static srtp_err_status_t fuzz_srtp_unprotect(srtp_t srtp_sender,
                                              void *hdr,
-                                             int *len,
+                                             size_t *len,
                                              uint8_t use_mki,
                                              unsigned int mki)
 {
@@ -202,7 +202,7 @@ static srtp_err_status_t fuzz_srtp_unprotect(srtp_t srtp_sender,
 
 static srtp_err_status_t fuzz_srtp_protect_rtcp(srtp_t srtp_sender,
                                                 void *hdr,
-                                                int *len,
+                                                size_t *len,
                                                 uint8_t use_mki,
                                                 unsigned int mki)
 {
@@ -211,7 +211,7 @@ static srtp_err_status_t fuzz_srtp_protect_rtcp(srtp_t srtp_sender,
 
 static srtp_err_status_t fuzz_srtp_unprotect_rtcp(srtp_t srtp_sender,
                                                   void *hdr,
-                                                  int *len,
+                                                  size_t *len,
                                                   uint8_t use_mki,
                                                   unsigned int mki)
 {
@@ -220,7 +220,7 @@ static srtp_err_status_t fuzz_srtp_unprotect_rtcp(srtp_t srtp_sender,
 
 static srtp_err_status_t fuzz_srtp_protect_mki(srtp_t srtp_sender,
                                                void *hdr,
-                                               int *len,
+                                               size_t *len,
                                                uint8_t use_mki,
                                                unsigned int mki)
 {
@@ -229,7 +229,7 @@ static srtp_err_status_t fuzz_srtp_protect_mki(srtp_t srtp_sender,
 
 static srtp_err_status_t fuzz_srtp_protect_rtcp_mki(srtp_t srtp_sender,
                                                     void *hdr,
-                                                    int *len,
+                                                    size_t *len,
                                                     uint8_t use_mki,
                                                     unsigned int mki)
 {
@@ -238,7 +238,7 @@ static srtp_err_status_t fuzz_srtp_protect_rtcp_mki(srtp_t srtp_sender,
 
 static srtp_err_status_t fuzz_srtp_unprotect_mki(srtp_t srtp_sender,
                                                  void *hdr,
-                                                 int *len,
+                                                 size_t *len,
                                                  uint8_t use_mki,
                                                  unsigned int mki)
 {
@@ -247,7 +247,7 @@ static srtp_err_status_t fuzz_srtp_unprotect_mki(srtp_t srtp_sender,
 
 static srtp_err_status_t fuzz_srtp_unprotect_rtcp_mki(srtp_t srtp_sender,
                                                       void *hdr,
-                                                      int *len,
+                                                      size_t *len,
                                                       uint8_t use_mki,
                                                       unsigned int mki)
 {
@@ -259,7 +259,7 @@ static srtp_err_status_t fuzz_srtp_unprotect_rtcp_mki(srtp_t srtp_sender,
 static srtp_err_status_t fuzz_srtp_get_protect_length(const srtp_t srtp_ctx,
                                                       uint8_t use_mki,
                                                       unsigned int mki,
-                                                      uint32_t *length)
+                                                      size_t *length)
 {
     return srtp_get_protect_trailer_length(srtp_ctx, 0, 0, length);
 }
@@ -268,7 +268,7 @@ static srtp_err_status_t fuzz_srtp_get_protect_rtcp_length(
     const srtp_t srtp_ctx,
     uint8_t use_mki,
     unsigned int mki,
-    uint32_t *length)
+    size_t *length)
 {
     return srtp_get_protect_rtcp_trailer_length(srtp_ctx, 0, 0, length);
 }
@@ -276,7 +276,7 @@ static srtp_err_status_t fuzz_srtp_get_protect_rtcp_length(
 static srtp_err_status_t fuzz_srtp_get_protect_mki_length(const srtp_t srtp_ctx,
                                                           uint8_t use_mki,
                                                           unsigned int mki,
-                                                          uint32_t *length)
+                                                          size_t *length)
 {
     return srtp_get_protect_trailer_length(srtp_ctx, use_mki, mki, length);
 }
@@ -285,7 +285,7 @@ static srtp_err_status_t fuzz_srtp_get_protect_rtcp_mki_length(
     const srtp_t srtp_ctx,
     uint8_t use_mki,
     unsigned int mki,
-    uint32_t *length)
+    size_t *length)
 {
     return srtp_get_protect_rtcp_trailer_length(srtp_ctx, use_mki, mki, length);
 }
@@ -621,7 +621,7 @@ static uint8_t *run_srtp_func(const srtp_t srtp_ctx,
         uint8_t use_mki;
         uint32_t mki;
     } params_2;
-    int ret_size;
+    size_t ret_size;
 
     EXTRACT_IF(&params_1, *data, *size, sizeof(params_1));
     params_1.srtp_func %= sizeof(srtp_funcs) / sizeof(srtp_funcs[0]);
@@ -644,7 +644,7 @@ static uint8_t *run_srtp_func(const srtp_t srtp_ctx,
     if (srtp_funcs[params_1.srtp_func].protect == true) {
         /* Intentionally not initialized to trigger MemorySanitizer, if
          * applicable */
-        uint32_t alloc_size;
+        size_t alloc_size;
 
         if (srtp_funcs[params_1.srtp_func].get_length(
                 srtp_ctx, params_1.use_mki, params_1.mki, &alloc_size) !=
@@ -682,7 +682,7 @@ static uint8_t *run_srtp_func(const srtp_t srtp_ctx,
     if (srtp_funcs[params_2.srtp_func].protect == true) {
         /* Intentionally not initialized to trigger MemorySanitizer, if
          * applicable */
-        uint32_t alloc_size;
+        size_t alloc_size;
 
         if (srtp_funcs[params_2.srtp_func].get_length(
                 srtp_ctx, params_2.use_mki, params_2.mki, &alloc_size) !=

--- a/fuzzer/fuzzer.h
+++ b/fuzzer/fuzzer.h
@@ -24,12 +24,12 @@
 #endif
 
 typedef srtp_err_status_t (
-    *fuzz_srtp_func)(srtp_t, void *, int *, uint8_t, unsigned int);
+    *fuzz_srtp_func)(srtp_t, void *, size_t *, uint8_t, unsigned int);
 typedef void (*fuzz_srtp_crypto_policy_func)(srtp_crypto_policy_t *);
 typedef srtp_err_status_t (*fuzz_srtp_get_length_func)(const srtp_t,
                                                        uint8_t,
                                                        unsigned int,
-                                                       uint32_t *);
+                                                       size_t *);
 
 struct fuzz_srtp_params {
     uint8_t srtp_func;
@@ -44,63 +44,63 @@ struct fuzz_srtp_params {
 
 static srtp_err_status_t fuzz_srtp_protect(srtp_t srtp_sender,
                                            void *hdr,
-                                           int *len,
+                                           size_t *len,
                                            uint8_t use_mki,
                                            unsigned int mki);
 static srtp_err_status_t fuzz_srtp_unprotect(srtp_t srtp_sender,
                                              void *hdr,
-                                             int *len,
+                                             size_t *len,
                                              uint8_t use_mki,
                                              unsigned int mki);
 static srtp_err_status_t fuzz_srtp_protect_rtcp(srtp_t srtp_sender,
                                                 void *hdr,
-                                                int *len,
+                                                size_t *len,
                                                 uint8_t use_mki,
                                                 unsigned int mki);
 static srtp_err_status_t fuzz_srtp_unprotect_rtcp(srtp_t srtp_sender,
                                                   void *hdr,
-                                                  int *len,
+                                                  size_t *len,
                                                   uint8_t use_mki,
                                                   unsigned int mki);
 static srtp_err_status_t fuzz_srtp_protect_mki(srtp_t srtp_sender,
                                                void *hdr,
-                                               int *len,
+                                               size_t *len,
                                                uint8_t use_mki,
                                                unsigned int mki);
 static srtp_err_status_t fuzz_srtp_protect_rtcp_mki(srtp_t srtp_sender,
                                                     void *hdr,
-                                                    int *len,
+                                                    size_t *len,
                                                     uint8_t use_mki,
                                                     unsigned int mki);
 static srtp_err_status_t fuzz_srtp_unprotect_mki(srtp_t srtp_sender,
                                                  void *hdr,
-                                                 int *len,
+                                                 size_t *len,
                                                  uint8_t use_mki,
                                                  unsigned int mki);
 static srtp_err_status_t fuzz_srtp_unprotect_rtcp_mki(srtp_t srtp_sender,
                                                       void *hdr,
-                                                      int *len,
+                                                      size_t *len,
                                                       uint8_t use_mki,
                                                       unsigned int mki);
 
 static srtp_err_status_t fuzz_srtp_get_protect_length(const srtp_t srtp_ctx,
                                                       uint8_t use_mki,
                                                       unsigned int mki,
-                                                      uint32_t *length);
+                                                      size_t *length);
 static srtp_err_status_t fuzz_srtp_get_protect_mki_length(const srtp_t srtp_ctx,
                                                           uint8_t use_mki,
                                                           unsigned int mki,
-                                                          uint32_t *length);
+                                                          size_t *length);
 static srtp_err_status_t fuzz_srtp_get_protect_rtcp_length(
     const srtp_t srtp_ctx,
     uint8_t use_mki,
     unsigned int mki,
-    uint32_t *length);
+    size_t *length);
 static srtp_err_status_t fuzz_srtp_get_protect_rtcp_mki_length(
     const srtp_t srtp_ctx,
     uint8_t use_mki,
     unsigned int mki,
-    uint32_t *length);
+    size_t *length);
 
 struct fuzz_srtp_func_ext {
     fuzz_srtp_func srtp_func;

--- a/include/srtp.h
+++ b/include/srtp.h
@@ -46,6 +46,7 @@
 #define SRTP_SRTP_H
 
 #include <stdint.h>
+#include <stddef.h>
 
 #ifdef __cplusplus
 extern "C" {
@@ -243,13 +244,13 @@ typedef enum {
 typedef struct srtp_crypto_policy_t {
     srtp_cipher_type_id_t cipher_type; /**< An integer representing          */
                                        /**< the type of cipher.              */
-    int cipher_key_len;                /**< The length of the cipher key     */
+    size_t cipher_key_len;             /**< The length of the cipher key     */
                                        /**< in octets.                       */
     srtp_auth_type_id_t auth_type;     /**< An integer representing the      */
                                        /**< authentication function.         */
-    int auth_key_len;                  /**< The length of the authentication */
+    size_t auth_key_len;               /**< The length of the authentication */
                                        /**< function key in octets.          */
-    int auth_tag_len;                  /**< The length of the authentication */
+    size_t auth_tag_len;               /**< The length of the authentication */
                                        /**< tag in octets.                   */
     srtp_sec_serv_t sec_serv;          /**< The flag indicating the security */
                                        /**< services to be applied.          */
@@ -296,7 +297,7 @@ typedef struct {
 typedef struct srtp_master_key_t {
     unsigned char *key;
     unsigned char *mki_id;
-    unsigned int mki_size;
+    size_t mki_size;
 } srtp_master_key_t;
 
 /**
@@ -422,7 +423,7 @@ srtp_err_status_t srtp_shutdown(void);
  *    - srtp_err_status_replay_fail   rtp sequence number was non-increasing
  *    - @e other                 failure in cryptographic mechanisms
  */
-srtp_err_status_t srtp_protect(srtp_t ctx, void *rtp_hdr, int *len_ptr);
+srtp_err_status_t srtp_protect(srtp_t ctx, void *rtp_hdr, size_t *len_ptr);
 
 /**
  * @brief srtp_protect_mki() is the Secure RTP sender-side packet processing
@@ -474,7 +475,7 @@ srtp_err_status_t srtp_protect(srtp_t ctx, void *rtp_hdr, int *len_ptr);
  */
 srtp_err_status_t srtp_protect_mki(srtp_ctx_t *ctx,
                                    void *rtp_hdr,
-                                   int *pkt_octet_len,
+                                   size_t *pkt_octet_len,
                                    unsigned int use_mki,
                                    unsigned int mki_index);
 
@@ -518,7 +519,7 @@ srtp_err_status_t srtp_protect_mki(srtp_ctx_t *ctx,
  *    - [other]  if there has been an error in the cryptographic mechanisms.
  *
  */
-srtp_err_status_t srtp_unprotect(srtp_t ctx, void *srtp_hdr, int *len_ptr);
+srtp_err_status_t srtp_unprotect(srtp_t ctx, void *srtp_hdr, size_t *len_ptr);
 
 /**
  * @brief srtp_unprotect_mki() is the Secure RTP receiver-side packet
@@ -568,7 +569,7 @@ srtp_err_status_t srtp_unprotect(srtp_t ctx, void *srtp_hdr, int *len_ptr);
  */
 srtp_err_status_t srtp_unprotect_mki(srtp_t ctx,
                                      void *srtp_hdr,
-                                     int *len_ptr,
+                                     size_t *len_ptr,
                                      unsigned int use_mki);
 
 /**
@@ -1248,12 +1249,12 @@ srtp_err_status_t srtp_crypto_policy_set_from_profile_for_rtcp(
 /**
  * @brief returns the master key length for a given SRTP profile
  */
-unsigned int srtp_profile_get_master_key_length(srtp_profile_t profile);
+size_t srtp_profile_get_master_key_length(srtp_profile_t profile);
 
 /**
  * @brief returns the master salt length for a given SRTP profile
  */
-unsigned int srtp_profile_get_master_salt_length(srtp_profile_t profile);
+size_t srtp_profile_get_master_salt_length(srtp_profile_t profile);
 
 /**
  * @brief appends the salt to the key
@@ -1267,9 +1268,9 @@ unsigned int srtp_profile_get_master_salt_length(srtp_profile_t profile);
  *
  */
 void srtp_append_salt_to_key(unsigned char *key,
-                             unsigned int bytes_in_key,
+                             size_t bytes_in_key,
                              unsigned char *salt,
-                             unsigned int bytes_in_salt);
+                             size_t bytes_in_salt);
 
 /**
  * @}
@@ -1333,7 +1334,7 @@ void srtp_append_salt_to_key(unsigned char *key,
  */
 srtp_err_status_t srtp_protect_rtcp(srtp_t ctx,
                                     void *rtcp_hdr,
-                                    int *pkt_octet_len);
+                                    size_t *pkt_octet_len);
 
 /**
  * @brief srtp_protect_rtcp_mki() is the Secure RTCP sender-side packet
@@ -1382,7 +1383,7 @@ srtp_err_status_t srtp_protect_rtcp(srtp_t ctx,
  */
 srtp_err_status_t srtp_protect_rtcp_mki(srtp_t ctx,
                                         void *rtcp_hdr,
-                                        int *pkt_octet_len,
+                                        size_t *pkt_octet_len,
                                         unsigned int use_mki,
                                         unsigned int mki_index);
 
@@ -1426,7 +1427,7 @@ srtp_err_status_t srtp_protect_rtcp_mki(srtp_t ctx,
  */
 srtp_err_status_t srtp_unprotect_rtcp(srtp_t ctx,
                                       void *srtcp_hdr,
-                                      int *pkt_octet_len);
+                                      size_t *pkt_octet_len);
 
 /**
  * @brief srtp_unprotect_rtcp() is the Secure RTCP receiver-side packet
@@ -1475,7 +1476,7 @@ srtp_err_status_t srtp_unprotect_rtcp(srtp_t ctx,
  */
 srtp_err_status_t srtp_unprotect_rtcp_mki(srtp_t ctx,
                                           void *srtcp_hdr,
-                                          int *pkt_octet_len,
+                                          size_t *pkt_octet_len,
                                           unsigned int use_mki);
 
 /**
@@ -1705,7 +1706,7 @@ srtp_err_status_t srtp_install_log_handler(srtp_log_handler_func_t func,
 srtp_err_status_t srtp_get_protect_trailer_length(srtp_t session,
                                                   uint32_t use_mki,
                                                   uint32_t mki_index,
-                                                  uint32_t *length);
+                                                  size_t *length);
 
 /**
  * @brief srtp_get_protect_rtcp_trailer_length(session, use_mki, mki_index,
@@ -1722,7 +1723,7 @@ srtp_err_status_t srtp_get_protect_trailer_length(srtp_t session,
 srtp_err_status_t srtp_get_protect_rtcp_trailer_length(srtp_t session,
                                                        uint32_t use_mki,
                                                        uint32_t mki_index,
-                                                       uint32_t *length);
+                                                       size_t *length);
 
 /**
  * @brief srtp_stream_set_roc(session, ssrc, roc)

--- a/include/srtp_priv.h
+++ b/include/srtp_priv.h
@@ -120,7 +120,7 @@ typedef struct srtp_session_keys_t {
     uint8_t salt[SRTP_AEAD_SALT_LEN];
     uint8_t c_salt[SRTP_AEAD_SALT_LEN];
     uint8_t *mki_id;
-    unsigned int mki_size;
+    size_t mki_size;
     srtp_key_limit_ctx_t *limit;
 } srtp_session_keys_t;
 

--- a/test/rtp.h
+++ b/test/rtp.h
@@ -100,9 +100,9 @@ typedef struct rtp_sender_ctx_t *rtp_sender_t;
 
 typedef struct rtp_receiver_ctx_t *rtp_receiver_t;
 
-int rtp_sendto(rtp_sender_t sender, const void *msg, int len);
+ssize_t rtp_sendto(rtp_sender_t sender, const void *msg, size_t len);
 
-int rtp_recvfrom(rtp_receiver_t receiver, void *msg, int *len);
+ssize_t rtp_recvfrom(rtp_receiver_t receiver, void *msg, size_t *len);
 
 int rtp_receiver_init(rtp_receiver_t rcvr,
                       int sock,

--- a/test/rtp_decoder.c
+++ b/test/rtp_decoder.c
@@ -559,7 +559,7 @@ int main(int argc, char *argv[])
         if (strlen(input_key) > (size_t)policy.rtp.cipher_key_len * 2) {
             fprintf(stderr,
                     "error: too many digits in key/salt "
-                    "(should be %d hexadecimal digits, found %u)\n",
+                    "(should be %zu hexadecimal digits, found %u)\n",
                     policy.rtp.cipher_key_len * 2, (unsigned)strlen(input_key));
             exit(1);
         }
@@ -738,7 +738,7 @@ void rtp_decoder_handle_pkt(u_char *arg,
     int rtp;
     int pktsize;
     struct timeval delta;
-    int octets_recvd;
+    size_t octets_recvd;
     srtp_err_status_t status;
     dcdr->frame_nr++;
 
@@ -753,11 +753,12 @@ void rtp_decoder_handle_pkt(u_char *arg,
 
     memcpy((void *)&message, rtp_packet, hdr->caplen - dcdr->rtp_offset);
     pktsize = hdr->caplen - dcdr->rtp_offset;
-    octets_recvd = pktsize;
 
-    if (octets_recvd == -1) {
+    if (pktsize < 0) {
         return;
     }
+
+    octets_recvd = pktsize;
 
     if (dcdr->mode == mode_rtp) {
         rtp = 1;

--- a/test/rtpw.c
+++ b/test/rtpw.c
@@ -149,8 +149,8 @@ int main(int argc, char *argv[])
     srtp_sec_serv_t sec_servs = sec_serv_none;
     unsigned char ttl = 5;
     int c;
-    int key_size = 128;
-    int tag_size = 8;
+    size_t key_size = 128;
+    size_t tag_size = 8;
     int gcm_on = 0;
     char *input_key = NULL;
     int b64_input = 0;
@@ -160,8 +160,8 @@ int main(int argc, char *argv[])
     rtp_sender_t snd;
     srtp_policy_t policy;
     srtp_err_status_t status;
-    int len;
-    int expected_len;
+    size_t len;
+    size_t expected_len;
     int do_list_mods = 0;
     uint32_t ssrc = 0xdeadbeef; /* ssrc value hardcoded for now */
 #ifdef RTPW_USE_WINSOCK2
@@ -207,7 +207,7 @@ int main(int argc, char *argv[])
         case 'e':
             key_size = atoi(optarg_s);
             if (key_size != 128 && key_size != 256) {
-                printf("error: encryption key size must be 128 or 256 (%d)\n",
+                printf("error: encryption key size must be 128 or 256 (%zu)\n",
                        key_size);
                 exit(1);
             }
@@ -216,7 +216,7 @@ int main(int argc, char *argv[])
         case 't':
             tag_size = atoi(optarg_s);
             if (tag_size != 8 && tag_size != 16) {
-                printf("error: GCM tag size must be 8 or 16 (%d)\n", tag_size);
+                printf("error: GCM tag size must be 8 or 16 (%zu)\n", tag_size);
                 exit(1);
             }
             break;
@@ -485,15 +485,15 @@ int main(int argc, char *argv[])
         if (len < expected_len) {
             fprintf(stderr,
                     "error: too few digits in key/salt "
-                    "(should be %d digits, found %d)\n",
+                    "(should be %zu digits, found %zu)\n",
                     expected_len, len);
             exit(1);
         }
-        if ((int)strlen(input_key) > policy.rtp.cipher_key_len * 2) {
+        if (strlen(input_key) > policy.rtp.cipher_key_len * 2) {
             fprintf(stderr,
                     "error: too many digits in key/salt "
-                    "(should be %d hexadecimal digits, found %u)\n",
-                    policy.rtp.cipher_key_len * 2, (unsigned)strlen(input_key));
+                    "(should be %zu hexadecimal digits, found %zu)\n",
+                    policy.rtp.cipher_key_len * 2, strlen(input_key));
             exit(1);
         }
 

--- a/test/srtp_driver.c
+++ b/test/srtp_driver.c
@@ -102,7 +102,7 @@ srtp_err_status_t srtp_test_set_receiver_roc(void);
 
 srtp_err_status_t srtp_test_set_sender_roc(void);
 
-double srtp_bits_per_second(int msg_len_octets, const srtp_policy_t *policy);
+double srtp_bits_per_second(size_t msg_len_octets, const srtp_policy_t *policy);
 
 double srtp_rejections_per_second(int msg_len_octets,
                                   const srtp_policy_t *policy);
@@ -121,8 +121,8 @@ srtp_err_status_t srtp_session_print_policy(srtp_t srtp);
 
 srtp_err_status_t srtp_print_policy(const srtp_policy_t *policy);
 
-char *srtp_packet_to_string(srtp_hdr_t *hdr, int packet_len);
-char *srtp_rtcp_packet_to_string(srtcp_hdr_t *hdr, int pkt_octet_len);
+char *srtp_packet_to_string(srtp_hdr_t *hdr, size_t packet_len);
+char *srtp_rtcp_packet_to_string(srtcp_hdr_t *hdr, size_t pkt_octet_len);
 
 double mips_estimate(int num_trials, int *ignore);
 
@@ -708,14 +708,14 @@ int main(int argc, char *argv[])
  * deallocated with the free() call once it is no longer needed.
  */
 
-srtp_hdr_t *srtp_create_test_packet(int pkt_octet_len,
+srtp_hdr_t *srtp_create_test_packet(size_t pkt_octet_len,
                                     uint32_t ssrc,
-                                    int *pkt_len)
+                                    size_t *pkt_len)
 {
-    int i;
+    size_t i;
     uint8_t *buffer;
     srtp_hdr_t *hdr;
-    int bytes_in_hdr = 12;
+    size_t bytes_in_hdr = 12;
 
     /* allocate memory for test packet */
     hdr = (srtp_hdr_t *)malloc(pkt_octet_len + bytes_in_hdr +
@@ -752,14 +752,14 @@ srtp_hdr_t *srtp_create_test_packet(int pkt_octet_len,
     return hdr;
 }
 
-srtcp_hdr_t *srtp_create_rtcp_test_packet(int pkt_octet_len,
+srtcp_hdr_t *srtp_create_rtcp_test_packet(size_t pkt_octet_len,
                                           uint32_t ssrc,
-                                          int *pkt_len)
+                                          size_t *pkt_len)
 {
-    int i;
+    size_t i;
     uint8_t *buffer;
     srtcp_hdr_t *hdr;
-    int bytes_in_hdr = 8;
+    size_t bytes_in_hdr = 8;
 
     /* allocate memory for test packet */
     hdr = (srtcp_hdr_t *)malloc(pkt_octet_len + bytes_in_hdr +
@@ -793,11 +793,11 @@ srtcp_hdr_t *srtp_create_rtcp_test_packet(int pkt_octet_len,
     return hdr;
 }
 
-static srtp_hdr_t *srtp_create_test_packet_extended(int pkt_octet_len,
+static srtp_hdr_t *srtp_create_test_packet_extended(size_t pkt_octet_len,
                                                     uint32_t ssrc,
                                                     uint16_t seq,
                                                     uint32_t ts,
-                                                    int *pkt_len)
+                                                    size_t *pkt_len)
 {
     srtp_hdr_t *hdr;
 
@@ -810,14 +810,14 @@ static srtp_hdr_t *srtp_create_test_packet_extended(int pkt_octet_len,
     return hdr;
 }
 
-srtp_hdr_t *srtp_create_test_packet_ext_hdr(int pkt_octet_len,
+srtp_hdr_t *srtp_create_test_packet_ext_hdr(size_t pkt_octet_len,
                                             uint32_t ssrc,
-                                            int *pkt_len)
+                                            size_t *pkt_len)
 {
-    int i;
+    size_t i;
     uint8_t *buffer;
     srtp_hdr_t *hdr;
-    int bytes_in_hdr = 12;
+    size_t bytes_in_hdr = 12;
     uint8_t extension_header[12] = { /* one-byte header */
                                      0xbe, 0xde,
                                      /* size */
@@ -917,14 +917,14 @@ void srtp_do_rejection_timing(const srtp_policy_t *policy)
 
 #define MAX_MSG_LEN 1024
 
-double srtp_bits_per_second(int msg_len_octets, const srtp_policy_t *policy)
+double srtp_bits_per_second(size_t msg_len_octets, const srtp_policy_t *policy)
 {
     srtp_t srtp;
     srtp_hdr_t *mesg;
     int i;
     clock_t timer;
     int num_trials = 100000;
-    int input_len, len;
+    size_t input_len, len;
     uint32_t ssrc;
     srtp_err_status_t status;
 
@@ -990,7 +990,7 @@ double srtp_rejections_per_second(int msg_len_octets,
     srtp_ctx_t *srtp;
     srtp_hdr_t *mesg;
     int i;
-    int len;
+    size_t len;
     clock_t timer;
     int num_trials = 1000000;
     uint32_t ssrc = policy->ssrc.value;
@@ -1039,7 +1039,7 @@ void err_check(srtp_err_status_t s)
 
 srtp_err_status_t srtp_test_call_protect(srtp_t srtp_sender,
                                          srtp_hdr_t *hdr,
-                                         int *len,
+                                         size_t *len,
                                          int mki_index)
 {
     if (mki_index == -1) {
@@ -1051,7 +1051,7 @@ srtp_err_status_t srtp_test_call_protect(srtp_t srtp_sender,
 
 srtp_err_status_t srtp_test_call_protect_rtcp(srtp_t srtp_sender,
                                               srtcp_hdr_t *hdr,
-                                              int *len,
+                                              size_t *len,
                                               int mki_index)
 {
     if (mki_index == -1) {
@@ -1063,7 +1063,7 @@ srtp_err_status_t srtp_test_call_protect_rtcp(srtp_t srtp_sender,
 
 srtp_err_status_t srtp_test_call_unprotect(srtp_t srtp_sender,
                                            srtp_hdr_t *hdr,
-                                           int *len,
+                                           size_t *len,
                                            int use_mki)
 {
     if (use_mki == -1) {
@@ -1075,7 +1075,7 @@ srtp_err_status_t srtp_test_call_unprotect(srtp_t srtp_sender,
 
 srtp_err_status_t srtp_test_call_unprotect_rtcp(srtp_t srtp_sender,
                                                 srtcp_hdr_t *hdr,
-                                                int *len,
+                                                size_t *len,
                                                 int use_mki)
 {
     if (use_mki == -1) {
@@ -1089,16 +1089,16 @@ srtp_err_status_t srtp_test(const srtp_policy_t *policy,
                             int extension_header,
                             int mki_index)
 {
-    int i;
+    size_t i;
     srtp_t srtp_sender;
     srtp_t srtp_rcvr;
     srtp_err_status_t status = srtp_err_status_ok;
     srtp_hdr_t *hdr, *hdr2;
     uint8_t hdr_enc[64];
     uint8_t *pkt_end;
-    int msg_len_octets, msg_len_enc, msg_len;
-    int len, len2;
-    uint32_t tag_length;
+    size_t msg_len_octets, msg_len_enc, msg_len;
+    size_t len, len2;
+    size_t tag_length;
     uint32_t ssrc;
     srtp_policy_t *rcvr_policy;
     srtp_policy_t tmp_policy;
@@ -1185,7 +1185,7 @@ srtp_err_status_t srtp_test(const srtp_policy_t *policy,
         if (pkt_end[i] != 0xff) {
             fprintf(stdout,
                     "overwrite in srtp_protect() function "
-                    "(expected %x, found %x in trailing octet %d)\n",
+                    "(expected %x, found %x in trailing octet %zu)\n",
                     0xff, ((uint8_t *)hdr)[i], i);
             free(hdr);
             free(hdr2);
@@ -1254,7 +1254,7 @@ srtp_err_status_t srtp_test(const srtp_policy_t *policy,
     /* verify that the unprotected packet matches the origial one */
     for (i = 0; i < len; i++) {
         if (((uint8_t *)hdr)[i] != ((uint8_t *)hdr2)[i]) {
-            fprintf(stdout, "mismatch at octet %d\n", i);
+            fprintf(stdout, "mismatch at octet %zu\n", i);
             status = srtp_err_status_algo_fail;
         }
     }
@@ -1322,16 +1322,16 @@ srtp_err_status_t srtp_test(const srtp_policy_t *policy,
 
 srtp_err_status_t srtcp_test(const srtp_policy_t *policy, int mki_index)
 {
-    int i;
+    size_t i;
     srtp_t srtcp_sender;
     srtp_t srtcp_rcvr;
     srtp_err_status_t status = srtp_err_status_ok;
     srtcp_hdr_t *hdr, *hdr2;
     uint8_t hdr_enc[64];
     uint8_t *pkt_end;
-    int msg_len_octets, msg_len_enc, msg_len;
-    int len, len2;
-    uint32_t tag_length;
+    size_t msg_len_octets, msg_len_enc, msg_len;
+    size_t len, len2;
+    size_t tag_length;
     uint32_t ssrc;
     srtp_policy_t *rcvr_policy;
     int use_mki = 0;
@@ -1402,7 +1402,7 @@ srtp_err_status_t srtcp_test(const srtp_policy_t *policy, int mki_index)
         if (pkt_end[i] != 0xff) {
             fprintf(stdout,
                     "overwrite in srtp_protect_rtcp() function "
-                    "(expected %x, found %x in trailing octet %d)\n",
+                    "(expected %x, found %x in trailing octet %zu)\n",
                     0xff, ((uint8_t *)hdr)[i], i);
             free(hdr);
             free(hdr2);
@@ -1464,7 +1464,7 @@ srtp_err_status_t srtcp_test(const srtp_policy_t *policy, int mki_index)
     /* verify that the unprotected packet matches the original one */
     for (i = 0; i < len; i++) {
         if (((uint8_t *)hdr)[i] != ((uint8_t *)hdr2)[i]) {
-            fprintf(stdout, "mismatch at octet %d\n", i);
+            fprintf(stdout, "mismatch at octet %zu\n", i);
             status = srtp_err_status_algo_fail;
         }
     }
@@ -1650,11 +1650,11 @@ srtp_err_status_t srtp_print_policy(const srtp_policy_t *policy)
 
 char packet_string[MTU];
 
-char *srtp_packet_to_string(srtp_hdr_t *hdr, int pkt_octet_len)
+char *srtp_packet_to_string(srtp_hdr_t *hdr, size_t pkt_octet_len)
 {
-    int octets_in_rtp_header = 12;
+    size_t octets_in_rtp_header = 12;
     uint8_t *data = ((uint8_t *)hdr) + octets_in_rtp_header;
-    int hex_len = pkt_octet_len - octets_in_rtp_header;
+    size_t hex_len = pkt_octet_len - octets_in_rtp_header;
 
     /* sanity checking */
     if ((hdr == NULL) || (pkt_octet_len > MTU)) {
@@ -1674,7 +1674,7 @@ char *srtp_packet_to_string(srtp_hdr_t *hdr, int pkt_octet_len)
              "   ts:\t\t%x\n"
              "   ssrc:\t%x\n"
              "   data:\t%s\n"
-             "} (%d octets in total)\n",
+             "} (%zu octets in total)\n",
              hdr->version, hdr->p, hdr->x, hdr->cc, hdr->m, hdr->pt, hdr->seq,
              hdr->ts, hdr->ssrc, octet_string_hex_string(data, hex_len),
              pkt_octet_len);
@@ -1682,11 +1682,11 @@ char *srtp_packet_to_string(srtp_hdr_t *hdr, int pkt_octet_len)
     return packet_string;
 }
 
-char *srtp_rtcp_packet_to_string(srtcp_hdr_t *hdr, int pkt_octet_len)
+char *srtp_rtcp_packet_to_string(srtcp_hdr_t *hdr, size_t pkt_octet_len)
 {
-    int octets_in_rtcp_header = 8;
+    size_t octets_in_rtcp_header = 8;
     uint8_t *data = ((uint8_t *)hdr) + octets_in_rtcp_header;
-    int hex_len = pkt_octet_len - octets_in_rtcp_header;
+    size_t hex_len = pkt_octet_len - octets_in_rtcp_header;
 
     /* sanity checking */
     if ((hdr == NULL) || (pkt_octet_len > MTU)) {
@@ -1703,7 +1703,7 @@ char *srtp_rtcp_packet_to_string(srtcp_hdr_t *hdr, int pkt_octet_len)
              "   len:\t\t%x\n"
              "   ssrc:\t%x\n"
              "   data:\t%s\n"
-             "} (%d octets in total)\n",
+             "} (%zu octets in total)\n",
              hdr->version, hdr->p, hdr->rc, hdr->pt, hdr->len, hdr->ssrc,
              octet_string_hex_string(data, hex_len), pkt_octet_len);
 
@@ -1793,7 +1793,7 @@ srtp_err_status_t srtp_validate(void)
 
     srtp_t srtp_snd, srtp_recv;
     srtp_err_status_t status;
-    int len;
+    size_t len;
     srtp_policy_t policy;
 
     /*
@@ -1953,7 +1953,7 @@ srtp_err_status_t srtp_validate_null(void)
 
     srtp_t srtp_snd, srtp_recv;
     srtp_err_status_t status;
-    int len;
+    size_t len;
     srtp_policy_t policy;
 
     /*
@@ -2115,7 +2115,7 @@ srtp_err_status_t srtp_validate_gcm(void)
 
     srtp_t srtp_snd, srtp_recv;
     srtp_err_status_t status;
-    int len;
+    size_t len;
     srtp_policy_t policy;
 
     /*
@@ -2277,7 +2277,7 @@ srtp_err_status_t srtp_validate_encrypted_extensions_headers(void)
 
     srtp_t srtp_snd, srtp_recv;
     srtp_err_status_t status;
-    int len;
+    size_t len;
     srtp_policy_t policy;
     int headers[3] = { 1, 3, 4 };
 
@@ -2398,7 +2398,7 @@ srtp_err_status_t srtp_validate_encrypted_extensions_headers_gcm(void)
 
     srtp_t srtp_snd, srtp_recv;
     srtp_err_status_t status;
-    int len;
+    size_t len;
     srtp_policy_t policy;
     int headers[3] = { 1, 3, 4 };
 
@@ -2515,7 +2515,7 @@ srtp_err_status_t srtp_validate_aes_256(void)
 
     srtp_t srtp_snd, srtp_recv;
     srtp_err_status_t status;
-    int len;
+    size_t len;
     srtp_policy_t policy;
 
     /*
@@ -2642,7 +2642,7 @@ srtp_err_status_t srtp_test_empty_payload(void)
 {
     srtp_t srtp_snd, srtp_recv;
     srtp_err_status_t status;
-    int len;
+    size_t len;
     srtp_policy_t policy;
     srtp_hdr_t *mesg;
 
@@ -2718,7 +2718,7 @@ srtp_err_status_t srtp_test_empty_payload_gcm(void)
 {
     srtp_t srtp_snd, srtp_recv;
     srtp_err_status_t status;
-    int len;
+    size_t len;
     srtp_policy_t policy;
     srtp_hdr_t *mesg;
 
@@ -2907,8 +2907,8 @@ srtp_err_status_t srtp_test_update(void)
 {
     srtp_err_status_t status;
     uint32_t ssrc = 0x12121212;
-    int msg_len_octets = 32;
-    int protected_msg_len_octets;
+    size_t msg_len_octets = 32;
+    size_t protected_msg_len_octets;
     srtp_hdr_t *msg;
     srtp_t srtp_snd, srtp_recv;
     srtp_policy_t policy;
@@ -3154,7 +3154,7 @@ srtp_err_status_t srtp_test_protect_trailer_length(void)
     srtp_t srtp_send_mki;
     srtp_t srtp_send_aes_gcm;
     srtp_t srtp_send_aes_gcm_mki;
-    uint32_t length = 0;
+    size_t length = 0;
     srtp_err_status_t status;
 
     srtp_test_setup_protect_trailer_streams(
@@ -3211,7 +3211,7 @@ srtp_err_status_t srtp_test_protect_rtcp_trailer_length(void)
     srtp_t srtp_send_mki;
     srtp_t srtp_send_aes_gcm;
     srtp_t srtp_send_aes_gcm_mki;
-    uint32_t length = 0;
+    size_t length = 0;
     srtp_err_status_t status;
 
     srtp_test_setup_protect_trailer_streams(
@@ -3275,7 +3275,7 @@ srtp_err_status_t srtp_test_out_of_order_after_rollover(void)
 
     const uint32_t num_pkts = 5;
     srtp_hdr_t *pkts[5];
-    int pkt_len_octets[5];
+    size_t pkt_len_octets[5];
 
     uint32_t i;
     uint32_t stream_roc;
@@ -3492,8 +3492,8 @@ srtp_err_status_t srtp_test_get_roc(void)
     uint32_t ts;
     uint16_t seq;
 
-    int msg_len_octets = 32;
-    int protected_msg_len_octets;
+    size_t msg_len_octets = 32;
+    size_t protected_msg_len_octets;
 
     memset(&policy, 0, sizeof(policy));
     srtp_crypto_policy_set_rtp_default(&policy.rtp);
@@ -3567,9 +3567,9 @@ static srtp_err_status_t test_set_receiver_roc(uint32_t packets,
     uint16_t seq;
     uint16_t stride;
 
-    int msg_len_octets = 32;
-    int protected_msg_len_octets_1;
-    int protected_msg_len_octets_2;
+    size_t msg_len_octets = 32;
+    size_t protected_msg_len_octets_1;
+    size_t protected_msg_len_octets_2;
 
     /* Create sender */
     memset(&sender_policy, 0, sizeof(sender_policy));
@@ -3598,7 +3598,7 @@ static srtp_err_status_t test_set_receiver_roc(uint32_t packets,
     stride = 0x4000;
     while (i < packets) {
         srtp_hdr_t *tmp_pkt;
-        int tmp_len;
+        size_t tmp_len;
 
         tmp_pkt = srtp_create_test_packet_extended(
             msg_len_octets, sender_policy.ssrc.value, seq, ts, &tmp_len);
@@ -3726,8 +3726,8 @@ static srtp_err_status_t test_set_sender_roc(uint16_t seq, uint32_t roc_to_set)
 
     uint32_t ts;
 
-    int msg_len_octets = 32;
-    int protected_msg_len_octets;
+    size_t msg_len_octets = 32;
+    size_t protected_msg_len_octets;
 
     /* Create sender */
     memset(&sender_policy, 0, sizeof(sender_policy));

--- a/test/util.c
+++ b/test/util.c
@@ -115,11 +115,11 @@ uint8_t nibble_to_hex_char(uint8_t nibble)
  * hex_string_to_octet_string converts a hexadecimal string
  * of length 2 * len to a raw octet string of length len
  */
-int hex_string_to_octet_string(char *raw, char *hex, int len)
+size_t hex_string_to_octet_string(char *raw, char *hex, size_t len)
 {
     uint8_t x;
     int tmp;
-    int hex_len;
+    size_t hex_len;
 
     hex_len = 0;
     while (hex_len < len) {
@@ -141,10 +141,10 @@ int hex_string_to_octet_string(char *raw, char *hex, int len)
     return hex_len;
 }
 
-char *octet_string_hex_string(const void *s, int length)
+char *octet_string_hex_string(const void *s, size_t length)
 {
     const uint8_t *str = (const uint8_t *)s;
-    int i;
+    size_t i;
 
     /* double length, since one octet takes two hex characters */
     length *= 2;
@@ -165,11 +165,11 @@ char *octet_string_hex_string(const void *s, int length)
 static const char b64chars[] = "ABCDEFGHIJKLMNOPQRSTUVWXYZ"
                                "abcdefghijklmnopqrstuvwxyz0123456789+/";
 
-static int base64_block_to_octet_triple(char *out, char *in)
+static size_t base64_block_to_octet_triple(char *out, char *in)
 {
     unsigned char sextets[4] = { 0 };
-    int j = 0;
-    int i;
+    size_t j = 0;
+    size_t i;
 
     for (i = 0; i < 4; i++) {
         char *p = strchr(b64chars, in[i]);
@@ -190,11 +190,11 @@ static int base64_block_to_octet_triple(char *out, char *in)
     return j;
 }
 
-int base64_string_to_octet_string(char *out, int *pad, char *in, int len)
+size_t base64_string_to_octet_string(char *out, int *pad, char *in, size_t len)
 {
-    int k = 0;
-    int i = 0;
-    int j = 0;
+    size_t k = 0;
+    size_t i = 0;
+    size_t j = 0;
 
     if (len % 4 != 0) {
         return 0;
@@ -205,6 +205,6 @@ int base64_string_to_octet_string(char *out, int *pad, char *in, int len)
         k += 3;
         i += 4;
     }
-    *pad = j;
+    *pad = (int)j;
     return i;
 }

--- a/test/util.h
+++ b/test/util.h
@@ -44,10 +44,15 @@
 #ifndef SRTP_TEST_UTIL_H
 #define SRTP_TEST_UTIL_H
 
+#include <stddef.h>
+
 #define MAX_PRINT_STRING_LEN 1024
 
-int hex_string_to_octet_string(char *raw, char *hex, int len);
-char *octet_string_hex_string(const void *s, int length);
-int base64_string_to_octet_string(char *raw, int *pad, char *base64, int len);
+size_t hex_string_to_octet_string(char *raw, char *hex, size_t len);
+char *octet_string_hex_string(const void *s, size_t length);
+size_t base64_string_to_octet_string(char *raw,
+                                     int *pad,
+                                     char *base64,
+                                     size_t len);
 
 #endif


### PR DESCRIPTION
This change effects both public API and internal API and variables. It is meant to provide a consistent interface that reduces the amount of casts and increases readability of the code.

Part of #671.