### PR TITLE
Renamed srtp_octet_string_is_eq, equal is true

### DIFF
--- a/crypto/include/datatypes.h
+++ b/crypto/include/datatypes.h
@@ -163,13 +163,13 @@ void v128_left_shift(v128_t *x, size_t shift_index);
     ((((x)->v32[(bit) >> 5]) &= ~((uint32_t)1 << ((bit)&31))))
 
 /*
- * srtp_octet_string_is_eq(a, b, len) returns true if the length len strings
- * a and b are NOT equal. It returns false otherwise. The running time of the
- * comparison depends only on len, making this safe to use for (e.g.)
+ * srtp_octet_string_equal(a, b, len) returns true if the octet strings
+ * a and b are equal. It returns false otherwise. The running time of the
+ * comparison depends only on length, making this safe to use for (e.g.)
  * verifying authentication tags.
  */
 
-bool srtp_octet_string_is_eq(const uint8_t *a, const uint8_t *b, size_t len);
+bool srtp_octet_string_equal(const uint8_t *a, const uint8_t *b, size_t len);
 
 /*
  * A portable way to zero out memory as recommended by

--- a/crypto/math/datatypes.c
+++ b/crypto/math/datatypes.c
@@ -403,20 +403,20 @@ void bitvector_left_shift(bitvector_t *x, size_t shift)
 
 #endif /* defined(__SSSE3__) */
 
-bool srtp_octet_string_is_eq(const uint8_t *a, const uint8_t *b, size_t len)
+bool srtp_octet_string_equal(const uint8_t *a, const uint8_t *b, size_t length)
 {
     /*
      * We use this somewhat obscure implementation to try to ensure the running
      * time only depends on len, even accounting for compiler optimizations.
      * The accumulator ends up zero iff the strings are equal.
      */
-    const uint8_t *end = b + len;
+    const uint8_t *end = b + length;
     uint32_t accumulator = 0;
 
 #if defined(__SSE2__)
     __m128i mm_accumulator1 = _mm_setzero_si128();
     __m128i mm_accumulator2 = _mm_setzero_si128();
-    for (size_t i = 0, n = len >> 5; i < n; ++i, a += 32, b += 32) {
+    for (size_t i = 0, n = length >> 5; i < n; ++i, a += 32, b += 32) {
         __m128i mm_a1 = _mm_loadu_si128((const __m128i *)a);
         __m128i mm_b1 = _mm_loadu_si128((const __m128i *)b);
         __m128i mm_a2 = _mm_loadu_si128((const __m128i *)(a + 16));
@@ -454,7 +454,7 @@ bool srtp_octet_string_is_eq(const uint8_t *a, const uint8_t *b, size_t len)
     accumulator = _mm_cvtsi128_si32(mm_accumulator1);
 #else
     uint32_t accumulator2 = 0;
-    for (size_t i = 0, n = len >> 3; i < n; ++i, a += 8, b += 8) {
+    for (size_t i = 0, n = length >> 3; i < n; ++i, a += 8, b += 8) {
         uint32_t a_val1, b_val1;
         uint32_t a_val2, b_val2;
         memcpy(&a_val1, a, sizeof(a_val1));
@@ -481,8 +481,8 @@ bool srtp_octet_string_is_eq(const uint8_t *a, const uint8_t *b, size_t len)
         accumulator |= (*a++ ^ *b++);
     }
 
-    /* Return 1 if *not* equal. */
-    return accumulator != 0;
+    /* Return true if equal */
+    return accumulator == 0;
 }
 
 void srtp_cleanse(void *s, size_t len)

--- a/srtp.def
+++ b/srtp.def
@@ -70,5 +70,5 @@ srtp_auth_type_self_test
 srtp_auth_type_test
 srtp_replace_auth_type
 srtp_octet_string_hex_string
-srtp_octet_string_is_eq
+srtp_octet_string_equal
 srtp_rdbx_get_window_size

--- a/srtp/srtp.c
+++ b/srtp/srtp.c
@@ -2763,7 +2763,7 @@ srtp_err_status_t srtp_unprotect_mki(srtp_ctx_t *ctx,
             return srtp_err_status_auth_fail;
         }
 
-        if (srtp_octet_string_is_eq(tmp_tag, auth_tag, tag_len)) {
+        if (!srtp_octet_string_equal(tmp_tag, auth_tag, tag_len)) {
             return srtp_err_status_auth_fail;
         }
     }
@@ -4414,7 +4414,7 @@ srtp_err_status_t srtp_unprotect_rtcp_mki(srtp_t ctx,
     /* compare the tag just computed with the one in the packet */
     debug_print(mod_srtp, "srtcp tag from packet:    %s",
                 srtp_octet_string_hex_string(auth_tag, tag_len));
-    if (srtp_octet_string_is_eq(tmp_tag, auth_tag, tag_len)) {
+    if (!srtp_octet_string_equal(tmp_tag, auth_tag, tag_len)) {
         return srtp_err_status_auth_fail;
     }
 

--- a/test/srtp_driver.c
+++ b/test/srtp_driver.c
@@ -1837,7 +1837,7 @@ srtp_err_status_t srtp_validate(void)
     debug_print(mod_driver, "ciphertext reference:\n  %s",
                 octet_string_hex_string(srtp_ciphertext, len));
 
-    if (srtp_octet_string_is_eq(srtp_plaintext, srtp_ciphertext, len)) {
+    if (!srtp_octet_string_equal(srtp_plaintext, srtp_ciphertext, len)) {
         return srtp_err_status_fail;
     }
 
@@ -1855,7 +1855,7 @@ srtp_err_status_t srtp_validate(void)
     debug_print(mod_driver, "srtcp ciphertext reference:\n  %s",
                 octet_string_hex_string(srtcp_ciphertext, len));
 
-    if (srtp_octet_string_is_eq(rtcp_plaintext, srtcp_ciphertext, len)) {
+    if (!srtp_octet_string_equal(rtcp_plaintext, srtcp_ciphertext, len)) {
         return srtp_err_status_fail;
     }
 
@@ -1877,7 +1877,7 @@ srtp_err_status_t srtp_validate(void)
         return status;
     }
 
-    if (srtp_octet_string_is_eq(srtp_ciphertext, srtp_plaintext_ref, len)) {
+    if (!srtp_octet_string_equal(srtp_ciphertext, srtp_plaintext_ref, len)) {
         return srtp_err_status_fail;
     }
 
@@ -1890,7 +1890,7 @@ srtp_err_status_t srtp_validate(void)
         return status;
     }
 
-    if (srtp_octet_string_is_eq(srtcp_ciphertext, rtcp_plaintext_ref, len)) {
+    if (!srtp_octet_string_equal(srtcp_ciphertext, rtcp_plaintext_ref, len)) {
         return srtp_err_status_fail;
     }
 
@@ -1996,7 +1996,7 @@ srtp_err_status_t srtp_validate_null(void)
     debug_print(mod_driver, "ciphertext reference:\n  %s",
                 octet_string_hex_string(srtp_ciphertext, len));
 
-    if (srtp_octet_string_is_eq(srtp_plaintext, srtp_ciphertext, len)) {
+    if (!srtp_octet_string_equal(srtp_plaintext, srtp_ciphertext, len)) {
         return srtp_err_status_fail;
     }
 
@@ -2014,7 +2014,7 @@ srtp_err_status_t srtp_validate_null(void)
     debug_print(mod_driver, "srtcp ciphertext reference:\n  %s",
                 octet_string_hex_string(srtcp_ciphertext, len));
 
-    if (srtp_octet_string_is_eq(rtcp_plaintext, srtcp_ciphertext, len)) {
+    if (!srtp_octet_string_equal(rtcp_plaintext, srtcp_ciphertext, len)) {
         return srtp_err_status_fail;
     }
 
@@ -2036,7 +2036,7 @@ srtp_err_status_t srtp_validate_null(void)
         return status;
     }
 
-    if (srtp_octet_string_is_eq(srtp_ciphertext, srtp_plaintext_ref, len)) {
+    if (!srtp_octet_string_equal(srtp_ciphertext, srtp_plaintext_ref, len)) {
         return srtp_err_status_fail;
     }
 
@@ -2049,7 +2049,7 @@ srtp_err_status_t srtp_validate_null(void)
         return status;
     }
 
-    if (srtp_octet_string_is_eq(srtcp_ciphertext, rtcp_plaintext_ref, len)) {
+    if (!srtp_octet_string_equal(srtcp_ciphertext, rtcp_plaintext_ref, len)) {
         return srtp_err_status_fail;
     }
 
@@ -2157,7 +2157,7 @@ srtp_err_status_t srtp_validate_gcm(void)
     debug_print(mod_driver, "srtp ciphertext reference:\n  %s",
                 octet_string_hex_string(srtp_ciphertext, len));
 
-    if (srtp_octet_string_is_eq(rtp_plaintext, srtp_ciphertext, len)) {
+    if (!srtp_octet_string_equal(rtp_plaintext, srtp_ciphertext, len)) {
         return srtp_err_status_fail;
     }
 
@@ -2175,7 +2175,7 @@ srtp_err_status_t srtp_validate_gcm(void)
     debug_print(mod_driver, "srtcp ciphertext reference:\n  %s",
                 octet_string_hex_string(srtcp_ciphertext, len));
 
-    if (srtp_octet_string_is_eq(rtcp_plaintext, srtcp_ciphertext, len)) {
+    if (!srtp_octet_string_equal(rtcp_plaintext, srtcp_ciphertext, len)) {
         return srtp_err_status_fail;
     }
 
@@ -2198,7 +2198,7 @@ srtp_err_status_t srtp_validate_gcm(void)
         return status;
     }
 
-    if (srtp_octet_string_is_eq(srtp_ciphertext, rtp_plaintext_ref, len)) {
+    if (!srtp_octet_string_equal(srtp_ciphertext, rtp_plaintext_ref, len)) {
         return srtp_err_status_fail;
     }
 
@@ -2217,7 +2217,7 @@ srtp_err_status_t srtp_validate_gcm(void)
                 octet_string_hex_string(rtcp_plaintext_ref,
                                         sizeof(rtcp_plaintext_ref)));
 
-    if (srtp_octet_string_is_eq(srtcp_ciphertext, rtcp_plaintext_ref, len)) {
+    if (!srtp_octet_string_equal(srtcp_ciphertext, rtcp_plaintext_ref, len)) {
         return srtp_err_status_fail;
     }
 
@@ -2321,7 +2321,7 @@ srtp_err_status_t srtp_validate_encrypted_extensions_headers(void)
     debug_print(mod_driver, "ciphertext reference:\n  %s",
                 srtp_octet_string_hex_string(srtp_ciphertext, len));
 
-    if (srtp_octet_string_is_eq(srtp_plaintext, srtp_ciphertext, len)) {
+    if (!srtp_octet_string_equal(srtp_plaintext, srtp_ciphertext, len)) {
         return srtp_err_status_fail;
     }
 
@@ -2345,7 +2345,7 @@ srtp_err_status_t srtp_validate_encrypted_extensions_headers(void)
         return srtp_err_status_fail;
     }
 
-    if (srtp_octet_string_is_eq(srtp_ciphertext, srtp_plaintext_ref, len)) {
+    if (!srtp_octet_string_equal(srtp_ciphertext, srtp_plaintext_ref, len)) {
         return srtp_err_status_fail;
     }
 
@@ -2450,7 +2450,7 @@ srtp_err_status_t srtp_validate_encrypted_extensions_headers_gcm(void)
     debug_print(mod_driver, " ? ciphertext reference:\n  %s",
                 srtp_octet_string_hex_string(srtp_ciphertext, len));
 
-    if (srtp_octet_string_is_eq(srtp_plaintext, srtp_ciphertext, len)) {
+    if (!srtp_octet_string_equal(srtp_plaintext, srtp_ciphertext, len)) {
         return srtp_err_status_fail;
     }
 
@@ -2474,7 +2474,7 @@ srtp_err_status_t srtp_validate_encrypted_extensions_headers_gcm(void)
         return srtp_err_status_fail;
     }
 
-    if (srtp_octet_string_is_eq(srtp_ciphertext, srtp_plaintext_ref, len)) {
+    if (!srtp_octet_string_equal(srtp_ciphertext, srtp_plaintext_ref, len)) {
         return srtp_err_status_fail;
     }
 
@@ -2570,7 +2570,7 @@ srtp_err_status_t srtp_validate_aes_256(void)
     debug_print(mod_driver, "ciphertext reference:\n  %s",
                 octet_string_hex_string(srtp_ciphertext, len));
 
-    if (srtp_octet_string_is_eq(srtp_plaintext, srtp_ciphertext, len)) {
+    if (!srtp_octet_string_equal(srtp_plaintext, srtp_ciphertext, len)) {
         return srtp_err_status_fail;
     }
 
@@ -2592,7 +2592,7 @@ srtp_err_status_t srtp_validate_aes_256(void)
         return status;
     }
 
-    if (srtp_octet_string_is_eq(srtp_ciphertext, srtp_plaintext_ref, len)) {
+    if (!srtp_octet_string_equal(srtp_ciphertext, srtp_plaintext_ref, len)) {
         return srtp_err_status_fail;
     }
 


### PR DESCRIPTION
This PR renames `srtp_octet_string_is_eq()` to `srtp_octet_string_equal()` and switches the logic of the return value. That function returned `false` if equal, which was opposite of what the name suggests.

However, every test is actually looking for inequality.  As such, perhaps a better name might be `srtp_octet_string_unequal()` or something?  I don't care what we name this, but I'd prefer for the name reflect what it's doing.