### PR TITLE
use uint8_t for byte and byte pointer

### DIFF
--- a/crypto/cipher/aes_gcm_mbedtls.c
+++ b/crypto/cipher/aes_gcm_mbedtls.c
@@ -213,8 +213,8 @@ static srtp_err_status_t srtp_aes_gcm_mbedtls_context_init(void *cv,
         break;
     }
 
-    errCode = mbedtls_gcm_setkey(c->ctx, MBEDTLS_CIPHER_ID_AES,
-                                 (const unsigned char *)key, key_len_in_bits);
+    errCode =
+        mbedtls_gcm_setkey(c->ctx, MBEDTLS_CIPHER_ID_AES, key, key_len_in_bits);
     if (errCode != 0) {
         debug_print(srtp_mod_aes_gcm, "mbedtls error code:  %d", errCode);
         return srtp_err_status_init_fail;
@@ -281,7 +281,7 @@ static srtp_err_status_t srtp_aes_gcm_mbedtls_set_aad(void *cv,
  *	enc_len	length of encrypt buffer
  */
 static srtp_err_status_t srtp_aes_gcm_mbedtls_encrypt(void *cv,
-                                                      unsigned char *buf,
+                                                      uint8_t *buf,
                                                       size_t *enc_len)
 {
     FUNC_ENTRY();
@@ -337,7 +337,7 @@ static srtp_err_status_t srtp_aes_gcm_mbedtls_get_tag(void *cv,
  *	enc_len	length of encrypt buffer
  */
 static srtp_err_status_t srtp_aes_gcm_mbedtls_decrypt(void *cv,
-                                                      unsigned char *buf,
+                                                      uint8_t *buf,
                                                       size_t *enc_len)
 {
     FUNC_ENTRY();

--- a/crypto/cipher/aes_gcm_nss.c
+++ b/crypto/cipher/aes_gcm_nss.c
@@ -281,7 +281,7 @@ static srtp_err_status_t srtp_aes_gcm_nss_set_aad(void *cv,
 
 static srtp_err_status_t srtp_aes_gcm_nss_do_crypto(void *cv,
                                                     int encrypt,
-                                                    unsigned char *buf,
+                                                    uint8_t *buf,
                                                     size_t *enc_len)
 {
     srtp_aes_gcm_ctx_t *c = (srtp_aes_gcm_ctx_t *)cv;
@@ -328,7 +328,7 @@ static srtp_err_status_t srtp_aes_gcm_nss_do_crypto(void *cv,
  *	enc_len	length of encrypt buffer
  */
 static srtp_err_status_t srtp_aes_gcm_nss_encrypt(void *cv,
-                                                  unsigned char *buf,
+                                                  uint8_t *buf,
                                                   size_t *enc_len)
 {
     srtp_aes_gcm_ctx_t *c = (srtp_aes_gcm_ctx_t *)cv;
@@ -338,8 +338,8 @@ static srtp_err_status_t srtp_aes_gcm_nss_encrypt(void *cv,
     // even though there's no data, we need to give NSS a buffer
     // where it can write the tag.  We can't just use c->tag because
     // memcpy has undefined behavior on overlapping ranges.
-    unsigned char tagbuf[16];
-    unsigned char *non_null_buf = buf;
+    uint8_t tagbuf[16];
+    uint8_t *non_null_buf = buf;
     if (!non_null_buf && (*enc_len == 0)) {
         non_null_buf = tagbuf;
     } else if (!non_null_buf) {
@@ -387,7 +387,7 @@ static srtp_err_status_t srtp_aes_gcm_nss_get_tag(void *cv,
  *	enc_len	length of encrypt buffer
  */
 static srtp_err_status_t srtp_aes_gcm_nss_decrypt(void *cv,
-                                                  unsigned char *buf,
+                                                  uint8_t *buf,
                                                   size_t *enc_len)
 {
     srtp_err_status_t status = srtp_aes_gcm_nss_do_crypto(cv, 0, buf, enc_len);

--- a/crypto/cipher/aes_gcm_ossl.c
+++ b/crypto/cipher/aes_gcm_ossl.c
@@ -293,7 +293,7 @@ static srtp_err_status_t srtp_aes_gcm_openssl_set_aad(void *cv,
  *	enc_len	length of encrypt buffer
  */
 static srtp_err_status_t srtp_aes_gcm_openssl_encrypt(void *cv,
-                                                      unsigned char *buf,
+                                                      uint8_t *buf,
                                                       size_t *enc_len)
 {
     srtp_aes_gcm_ctx_t *c = (srtp_aes_gcm_ctx_t *)cv;
@@ -354,7 +354,7 @@ static srtp_err_status_t srtp_aes_gcm_openssl_get_tag(void *cv,
  *	enc_len	length of encrypt buffer
  */
 static srtp_err_status_t srtp_aes_gcm_openssl_decrypt(void *cv,
-                                                      unsigned char *buf,
+                                                      uint8_t *buf,
                                                       size_t *enc_len)
 {
     srtp_aes_gcm_ctx_t *c = (srtp_aes_gcm_ctx_t *)cv;

--- a/crypto/cipher/aes_icm.c
+++ b/crypto/cipher/aes_icm.c
@@ -295,7 +295,7 @@ static void srtp_aes_icm_advance(srtp_aes_icm_ctx_t *c)
  */
 
 static srtp_err_status_t srtp_aes_icm_encrypt(void *cv,
-                                              unsigned char *buf,
+                                              uint8_t *buf,
                                               size_t *enc_len)
 {
     srtp_aes_icm_ctx_t *c = (srtp_aes_icm_ctx_t *)cv;

--- a/crypto/cipher/aes_icm_mbedtls.c
+++ b/crypto/cipher/aes_icm_mbedtls.c
@@ -290,7 +290,7 @@ static srtp_err_status_t srtp_aes_icm_mbedtls_set_iv(
  *	enc_len	length of encrypt buffer
  */
 static srtp_err_status_t srtp_aes_icm_mbedtls_encrypt(void *cv,
-                                                      unsigned char *buf,
+                                                      uint8_t *buf,
                                                       size_t *enc_len)
 {
     srtp_aes_icm_ctx_t *c = (srtp_aes_icm_ctx_t *)cv;

--- a/crypto/cipher/aes_icm_nss.c
+++ b/crypto/cipher/aes_icm_nss.c
@@ -323,7 +323,7 @@ static srtp_err_status_t srtp_aes_icm_nss_set_iv(void *cv,
  *	enc_len	length of encrypt buffer
  */
 static srtp_err_status_t srtp_aes_icm_nss_encrypt(void *cv,
-                                                  unsigned char *buf,
+                                                  uint8_t *buf,
                                                   size_t *enc_len)
 {
     srtp_aes_icm_ctx_t *c = (srtp_aes_icm_ctx_t *)cv;

--- a/crypto/cipher/aes_icm_ossl.c
+++ b/crypto/cipher/aes_icm_ossl.c
@@ -298,7 +298,7 @@ static srtp_err_status_t srtp_aes_icm_openssl_set_iv(
  *	enc_len	length of encrypt buffer
  */
 static srtp_err_status_t srtp_aes_icm_openssl_encrypt(void *cv,
-                                                      unsigned char *buf,
+                                                      uint8_t *buf,
                                                       size_t *enc_len)
 {
     srtp_aes_icm_ctx_t *c = (srtp_aes_icm_ctx_t *)cv;

--- a/crypto/cipher/null_cipher.c
+++ b/crypto/cipher/null_cipher.c
@@ -116,7 +116,7 @@ static srtp_err_status_t srtp_null_cipher_set_iv(void *cv,
 }
 
 static srtp_err_status_t srtp_null_cipher_encrypt(void *cv,
-                                                  unsigned char *buf,
+                                                  uint8_t *buf,
                                                   size_t *bytes_to_encr)
 {
     /* srtp_null_cipher_ctx_t *c = (srtp_null_cipher_ctx_t *)cv; */

--- a/crypto/include/cipher_priv.h
+++ b/crypto/include/cipher_priv.h
@@ -47,7 +47,7 @@ extern "C" {
  * A trivial platform independent random source.
  * For use in test only.
  */
-void srtp_cipher_rand_for_tests(void *dest, size_t len);
+void srtp_cipher_rand_for_tests(uint8_t *dest, size_t len);
 
 /*
  * A trivial platform independent 32 bit random number.

--- a/crypto/test/aes_calc.c
+++ b/crypto/test/aes_calc.c
@@ -112,7 +112,7 @@ int main(int argc, char *argv[])
                 AES_MAX_KEY_LEN * 2, (unsigned)strlen(argv[1]));
         exit(1);
     }
-    len = hex_string_to_octet_string((char *)key, argv[1], AES_MAX_KEY_LEN * 2);
+    len = hex_string_to_octet_string(key, argv[1], AES_MAX_KEY_LEN * 2);
     /* check that hex string is the right length */
     if (len != 32 && len != 48 && len != 64) {
         fprintf(stderr,
@@ -131,7 +131,7 @@ int main(int argc, char *argv[])
                 16 * 2, (unsigned)strlen(argv[2]));
         exit(1);
     }
-    len = hex_string_to_octet_string((char *)(&data), argv[2], 16 * 2);
+    len = hex_string_to_octet_string((uint8_t *)&data, argv[2], 16 * 2);
     /* check that hex string is the right length */
     if (len < 16 * 2) {
         fprintf(stderr,

--- a/crypto/test/cipher_driver.c
+++ b/crypto/test/cipher_driver.c
@@ -367,7 +367,7 @@ srtp_err_status_t cipher_driver_test_buffering(srtp_cipher_t *c)
         }
 
         /* initialize cipher  */
-        status = srtp_cipher_set_iv(c, (uint8_t *)idx, srtp_direction_encrypt);
+        status = srtp_cipher_set_iv(c, idx, srtp_direction_encrypt);
         if (status)
             return status;
 
@@ -377,7 +377,7 @@ srtp_err_status_t cipher_driver_test_buffering(srtp_cipher_t *c)
             return status;
 
         /* re-initialize cipher */
-        status = srtp_cipher_set_iv(c, (uint8_t *)idx, srtp_direction_encrypt);
+        status = srtp_cipher_set_iv(c, idx, srtp_direction_encrypt);
         if (status)
             return status;
 
@@ -525,7 +525,7 @@ uint64_t cipher_array_bits_per_second(srtp_cipher_t *cipher_array[],
     int i;
     v128_t nonce;
     clock_t timer;
-    unsigned char *enc_buf;
+    uint8_t *enc_buf;
     int cipher_index = srtp_cipher_rand_u32_for_tests() % num_cipher;
 
     /* Over-alloc, for NIST CBC padding */

--- a/crypto/test/datatypes_driver.c
+++ b/crypto/test/datatypes_driver.c
@@ -152,7 +152,7 @@ void test_hex_string_funcs(void)
 {
     char hex1[] = "abadcafe";
     char hex2[] = "0123456789abcdefqqqqq";
-    char raw[10];
+    uint8_t raw[10];
     size_t len;
 
     len = hex_string_to_octet_string(raw, hex1, strlen(hex1));

--- a/crypto/test/sha1_driver.c
+++ b/crypto/test/sha1_driver.c
@@ -82,15 +82,15 @@ srtp_err_status_t hash_test_case_add(hash_test_case_t **list_ptr,
     if (test_case == NULL)
         return srtp_err_status_alloc_fail;
 
-    tmp_len = hex_string_to_octet_string((char *)test_case->data, hex_data,
-                                         data_len * 2);
+    tmp_len =
+        hex_string_to_octet_string(test_case->data, hex_data, data_len * 2);
     if (tmp_len != data_len * 2) {
         free(test_case);
         return srtp_err_status_parse_err;
     }
 
-    tmp_len = hex_string_to_octet_string((char *)test_case->hash, hex_hash,
-                                         hash_len * 2);
+    tmp_len =
+        hex_string_to_octet_string(test_case->hash, hex_hash, hash_len * 2);
     if (tmp_len != hash_len * 2) {
         free(test_case);
         return srtp_err_status_parse_err;

--- a/include/srtp.h
+++ b/include/srtp.h
@@ -296,8 +296,8 @@ typedef struct {
  * Index Size to correctly read it from a packet.
  */
 typedef struct srtp_master_key_t {
-    unsigned char *key;
-    unsigned char *mki_id;
+    uint8_t *key;
+    uint8_t *mki_id;
     size_t mki_size;
 } srtp_master_key_t;
 
@@ -334,7 +334,7 @@ typedef struct srtp_policy_t {
                                 /**< is used for this policy element.    */
     srtp_crypto_policy_t rtp;   /**< SRTP crypto policy.                 */
     srtp_crypto_policy_t rtcp;  /**< SRTCP crypto policy.                */
-    unsigned char *key;         /**< Pointer to the SRTP master key for  */
+    uint8_t *key;               /**< Pointer to the SRTP master key for  */
                                 /**< this stream.                        */
     srtp_master_key_t **keys;   /** Array of Master Key structures       */
     size_t num_master_keys;     /** Number of master keys                */
@@ -422,7 +422,7 @@ srtp_err_status_t srtp_shutdown(void);
  *    - srtp_err_status_replay_fail   rtp sequence number was non-increasing
  *    - @e other                 failure in cryptographic mechanisms
  */
-srtp_err_status_t srtp_protect(srtp_t ctx, void *rtp_hdr, size_t *len_ptr);
+srtp_err_status_t srtp_protect(srtp_t ctx, uint8_t *rtp_hdr, size_t *len_ptr);
 
 /**
  * @brief srtp_protect_mki() is the Secure RTP sender-side packet processing
@@ -473,7 +473,7 @@ srtp_err_status_t srtp_protect(srtp_t ctx, void *rtp_hdr, size_t *len_ptr);
  *    - @e other                 failure in cryptographic mechanisms
  */
 srtp_err_status_t srtp_protect_mki(srtp_ctx_t *ctx,
-                                   void *rtp_hdr,
+                                   uint8_t *rtp_hdr,
                                    size_t *pkt_octet_len,
                                    bool use_mki,
                                    unsigned int mki_index);
@@ -518,7 +518,9 @@ srtp_err_status_t srtp_protect_mki(srtp_ctx_t *ctx,
  *    - [other]  if there has been an error in the cryptographic mechanisms.
  *
  */
-srtp_err_status_t srtp_unprotect(srtp_t ctx, void *srtp_hdr, size_t *len_ptr);
+srtp_err_status_t srtp_unprotect(srtp_t ctx,
+                                 uint8_t *srtp_hdr,
+                                 size_t *len_ptr);
 
 /**
  * @brief srtp_unprotect_mki() is the Secure RTP receiver-side packet
@@ -567,7 +569,7 @@ srtp_err_status_t srtp_unprotect(srtp_t ctx, void *srtp_hdr, size_t *len_ptr);
  *
  */
 srtp_err_status_t srtp_unprotect_mki(srtp_t ctx,
-                                     void *srtp_hdr,
+                                     uint8_t *srtp_hdr,
                                      size_t *len_ptr,
                                      bool use_mki);
 
@@ -1266,9 +1268,9 @@ size_t srtp_profile_get_master_salt_length(srtp_profile_t profile);
  *          available at the location pointed to by key.
  *
  */
-void srtp_append_salt_to_key(unsigned char *key,
+void srtp_append_salt_to_key(uint8_t *key,
                              size_t bytes_in_key,
-                             unsigned char *salt,
+                             uint8_t *salt,
                              size_t bytes_in_salt);
 
 /**
@@ -1332,7 +1334,7 @@ void srtp_append_salt_to_key(unsigned char *key,
  *                               the cryptographic mechanisms.
  */
 srtp_err_status_t srtp_protect_rtcp(srtp_t ctx,
-                                    void *rtcp_hdr,
+                                    uint8_t *rtcp_hdr,
                                     size_t *pkt_octet_len);
 
 /**
@@ -1381,7 +1383,7 @@ srtp_err_status_t srtp_protect_rtcp(srtp_t ctx,
  *                               the cryptographic mechanisms.
  */
 srtp_err_status_t srtp_protect_rtcp_mki(srtp_t ctx,
-                                        void *rtcp_hdr,
+                                        uint8_t *rtcp_hdr,
                                         size_t *pkt_octet_len,
                                         bool use_mki,
                                         unsigned int mki_index);
@@ -1425,7 +1427,7 @@ srtp_err_status_t srtp_protect_rtcp_mki(srtp_t ctx,
  *
  */
 srtp_err_status_t srtp_unprotect_rtcp(srtp_t ctx,
-                                      void *srtcp_hdr,
+                                      uint8_t *srtcp_hdr,
                                       size_t *pkt_octet_len);
 
 /**
@@ -1474,7 +1476,7 @@ srtp_err_status_t srtp_unprotect_rtcp(srtp_t ctx,
  *
  */
 srtp_err_status_t srtp_unprotect_rtcp_mki(srtp_t ctx,
-                                          void *srtcp_hdr,
+                                          uint8_t *srtcp_hdr,
                                           size_t *pkt_octet_len,
                                           bool use_mki);
 

--- a/include/srtp_priv.h
+++ b/include/srtp_priv.h
@@ -93,7 +93,7 @@ srtp_err_status_t srtp_stream_init_keys(srtp_stream_ctx_t *srtp,
  */
 srtp_err_status_t srtp_stream_init_all_master_keys(
     srtp_stream_ctx_t *srtp,
-    unsigned char *key,
+    uint8_t *key,
     srtp_master_key_t **keys,
     const size_t max_master_keys);
 

--- a/srtp/srtp.c
+++ b/srtp/srtp.c
@@ -2648,8 +2648,8 @@ srtp_err_status_t srtp_unprotect_mki(srtp_ctx_t *ctx,
         if (!(enc_start <= srtp_hdr + (*pkt_octet_len - tag_len - mki_size)))
             return srtp_err_status_parse_err;
 
-        enc_octet_len = *pkt_octet_len - tag_len - mki_size -
-                        (enc_start - srtp_hdr);
+        enc_octet_len =
+            *pkt_octet_len - tag_len - mki_size - (enc_start - srtp_hdr);
     } else {
         enc_start = NULL;
     }

--- a/srtp/srtp.c
+++ b/srtp/srtp.c
@@ -1824,7 +1824,7 @@ static srtp_err_status_t srtp_protect_aead(srtp_ctx_t *ctx,
     if (!(enc_start <= rtp_hdr + *pkt_octet_len))
         return srtp_err_status_parse_err;
 
-    enc_octet_len = *pkt_octet_len - (size_t)(enc_start - rtp_hdr);
+    enc_octet_len = *pkt_octet_len - (enc_start - rtp_hdr);
 
     /*
      * estimate the packet index using the start of the replay window
@@ -1895,7 +1895,7 @@ static srtp_err_status_t srtp_protect_aead(srtp_ctx_t *ctx,
     /*
      * Set the AAD over the RTP header
      */
-    aad_len = (size_t)(enc_start - rtp_hdr);
+    aad_len = enc_start - rtp_hdr;
     status = srtp_cipher_set_aad(session_keys->rtp_cipher, rtp_hdr, aad_len);
     if (status) {
         return (srtp_err_status_cipher_fail);
@@ -2005,7 +2005,7 @@ static srtp_err_status_t srtp_unprotect_aead(srtp_ctx_t *ctx,
     /*
      * We pass the tag down to the cipher when doing GCM mode
      */
-    enc_octet_len = *pkt_octet_len - mki_size - (size_t)(enc_start - srtp_hdr);
+    enc_octet_len = *pkt_octet_len - mki_size - (enc_start - srtp_hdr);
 
     /*
      * Sanity check the encrypted payload length against
@@ -2037,7 +2037,7 @@ static srtp_err_status_t srtp_unprotect_aead(srtp_ctx_t *ctx,
     /*
      * Set the AAD for AES-GCM, which is the RTP header
      */
-    aad_len = (size_t)(enc_start - srtp_hdr);
+    aad_len = enc_start - srtp_hdr;
     status = srtp_cipher_set_aad(session_keys->rtp_cipher, srtp_hdr, aad_len);
     if (status) {
         return (srtp_err_status_cipher_fail);
@@ -2280,7 +2280,7 @@ srtp_err_status_t srtp_protect_mki(srtp_ctx_t *ctx,
         if (!(enc_start <= rtp_hdr + *pkt_octet_len))
             return srtp_err_status_parse_err;
 
-        enc_octet_len = *pkt_octet_len - (size_t)(enc_start - rtp_hdr);
+        enc_octet_len = *pkt_octet_len - (enc_start - rtp_hdr);
     } else {
         enc_start = NULL;
     }
@@ -2649,7 +2649,7 @@ srtp_err_status_t srtp_unprotect_mki(srtp_ctx_t *ctx,
             return srtp_err_status_parse_err;
 
         enc_octet_len = *pkt_octet_len - tag_len - mki_size -
-                        (size_t)(enc_start - srtp_hdr);
+                        (enc_start - srtp_hdr);
     } else {
         enc_start = NULL;
     }

--- a/test/rtp.c
+++ b/test/rtp.c
@@ -74,7 +74,8 @@ ssize_t rtp_sendto(rtp_sender_t sender, const void *msg, size_t len)
     sender->message.header.ts = htonl(sender->message.header.ts);
 
     /* apply srtp */
-    stat = srtp_protect(sender->srtp_ctx, &sender->message.header, &pkt_len);
+    stat = srtp_protect(sender->srtp_ctx, (uint8_t *)&sender->message.header,
+                        &pkt_len);
     if (stat) {
 #if PRINT_DEBUG
         fprintf(stderr, "error: srtp protection failed with code %d\n", stat);
@@ -129,8 +130,8 @@ ssize_t rtp_recvfrom(rtp_receiver_t receiver, void *msg, size_t *len)
 #endif
 
     /* apply srtp */
-    stat = srtp_unprotect(receiver->srtp_ctx, &receiver->message.header,
-                          &octets_recvd);
+    stat = srtp_unprotect(receiver->srtp_ctx,
+                          (uint8_t *)&receiver->message.header, &octets_recvd);
     if (stat) {
         fprintf(stderr, "error: srtp unprotection failed with code %d%s\n",
                 stat,

--- a/test/rtp.h
+++ b/test/rtp.h
@@ -114,24 +114,6 @@ int rtp_sender_init(rtp_sender_t sender,
                     struct sockaddr_in addr,
                     uint32_t ssrc);
 
-/*
- * srtp_sender_init(...) initializes an rtp_sender_t
- */
-
-int srtp_sender_init(
-    rtp_sender_t rtp_ctx,              /* structure to be init'ed */
-    struct sockaddr_in name,           /* socket name             */
-    srtp_sec_serv_t security_services, /* sec. servs. to be used  */
-    unsigned char *input_key           /* master key/salt in hex  */
-);
-
-int srtp_receiver_init(
-    rtp_receiver_t rtp_ctx,            /* structure to be init'ed */
-    struct sockaddr_in name,           /* socket name             */
-    srtp_sec_serv_t security_services, /* sec. servs. to be used  */
-    unsigned char *input_key           /* master key/salt in hex  */
-);
-
 int rtp_sender_init_srtp(rtp_sender_t sender, const srtp_policy_t *policy);
 
 int rtp_sender_deinit_srtp(rtp_sender_t sender);

--- a/test/rtp_decoder.c
+++ b/test/rtp_decoder.c
@@ -170,7 +170,7 @@ int main(int argc, char *argv[])
     int gcm_on = 0;
     char *input_key = NULL;
     int b64_input = 0;
-    char key[MAX_KEY_LEN];
+    uint8_t key[MAX_KEY_LEN];
     struct bpf_program fp;
     char filter_exp[MAX_FILTER] = "";
     char pcap_file[MAX_FILE] = "-";
@@ -520,7 +520,7 @@ int main(int argc, char *argv[])
             return -1;
         }
 
-        policy.key = (uint8_t *)key;
+        policy.key = key;
         policy.next = NULL;
         policy.window_size = 128;
         policy.allow_repeat_tx = false;
@@ -779,14 +779,16 @@ void rtp_decoder_handle_pkt(u_char *arg,
             return;
         }
 
-        status = srtp_unprotect(dcdr->srtp_ctx, &message, &octets_recvd);
+        status =
+            srtp_unprotect(dcdr->srtp_ctx, (uint8_t *)&message, &octets_recvd);
         if (status) {
             dcdr->error_cnt++;
             return;
         }
         dcdr->rtp_cnt++;
     } else {
-        status = srtp_unprotect_rtcp(dcdr->srtp_ctx, &message, &octets_recvd);
+        status = srtp_unprotect_rtcp(dcdr->srtp_ctx, (uint8_t *)&message,
+                                     &octets_recvd);
         if (status) {
             dcdr->error_cnt++;
             return;

--- a/test/rtp_decoder.c
+++ b/test/rtp_decoder.c
@@ -556,7 +556,7 @@ int main(int argc, char *argv[])
                     expected_len, len);
             exit(1);
         }
-        if (strlen(input_key) > (size_t)policy.rtp.cipher_key_len * 2) {
+        if (strlen(input_key) > policy.rtp.cipher_key_len * 2) {
             fprintf(stderr,
                     "error: too many digits in key/salt "
                     "(should be %zu hexadecimal digits, found %u)\n",

--- a/test/rtpw.c
+++ b/test/rtpw.c
@@ -155,7 +155,7 @@ int main(int argc, char *argv[])
     char *input_key = NULL;
     int b64_input = 0;
     char *address = NULL;
-    char key[MAX_KEY_LEN];
+    uint8_t key[MAX_KEY_LEN];
     unsigned short port = 0;
     rtp_sender_t snd;
     srtp_policy_t policy;
@@ -453,7 +453,7 @@ int main(int argc, char *argv[])
         }
         policy.ssrc.type = ssrc_specific;
         policy.ssrc.value = ssrc;
-        policy.key = (uint8_t *)key;
+        policy.key = key;
         policy.next = NULL;
         policy.window_size = 128;
         policy.allow_repeat_tx = false;

--- a/test/util.c
+++ b/test/util.c
@@ -51,7 +51,7 @@
 /* include space for null terminator */
 static char bit_string[MAX_PRINT_STRING_LEN + 1];
 
-static inline int hex_char_to_nibble(uint8_t c)
+static inline int hex_char_to_nibble(char c)
 {
     switch (c) {
     case ('0'):
@@ -103,7 +103,7 @@ static inline int hex_char_to_nibble(uint8_t c)
     }
 }
 
-uint8_t nibble_to_hex_char(uint8_t nibble)
+char nibble_to_hex_char(uint8_t nibble)
 {
     char buf[16] = { '0', '1', '2', '3', '4', '5', '6', '7',
                      '8', '9', 'a', 'b', 'c', 'd', 'e', 'f' };
@@ -115,7 +115,7 @@ uint8_t nibble_to_hex_char(uint8_t nibble)
  * hex_string_to_octet_string converts a hexadecimal string
  * of length 2 * len to a raw octet string of length len
  */
-size_t hex_string_to_octet_string(char *raw, char *hex, size_t len)
+size_t hex_string_to_octet_string(uint8_t *raw, const char *hex, size_t len)
 {
     uint8_t x;
     int tmp;
@@ -141,9 +141,8 @@ size_t hex_string_to_octet_string(char *raw, char *hex, size_t len)
     return hex_len;
 }
 
-char *octet_string_hex_string(const void *s, size_t length)
+const char *octet_string_hex_string(const uint8_t *str, size_t length)
 {
-    const uint8_t *str = (const uint8_t *)s;
     size_t i;
 
     /* double length, since one octet takes two hex characters */
@@ -165,16 +164,16 @@ char *octet_string_hex_string(const void *s, size_t length)
 static const char b64chars[] = "ABCDEFGHIJKLMNOPQRSTUVWXYZ"
                                "abcdefghijklmnopqrstuvwxyz0123456789+/";
 
-static size_t base64_block_to_octet_triple(char *out, char *in)
+static size_t base64_block_to_octet_triple(uint8_t *out, const char *in)
 {
-    unsigned char sextets[4] = { 0 };
+    uint8_t sextets[4] = { 0 };
     size_t j = 0;
     size_t i;
 
     for (i = 0; i < 4; i++) {
         char *p = strchr(b64chars, in[i]);
         if (p != NULL) {
-            sextets[i] = (unsigned char)(p - b64chars);
+            sextets[i] = (uint8_t)(p - b64chars);
         } else {
             j++;
         }
@@ -190,7 +189,10 @@ static size_t base64_block_to_octet_triple(char *out, char *in)
     return j;
 }
 
-size_t base64_string_to_octet_string(char *out, int *pad, char *in, size_t len)
+size_t base64_string_to_octet_string(uint8_t *out,
+                                     int *pad,
+                                     const char *in,
+                                     size_t len)
 {
     size_t k = 0;
     size_t i = 0;

--- a/test/util.h
+++ b/test/util.h
@@ -45,14 +45,15 @@
 #define SRTP_TEST_UTIL_H
 
 #include <stddef.h>
+#include <stdint.h>
 
 #define MAX_PRINT_STRING_LEN 1024
 
-size_t hex_string_to_octet_string(char *raw, char *hex, size_t len);
-char *octet_string_hex_string(const void *s, size_t length);
-size_t base64_string_to_octet_string(char *raw,
+size_t hex_string_to_octet_string(uint8_t *raw, const char *hex, size_t len);
+const char *octet_string_hex_string(const uint8_t *str, size_t length);
+size_t base64_string_to_octet_string(uint8_t *raw,
                                      int *pad,
-                                     char *base64,
+                                     const char *base64,
                                      size_t len);
 
 #endif


### PR DESCRIPTION
This replaces "void *" in the API and usage of "unsigned char" as a byte type.

#671