### PR TITLE
Change loops to use local size_t variables

### DIFF
--- a/crypto/cipher/aes_icm.c
+++ b/crypto/cipher/aes_icm.c
@@ -300,7 +300,6 @@ static srtp_err_status_t srtp_aes_icm_encrypt(void *cv,
 {
     srtp_aes_icm_ctx_t *c = (srtp_aes_icm_ctx_t *)cv;
     unsigned int bytes_to_encr = (unsigned int)*enc_len;
-    unsigned int i;
     uint32_t *b;
 
     /* check that there's enough segment left*/
@@ -313,7 +312,7 @@ static srtp_err_status_t srtp_aes_icm_encrypt(void *cv,
     debug_print(srtp_mod_aes_icm, "block index: %d", htons(c->counter.v16[7]));
     if (bytes_to_encr <= (unsigned int)c->bytes_in_buffer) {
         /* deal with odd case of small bytes_to_encr */
-        for (i = (sizeof(v128_t) - c->bytes_in_buffer);
+        for (size_t i = (sizeof(v128_t) - c->bytes_in_buffer);
              i < (sizeof(v128_t) - c->bytes_in_buffer + bytes_to_encr); i++) {
             *buf++ ^= c->keystream_buffer.v8[i];
         }
@@ -325,8 +324,8 @@ static srtp_err_status_t srtp_aes_icm_encrypt(void *cv,
 
     } else {
         /* encrypt bytes until the remaining data is 16-byte aligned */
-        for (i = (sizeof(v128_t) - c->bytes_in_buffer); i < sizeof(v128_t);
-             i++) {
+        for (size_t i = (sizeof(v128_t) - c->bytes_in_buffer);
+             i < sizeof(v128_t); i++) {
             *buf++ ^= c->keystream_buffer.v8[i];
         }
 
@@ -335,7 +334,7 @@ static srtp_err_status_t srtp_aes_icm_encrypt(void *cv,
     }
 
     /* now loop over entire 16-byte blocks of keystream */
-    for (i = 0; i < (bytes_to_encr / sizeof(v128_t)); i++) {
+    for (size_t i = 0; i < (bytes_to_encr / sizeof(v128_t)); i++) {
         /* fill buffer with new keystream */
         srtp_aes_icm_advance(c);
 
@@ -385,12 +384,12 @@ static srtp_err_status_t srtp_aes_icm_encrypt(void *cv,
         /* fill buffer with new keystream */
         srtp_aes_icm_advance(c);
 
-        for (i = 0; i < (bytes_to_encr & 0xf); i++) {
+        for (size_t i = 0; i < (bytes_to_encr & 0xf); i++) {
             *buf++ ^= c->keystream_buffer.v8[i];
         }
 
         /* reset the keystream buffer size to right value */
-        c->bytes_in_buffer = sizeof(v128_t) - i;
+        c->bytes_in_buffer = sizeof(v128_t) - (bytes_to_encr & 0xf);
     } else {
         /* no tail, so just reset the keystream buffer size to zero */
         c->bytes_in_buffer = 0;

--- a/crypto/hash/hmac.c
+++ b/crypto/hash/hmac.c
@@ -117,7 +117,6 @@ static srtp_err_status_t srtp_hmac_init(void *statev,
                                         size_t key_len)
 {
     srtp_hmac_ctx_t *state = (srtp_hmac_ctx_t *)statev;
-    size_t i;
     uint8_t ipad[64];
 
     /*
@@ -132,12 +131,12 @@ static srtp_err_status_t srtp_hmac_init(void *statev,
      * set values of ipad and opad by exoring the key into the
      * appropriate constant values
      */
-    for (i = 0; i < key_len; i++) {
+    for (size_t i = 0; i < key_len; i++) {
         ipad[i] = key[i] ^ 0x36;
         state->opad[i] = key[i] ^ 0x5c;
     }
     /* set the rest of ipad, opad to constant values */
-    for (; i < 64; i++) {
+    for (size_t i = key_len; i < 64; i++) {
         ipad[i] = 0x36;
         ((uint8_t *)state->opad)[i] = 0x5c;
     }

--- a/fuzzer/fuzzer.c
+++ b/fuzzer/fuzzer.c
@@ -346,7 +346,7 @@ end:
 static srtp_master_key_t **extract_master_keys(const uint8_t **data,
                                                size_t *size,
                                                const size_t key_size,
-                                               unsigned long *num_master_keys)
+                                               size_t *num_master_keys)
 {
     const uint8_t *data_orig = *data;
     size_t size_orig = *size;

--- a/include/srtp.h
+++ b/include/srtp.h
@@ -328,29 +328,29 @@ typedef struct srtp_master_key_t {
  */
 
 typedef struct srtp_policy_t {
-    srtp_ssrc_t ssrc;              /**< The SSRC value of stream, or the    */
-                                   /**< flags SSRC_ANY_INBOUND or           */
-                                   /**< SSRC_ANY_OUTBOUND if key sharing    */
-                                   /**< is used for this policy element.    */
-    srtp_crypto_policy_t rtp;      /**< SRTP crypto policy.                 */
-    srtp_crypto_policy_t rtcp;     /**< SRTCP crypto policy.                */
-    unsigned char *key;            /**< Pointer to the SRTP master key for  */
-                                   /**< this stream.                        */
-    srtp_master_key_t **keys;      /** Array of Master Key structures       */
-    unsigned long num_master_keys; /** Number of master keys                */
-    unsigned long window_size;     /**< The window size to use for replay   */
-                                   /**< protection.                         */
-    bool allow_repeat_tx;          /**< Whether retransmissions of          */
-                                   /**< packets with the same sequence      */
-                                   /**< number are allowed.                 */
-                                   /**< (Note that such repeated            */
-                                   /**< transmissions must have the same    */
-                                   /**< RTP payload, or a severe security   */
-                                   /**< weakness is introduced!)            */
-    int *enc_xtn_hdr;              /**< List of header ids to encrypt.      */
-    int enc_xtn_hdr_count;         /**< Number of entries in list of header */
-                                   /**<  ids.                               */
-    struct srtp_policy_t *next;    /**< Pointer to next stream policy.      */
+    srtp_ssrc_t ssrc;           /**< The SSRC value of stream, or the    */
+                                /**< flags SSRC_ANY_INBOUND or           */
+                                /**< SSRC_ANY_OUTBOUND if key sharing    */
+                                /**< is used for this policy element.    */
+    srtp_crypto_policy_t rtp;   /**< SRTP crypto policy.                 */
+    srtp_crypto_policy_t rtcp;  /**< SRTCP crypto policy.                */
+    unsigned char *key;         /**< Pointer to the SRTP master key for  */
+                                /**< this stream.                        */
+    srtp_master_key_t **keys;   /** Array of Master Key structures       */
+    size_t num_master_keys;     /** Number of master keys                */
+    unsigned long window_size;  /**< The window size to use for replay   */
+                                /**< protection.                         */
+    bool allow_repeat_tx;       /**< Whether retransmissions of          */
+                                /**< packets with the same sequence      */
+                                /**< number are allowed.                 */
+                                /**< (Note that such repeated            */
+                                /**< transmissions must have the same    */
+                                /**< RTP payload, or a severe security   */
+                                /**< weakness is introduced!)            */
+    int *enc_xtn_hdr;           /**< List of header ids to encrypt.      */
+    int enc_xtn_hdr_count;      /**< Number of entries in list of header */
+                                /**<  ids.                               */
+    struct srtp_policy_t *next; /**< Pointer to next stream policy.      */
 } srtp_policy_t;
 
 /**

--- a/include/srtp_priv.h
+++ b/include/srtp_priv.h
@@ -84,7 +84,7 @@ srtp_stream_t srtp_get_stream(srtp_t srtp, uint32_t ssrc);
  */
 srtp_err_status_t srtp_stream_init_keys(srtp_stream_ctx_t *srtp,
                                         srtp_master_key_t *master_key,
-                                        const unsigned int current_mki_index);
+                                        const size_t current_mki_index);
 
 /*
  * srtp_stream_init_all_master_keys(s, k, m) (re)initializes the srtp_stream_t s
@@ -95,7 +95,7 @@ srtp_err_status_t srtp_stream_init_all_master_keys(
     srtp_stream_ctx_t *srtp,
     unsigned char *key,
     srtp_master_key_t **keys,
-    const unsigned int max_master_keys);
+    const size_t max_master_keys);
 
 /*
  * libsrtp internal datatypes
@@ -134,7 +134,7 @@ typedef struct srtp_session_keys_t {
 typedef struct srtp_stream_ctx_t_ {
     uint32_t ssrc;
     srtp_session_keys_t *session_keys;
-    unsigned int num_master_keys;
+    size_t num_master_keys;
     srtp_rdbx_t rtp_rdbx;
     srtp_sec_serv_t rtp_services;
     srtp_rdb_t rtcp_rdb;

--- a/srtp/srtp.c
+++ b/srtp/srtp.c
@@ -177,7 +177,6 @@ static srtp_err_status_t srtp_stream_dealloc(
     const srtp_stream_ctx_t *stream_template)
 {
     srtp_err_status_t status;
-    unsigned int i = 0;
     srtp_session_keys_t *session_keys = NULL;
     srtp_session_keys_t *template_session_keys = NULL;
 
@@ -187,7 +186,7 @@ static srtp_err_status_t srtp_stream_dealloc(
      * anything else
      */
     if (stream->session_keys) {
-        for (i = 0; i < stream->num_master_keys; i++) {
+        for (size_t i = 0; i < stream->num_master_keys; i++) {
             session_keys = &stream->session_keys[i];
 
             if (stream_template &&
@@ -377,7 +376,7 @@ static srtp_err_status_t srtp_stream_alloc(srtp_stream_ctx_t **str_ptr,
 {
     srtp_stream_ctx_t *str;
     srtp_err_status_t stat;
-    unsigned int i = 0;
+    size_t i = 0;
     srtp_session_keys_t *session_keys = NULL;
 
     stat = srtp_valid_policy(p);
@@ -544,7 +543,6 @@ static srtp_err_status_t srtp_stream_clone(
 {
     srtp_err_status_t status;
     srtp_stream_ctx_t *str;
-    unsigned int i = 0;
     srtp_session_keys_t *session_keys = NULL;
     const srtp_session_keys_t *template_session_keys = NULL;
 
@@ -566,7 +564,7 @@ static srtp_err_status_t srtp_stream_clone(
         return srtp_err_status_alloc_fail;
     }
 
-    for (i = 0; i < stream_template->num_master_keys; i++) {
+    for (size_t i = 0; i < stream_template->num_master_keys; i++) {
         session_keys = &str->session_keys[i];
         template_session_keys = &stream_template->session_keys[i];
 
@@ -914,13 +912,11 @@ size_t srtp_inject_mki(uint8_t *mki_tag_location,
     return mki_size;
 }
 
-srtp_err_status_t srtp_stream_init_all_master_keys(
-    srtp_stream_ctx_t *srtp,
-    unsigned char *key,
-    srtp_master_key_t **keys,
-    const unsigned int max_master_keys)
+srtp_err_status_t srtp_stream_init_all_master_keys(srtp_stream_ctx_t *srtp,
+                                                   unsigned char *key,
+                                                   srtp_master_key_t **keys,
+                                                   const size_t max_master_keys)
 {
-    unsigned int i = 0;
     srtp_err_status_t status = srtp_err_status_ok;
     srtp_master_key_t single_master_key;
 
@@ -933,8 +929,8 @@ srtp_err_status_t srtp_stream_init_all_master_keys(
     } else {
         srtp->num_master_keys = max_master_keys;
 
-        for (i = 0; i < srtp->num_master_keys && i < SRTP_MAX_NUM_MASTER_KEYS;
-             i++) {
+        for (size_t i = 0;
+             i < srtp->num_master_keys && i < SRTP_MAX_NUM_MASTER_KEYS; i++) {
             status = srtp_stream_init_keys(srtp, keys[i], i);
 
             if (status) {
@@ -948,7 +944,7 @@ srtp_err_status_t srtp_stream_init_all_master_keys(
 
 srtp_err_status_t srtp_stream_init_keys(srtp_stream_ctx_t *srtp,
                                         srtp_master_key_t *master_key,
-                                        const unsigned int current_mki_index)
+                                        const size_t current_mki_index)
 {
     srtp_err_status_t stat;
     srtp_kdf_t kdf;
@@ -1637,7 +1633,6 @@ srtp_session_keys_t *srtp_get_session_keys(srtp_stream_ctx_t *stream,
     size_t base_mki_start_location = pkt_octet_len;
     size_t mki_start_location = 0;
     size_t tag_len = 0;
-    unsigned int i = 0;
 
     // Determine the authentication tag size
     if (stream->session_keys[0].rtp_cipher->algorithm == SRTP_AES_GCM_128 ||
@@ -1654,7 +1649,7 @@ srtp_session_keys_t *srtp_get_session_keys(srtp_stream_ctx_t *stream,
 
     base_mki_start_location -= tag_len;
 
-    for (i = 0; i < stream->num_master_keys; i++) {
+    for (size_t i = 0; i < stream->num_master_keys; i++) {
         if (stream->session_keys[i].mki_size != 0 &&
             stream->session_keys[i].mki_size <= base_mki_start_location) {
             *mki_size = stream->session_keys[i].mki_size;


### PR DESCRIPTION
Change for loops to use locally-scoped size_t variables.