### PR TITLE
make MKI a stream level setting

### DIFF
--- a/fuzzer/fuzzer.c
+++ b/fuzzer/fuzzer.c
@@ -279,7 +279,6 @@ static srtp_master_key_t *extract_master_key(const uint8_t **data,
 
     EXTRACT(ret->key, *data, *size, key_size);
     EXTRACT(ret->mki_id, *data, *size, mki_id_size);
-    ret->mki_size = mki_id_size;
 end:
     return ret;
 }

--- a/fuzzer/fuzzer.h
+++ b/fuzzer/fuzzer.h
@@ -23,11 +23,9 @@
 #error "Cannot detect word size"
 #endif
 
-typedef srtp_err_status_t (
-    *fuzz_srtp_func)(srtp_t, void *, size_t *, uint8_t, size_t);
+typedef srtp_err_status_t (*fuzz_srtp_func)(srtp_t, void *, size_t *, size_t);
 typedef void (*fuzz_srtp_crypto_policy_func)(srtp_crypto_policy_t *);
 typedef srtp_err_status_t (*fuzz_srtp_get_length_func)(const srtp_t,
-                                                       uint8_t,
                                                        size_t,
                                                        size_t *);
 
@@ -45,60 +43,25 @@ struct fuzz_srtp_params {
 static srtp_err_status_t fuzz_srtp_protect(srtp_t srtp_sender,
                                            void *hdr,
                                            size_t *len,
-                                           uint8_t use_mki,
                                            size_t mki);
 static srtp_err_status_t fuzz_srtp_unprotect(srtp_t srtp_sender,
                                              void *hdr,
                                              size_t *len,
-                                             uint8_t use_mki,
                                              size_t mki);
 static srtp_err_status_t fuzz_srtp_protect_rtcp(srtp_t srtp_sender,
                                                 void *hdr,
                                                 size_t *len,
-                                                uint8_t use_mki,
                                                 size_t mki);
 static srtp_err_status_t fuzz_srtp_unprotect_rtcp(srtp_t srtp_sender,
                                                   void *hdr,
                                                   size_t *len,
-                                                  uint8_t use_mki,
                                                   size_t mki);
-static srtp_err_status_t fuzz_srtp_protect_mki(srtp_t srtp_sender,
-                                               void *hdr,
-                                               size_t *len,
-                                               uint8_t use_mki,
-                                               size_t mki);
-static srtp_err_status_t fuzz_srtp_protect_rtcp_mki(srtp_t srtp_sender,
-                                                    void *hdr,
-                                                    size_t *len,
-                                                    uint8_t use_mki,
-                                                    size_t mki);
-static srtp_err_status_t fuzz_srtp_unprotect_mki(srtp_t srtp_sender,
-                                                 void *hdr,
-                                                 size_t *len,
-                                                 uint8_t use_mki,
-                                                 size_t mki);
-static srtp_err_status_t fuzz_srtp_unprotect_rtcp_mki(srtp_t srtp_sender,
-                                                      void *hdr,
-                                                      size_t *len,
-                                                      uint8_t use_mki,
-                                                      size_t mki);
 
 static srtp_err_status_t fuzz_srtp_get_protect_length(const srtp_t srtp_ctx,
-                                                      uint8_t use_mki,
                                                       size_t mki,
                                                       size_t *length);
-static srtp_err_status_t fuzz_srtp_get_protect_mki_length(const srtp_t srtp_ctx,
-                                                          uint8_t use_mki,
-                                                          size_t mki,
-                                                          size_t *length);
 static srtp_err_status_t fuzz_srtp_get_protect_rtcp_length(
     const srtp_t srtp_ctx,
-    uint8_t use_mki,
-    size_t mki,
-    size_t *length);
-static srtp_err_status_t fuzz_srtp_get_protect_rtcp_mki_length(
-    const srtp_t srtp_ctx,
-    uint8_t use_mki,
     size_t mki,
     size_t *length);
 
@@ -112,11 +75,7 @@ const struct fuzz_srtp_func_ext srtp_funcs[] = {
     { fuzz_srtp_protect, true, fuzz_srtp_get_protect_length },
     { fuzz_srtp_unprotect, false, NULL },
     { fuzz_srtp_protect_rtcp, true, fuzz_srtp_get_protect_rtcp_length },
-    { fuzz_srtp_unprotect_rtcp, false, NULL },
-    { fuzz_srtp_protect_mki, true, fuzz_srtp_get_protect_mki_length },
-    { fuzz_srtp_unprotect_mki, false, NULL },
-    { fuzz_srtp_protect_rtcp_mki, true, fuzz_srtp_get_protect_rtcp_mki_length },
-    { fuzz_srtp_unprotect_rtcp_mki, false, NULL }
+    { fuzz_srtp_unprotect_rtcp, false, NULL }
 };
 
 struct fuzz_srtp_crypto_policy_func_ext {

--- a/include/srtp.h
+++ b/include/srtp.h
@@ -338,6 +338,7 @@ typedef struct srtp_policy_t {
                                 /**< this stream.                        */
     srtp_master_key_t **keys;   /** Array of Master Key structures       */
     size_t num_master_keys;     /** Number of master keys                */
+    bool use_mki;               /** Whether MKI is in use                */
     size_t window_size;         /**< The window size to use for replay   */
                                 /**< protection.                         */
     bool allow_repeat_tx;       /**< Whether retransmissions of          */
@@ -417,66 +418,18 @@ srtp_err_status_t srtp_shutdown(void);
  * complete SRTP packet after the call, if srtp_err_status_ok was returned.
  * Otherwise, the value of the data to which it points is undefined.
  *
- * @return
- *    - srtp_err_status_ok            no problems
- *    - srtp_err_status_replay_fail   rtp sequence number was non-increasing
- *    - @e other                 failure in cryptographic mechanisms
- */
-srtp_err_status_t srtp_protect(srtp_t ctx, uint8_t *rtp_hdr, size_t *len_ptr);
-
-/**
- * @brief srtp_protect_mki() is the Secure RTP sender-side packet processing
- * function that can utilize MKI.
- *
- * The function call srtp_protect(ctx, rtp_hdr, len_ptr) applies SRTP
- * protection to the RTP packet rtp_hdr (which has length *len_ptr) using
- * the SRTP context ctx.  If srtp_err_status_ok is returned, then rtp_hdr
- * points to the resulting SRTP packet and *len_ptr is the number of
- * octets in that packet; otherwise, no assumptions should be made
- * about the value of either data elements.
- *
- * The sequence numbers of the RTP packets presented to this function
- * need not be consecutive, but they @b must be out of order by less
- * than 2^15 = 32,768 packets.
- *
- * @warning This function assumes that it can write the authentication
- * tag into the location in memory immediately following the RTP
- * packet, and assumes that the RTP packet is aligned on a 32-bit
- * boundary.
- *
- * @warning This function assumes that it can write SRTP_MAX_TRAILER_LEN
- * into the location in memory immediately following the RTP packet.
- * Callers MUST ensure that this much writable memory is available in
- * the buffer that holds the RTP packet.
- *
- * @param ctx is the SRTP context to use in processing the packet.
- *
- * @param rtp_hdr is a pointer to the RTP packet (before the call); after
- * the function returns, it points to the srtp packet.
- *
- * @param pkt_octet_len is a pointer to the length in octets of the complete
- * RTP packet (header and body) before the function call, and of the
- * complete SRTP packet after the call, if srtp_err_status_ok was returned.
- * Otherwise, the value of the data to which it points is undefined.
- *
- * @param use_mki is a boolean to tell the system if mki is being used.  If
- * set to false then will use the first set of session keys.  If set to true
- * will
- * use the session keys identified by the mki_index
- *
  * @param mki_index integer value specifying which set of session keys should be
- * used if use_mki is set to true.
+ * used if use_mki in the policy was set to true. Otherwise ignored.
  *
  * @return
  *    - srtp_err_status_ok            no problems
  *    - srtp_err_status_replay_fail   rtp sequence number was non-increasing
  *    - @e other                 failure in cryptographic mechanisms
  */
-srtp_err_status_t srtp_protect_mki(srtp_ctx_t *ctx,
-                                   uint8_t *rtp_hdr,
-                                   size_t *pkt_octet_len,
-                                   bool use_mki,
-                                   size_t mki_index);
+srtp_err_status_t srtp_protect(srtp_ctx_t *ctx,
+                               uint8_t *rtp_hdr,
+                               size_t *pkt_octet_len,
+                               size_t mki_index);
 
 /**
  * @brief srtp_unprotect() is the Secure RTP receiver-side packet
@@ -515,63 +468,13 @@ srtp_err_status_t srtp_protect_mki(srtp_ctx_t *ctx,
  *                                  authentication check.
  *    - srtp_err_status_replay_fail if the SRTP packet is a replay (e.g. packet
  *                                  has already been processed and accepted).
+ *    - srtp_err_status_bad_mki if the MKI in the packet is not a known MKI id
  *    - [other]  if there has been an error in the cryptographic mechanisms.
  *
  */
 srtp_err_status_t srtp_unprotect(srtp_t ctx,
                                  uint8_t *srtp_hdr,
                                  size_t *len_ptr);
-
-/**
- * @brief srtp_unprotect_mki() is the Secure RTP receiver-side packet
- * processing function that checks for MKI.
- *
- * The function call srtp_unprotect(ctx, srtp_hdr, len_ptr) verifies
- * the Secure RTP protection of the SRTP packet pointed to by srtp_hdr
- * (which has length *len_ptr), using the SRTP context ctx.  If
- * srtp_err_status_ok is returned, then srtp_hdr points to the resulting
- * RTP packet and *len_ptr is the number of octets in that packet;
- * otherwise, no assumptions should be made about the value of either
- * data elements.
- *
- * The sequence numbers of the RTP packets presented to this function
- * need not be consecutive, but they @b must be out of order by less
- * than 2^15 = 32,768 packets.
- *
- * @warning This function assumes that the SRTP packet is aligned on a
- * 32-bit boundary.
- *
- * @param ctx is the SRTP session which applies to the particular packet.
- *
- * @param srtp_hdr is a pointer to the header of the SRTP packet
- * (before the call).  after the function returns, it points to the
- * rtp packet if srtp_err_status_ok was returned; otherwise, the value of
- * the data to which it points is undefined.
- *
- * @param len_ptr is a pointer to the length in octets of the complete
- * srtp packet (header and body) before the function call, and of the
- * complete rtp packet after the call, if srtp_err_status_ok was returned.
- * Otherwise, the value of the data to which it points is undefined.
- *
- * @param use_mki is a boolean to tell the system if mki is being used.  If
- * set to false then will use the first set of session keys.  If set to true
- * will
- * use the session keys identified by the mki_index
- *
- * @return
- *    - srtp_err_status_ok          if the RTP packet is valid.
- *    - srtp_err_status_auth_fail   if the SRTP packet failed the message
- *                                  authentication check.
- *    - srtp_err_status_replay_fail if the SRTP packet is a replay (e.g. packet
- *                                  has already been processed and accepted).
- *    - srtp_err_status_bad_mki if the MKI in the packet is not a known MKI id
- *    - [other]  if there has been an error in the cryptographic mechanisms.
- *
- */
-srtp_err_status_t srtp_unprotect_mki(srtp_t ctx,
-                                     uint8_t *srtp_hdr,
-                                     size_t *len_ptr,
-                                     bool use_mki);
 
 /**
  * @brief srtp_create() allocates and initializes an SRTP session.
@@ -1236,6 +1139,9 @@ void srtp_append_salt_to_key(uint8_t *key,
  * was returned.  Otherwise, the value of the data to which it points
  * is undefined.
  *
+ * @param mki_index integer value specifying which set of session keys should be
+ * used if use_mki was set to true. Otherwise ignored.
+ *
  * @return
  *    - srtp_err_status_ok            if there were no problems.
  *    - [other]                  if there was a failure in
@@ -1243,58 +1149,8 @@ void srtp_append_salt_to_key(uint8_t *key,
  */
 srtp_err_status_t srtp_protect_rtcp(srtp_t ctx,
                                     uint8_t *rtcp_hdr,
-                                    size_t *pkt_octet_len);
-
-/**
- * @brief srtp_protect_rtcp_mki() is the Secure RTCP sender-side packet
- * processing function that can utilize mki.
- *
- * The function call srtp_protect_rtcp(ctx, rtp_hdr, len_ptr) applies
- * SRTCP protection to the RTCP packet rtcp_hdr (which has length
- * *len_ptr) using the SRTP session context ctx.  If srtp_err_status_ok is
- * returned, then rtp_hdr points to the resulting SRTCP packet and
- * *len_ptr is the number of octets in that packet; otherwise, no
- * assumptions should be made about the value of either data elements.
- *
- * @warning This function assumes that it can write the authentication
- * tag into the location in memory immediately following the RTCP
- * packet, and assumes that the RTCP packet is aligned on a 32-bit
- * boundary.
- *
- * @warning This function assumes that it can write SRTP_MAX_SRTCP_TRAILER_LEN
- * into the location in memory immediately following the RTCP packet.
- * Callers MUST ensure that this much writable memory is available in
- * the buffer that holds the RTCP packet.
- *
- * @param ctx is the SRTP context to use in processing the packet.
- *
- * @param rtcp_hdr is a pointer to the RTCP packet (before the call); after
- * the function returns, it points to the srtp packet.
- *
- * @param pkt_octet_len is a pointer to the length in octets of the
- * complete RTCP packet (header and body) before the function call,
- * and of the complete SRTCP packet after the call, if srtp_err_status_ok
- * was returned.  Otherwise, the value of the data to which it points
- * is undefined.
- *
- * @param use_mki is a boolean to tell the system if mki is being used.  If
- * set to false then will use the first set of session keys.  If set to true
- * will
- * use the session keys identified by the mki_index
- *
- * @param mki_index integer value specifying which set of session keys should be
- * used if use_mki is set to true.
- *
- * @return
- *    - srtp_err_status_ok            if there were no problems.
- *    - [other]                  if there was a failure in
- *                               the cryptographic mechanisms.
- */
-srtp_err_status_t srtp_protect_rtcp_mki(srtp_t ctx,
-                                        uint8_t *rtcp_hdr,
-                                        size_t *pkt_octet_len,
-                                        bool use_mki,
-                                        size_t mki_index);
+                                    size_t *pkt_octet_len,
+                                    size_t mki_index);
 
 /**
  * @brief srtp_unprotect_rtcp() is the Secure RTCP receiver-side packet
@@ -1331,62 +1187,14 @@ srtp_err_status_t srtp_protect_rtcp_mki(srtp_t ctx,
  *                             authentication check.
  *    - srtp_err_status_replay_fail if the SRTCP packet is a replay (e.g. has
  *                             already been processed and accepted).
+ *    - srtp_err_status_bad_mki     if the MKI in the packet is not a known MKI
+ *                                  id
  *    - [other]  if there has been an error in the cryptographic mechanisms.
  *
  */
 srtp_err_status_t srtp_unprotect_rtcp(srtp_t ctx,
                                       uint8_t *srtcp_hdr,
                                       size_t *pkt_octet_len);
-
-/**
- * @brief srtp_unprotect_rtcp() is the Secure RTCP receiver-side packet
- * processing function.
- *
- * The function call srtp_unprotect_rtcp(ctx, srtp_hdr, len_ptr)
- * verifies the Secure RTCP protection of the SRTCP packet pointed to
- * by srtcp_hdr (which has length *len_ptr), using the SRTP session
- * context ctx.  If srtp_err_status_ok is returned, then srtcp_hdr points
- * to the resulting RTCP packet and *len_ptr is the number of octets
- * in that packet; otherwise, no assumptions should be made about the
- * value of either data elements.
- *
- * @warning This function assumes that the SRTCP packet is aligned on a
- * 32-bit boundary.
- *
- * @param ctx is a pointer to the srtp_t which applies to the
- * particular packet.
- *
- * @param srtcp_hdr is a pointer to the header of the SRTCP packet
- * (before the call).  After the function returns, it points to the
- * rtp packet if srtp_err_status_ok was returned; otherwise, the value of
- * the data to which it points is undefined.
- *
- * @param pkt_octet_len is a pointer to the length in octets of the
- * complete SRTCP packet (header and body) before the function call,
- * and of the complete rtp packet after the call, if srtp_err_status_ok was
- * returned.  Otherwise, the value of the data to which it points is
- * undefined.
- *
- * @param use_mki is a boolean to tell the system if mki is being used.  If
- * set to false then will use the first set of session keys.  If set to true
- * will use the session keys identified by the mki_index
- *
- * @return
- *    - srtp_err_status_ok          if the RTCP packet is valid.
- *    - srtp_err_status_auth_fail   if the SRTCP packet failed the message
- *                                  authentication check.
- *    - srtp_err_status_replay_fail if the SRTCP packet is a replay (e.g. has
- *                                  already been processed and accepted).
- *    - srtp_err_status_bad_mki     if the MKI in the packet is not a known MKI
- *                                  id
- *    - [other]                     if there has been an error in the
- *                                  cryptographic mechanisms.
- *
- */
-srtp_err_status_t srtp_unprotect_rtcp_mki(srtp_t ctx,
-                                          uint8_t *srtcp_hdr,
-                                          size_t *pkt_octet_len,
-                                          bool use_mki);
 
 /**
  * @}
@@ -1613,7 +1421,6 @@ srtp_err_status_t srtp_install_log_handler(srtp_log_handler_func_t func,
  *
  */
 srtp_err_status_t srtp_get_protect_trailer_length(srtp_t session,
-                                                  bool use_mki,
                                                   size_t mki_index,
                                                   size_t *length);
 
@@ -1630,7 +1437,6 @@ srtp_err_status_t srtp_get_protect_trailer_length(srtp_t session,
  *
  */
 srtp_err_status_t srtp_get_protect_rtcp_trailer_length(srtp_t session,
-                                                       bool use_mki,
                                                        size_t mki_index,
                                                        size_t *length);
 

--- a/include/srtp.h
+++ b/include/srtp.h
@@ -292,13 +292,11 @@ typedef struct {
 /**
  * @brief srtp_master_key_t represents a master key.  There will
  * be a Master Key Index and the Master Key associated with the
- * Master Key Index.  Need to also keep track of the Master Key
- * Index Size to correctly read it from a packet.
+ * Master Key Index.
  */
 typedef struct srtp_master_key_t {
     uint8_t *key;
     uint8_t *mki_id;
-    size_t mki_size;
 } srtp_master_key_t;
 
 /**
@@ -339,6 +337,7 @@ typedef struct srtp_policy_t {
     srtp_master_key_t **keys;   /** Array of Master Key structures       */
     size_t num_master_keys;     /** Number of master keys                */
     bool use_mki;               /** Whether MKI is in use                */
+    size_t mki_size;            /** Size of MKI when in use              */
     size_t window_size;         /**< The window size to use for replay   */
                                 /**< protection.                         */
     bool allow_repeat_tx;       /**< Whether retransmissions of          */

--- a/include/srtp_priv.h
+++ b/include/srtp_priv.h
@@ -79,25 +79,6 @@ typedef struct srtp_stream_list_ctx_t_ *srtp_stream_list_t;
 srtp_stream_t srtp_get_stream(srtp_t srtp, uint32_t ssrc);
 
 /*
- * srtp_stream_init_keys(s, k) (re)initializes the srtp_stream_t s by
- * deriving all of the needed keys using the KDF and the key k.
- */
-srtp_err_status_t srtp_stream_init_keys(srtp_stream_ctx_t *srtp,
-                                        srtp_master_key_t *master_key,
-                                        const size_t current_mki_index);
-
-/*
- * srtp_stream_init_all_master_keys(s, k, m) (re)initializes the srtp_stream_t s
- * by deriving all of the needed keys for all the master keys using the KDF and
- * the keys from k.
- */
-srtp_err_status_t srtp_stream_init_all_master_keys(
-    srtp_stream_ctx_t *srtp,
-    uint8_t *key,
-    srtp_master_key_t **keys,
-    const size_t max_master_keys);
-
-/*
  * libsrtp internal datatypes
  */
 typedef enum direction_t {
@@ -135,6 +116,7 @@ typedef struct srtp_stream_ctx_t_ {
     uint32_t ssrc;
     srtp_session_keys_t *session_keys;
     size_t num_master_keys;
+    bool use_mki;
     srtp_rdbx_t rtp_rdbx;
     srtp_sec_serv_t rtp_services;
     srtp_rdb_t rtcp_rdb;

--- a/include/srtp_priv.h
+++ b/include/srtp_priv.h
@@ -101,7 +101,6 @@ typedef struct srtp_session_keys_t {
     uint8_t salt[SRTP_AEAD_SALT_LEN];
     uint8_t c_salt[SRTP_AEAD_SALT_LEN];
     uint8_t *mki_id;
-    size_t mki_size;
     srtp_key_limit_ctx_t *limit;
 } srtp_session_keys_t;
 
@@ -117,6 +116,7 @@ typedef struct srtp_stream_ctx_t_ {
     srtp_session_keys_t *session_keys;
     size_t num_master_keys;
     bool use_mki;
+    size_t mki_size;
     srtp_rdbx_t rtp_rdbx;
     srtp_sec_serv_t rtp_services;
     srtp_rdb_t rtcp_rdb;

--- a/srtp.def
+++ b/srtp.def
@@ -2,9 +2,7 @@ EXPORTS
 srtp_init
 srtp_shutdown
 srtp_protect
-srtp_protect_mki
 srtp_unprotect
-srtp_unprotect_mki
 srtp_create
 srtp_stream_add
 srtp_stream_remove
@@ -34,9 +32,7 @@ srtp_append_salt_to_key
 srtp_get_protect_trailer_length
 srtp_get_protect_rtcp_trailer_length
 srtp_protect_rtcp
-srtp_protect_rtcp_mki
 srtp_unprotect_rtcp
-srtp_unprotect_rtcp_mki
 srtp_stream_set_roc
 srtp_set_user_data
 srtp_stream_get_roc

--- a/test/rtp.c
+++ b/test/rtp.c
@@ -75,7 +75,7 @@ ssize_t rtp_sendto(rtp_sender_t sender, const void *msg, size_t len)
 
     /* apply srtp */
     stat = srtp_protect(sender->srtp_ctx, (uint8_t *)&sender->message.header,
-                        &pkt_len);
+                        &pkt_len, 0);
     if (stat) {
 #if PRINT_DEBUG
         fprintf(stderr, "error: srtp protection failed with code %d\n", stat);

--- a/test/srtp_driver.c
+++ b/test/srtp_driver.c
@@ -62,6 +62,8 @@
 
 srtp_err_status_t srtp_validate(void);
 
+srtp_err_status_t srtp_validate_mki(void);
+
 srtp_err_status_t srtp_validate_null(void);
 
 #ifdef GCM
@@ -455,6 +457,19 @@ int main(int argc, char *argv[])
         printf("testing srtp_protect and srtp_unprotect against "
                "reference packet\n");
         if (srtp_validate() == srtp_err_status_ok) {
+            printf("passed\n\n");
+        } else {
+            printf("failed\n");
+            exit(1);
+        }
+
+        /*
+         * run validation test against the reference packets - note
+         * that this test only covers the default policy
+         */
+        printf("testing srtp_protect and srtp_unprotect against "
+               "reference packet using mki\n");
+        if (srtp_validate_mki() == srtp_err_status_ok) {
             printf("passed\n\n");
         } else {
             printf("failed\n");
@@ -964,7 +979,7 @@ double srtp_bits_per_second(size_t msg_len_octets, const srtp_policy_t *policy)
     for (size_t i = 0; i < num_trials; i++) {
         len = input_len;
         /* srtp protect message */
-        status = srtp_protect(srtp, mesg, &len);
+        status = srtp_protect(srtp, mesg, &len, 0);
         if (status) {
             printf("error: srtp_protect() failed with error code %d\n", status);
             exit(1);
@@ -1016,7 +1031,7 @@ double srtp_rejections_per_second(size_t msg_len_octets,
     if (mesg == NULL) {
         return 0.0; /* indicate failure by returning zero */
     }
-    srtp_protect(srtp, mesg, &len);
+    srtp_protect(srtp, mesg, &len, 0);
 
     timer = clock();
     for (size_t i = 0; i < num_trials; i++) {
@@ -1044,56 +1059,6 @@ void err_check(srtp_err_status_t s)
     }
 }
 
-srtp_err_status_t srtp_test_call_protect(srtp_t srtp_sender,
-                                         uint8_t *hdr,
-                                         size_t *len,
-                                         bool use_mki,
-                                         size_t mki_index)
-{
-    if (!use_mki) {
-        return srtp_protect(srtp_sender, hdr, len);
-    } else {
-        return srtp_protect_mki(srtp_sender, hdr, len, true, mki_index);
-    }
-}
-
-srtp_err_status_t srtp_test_call_protect_rtcp(srtp_t srtp_sender,
-                                              uint8_t *hdr,
-                                              size_t *len,
-                                              bool use_mki,
-                                              size_t mki_index)
-{
-    if (!use_mki) {
-        return srtp_protect_rtcp(srtp_sender, hdr, len);
-    } else {
-        return srtp_protect_rtcp_mki(srtp_sender, hdr, len, true, mki_index);
-    }
-}
-
-srtp_err_status_t srtp_test_call_unprotect(srtp_t srtp_sender,
-                                           uint8_t *hdr,
-                                           size_t *len,
-                                           bool use_mki)
-{
-    if (!use_mki) {
-        return srtp_unprotect(srtp_sender, hdr, len);
-    } else {
-        return srtp_unprotect_mki(srtp_sender, hdr, len, use_mki);
-    }
-}
-
-srtp_err_status_t srtp_test_call_unprotect_rtcp(srtp_t srtp_sender,
-                                                uint8_t *hdr,
-                                                size_t *len,
-                                                bool use_mki)
-{
-    if (!use_mki) {
-        return srtp_unprotect_rtcp(srtp_sender, hdr, len);
-    } else {
-        return srtp_unprotect_rtcp_mki(srtp_sender, hdr, len, use_mki);
-    }
-}
-
 srtp_err_status_t srtp_test(const srtp_policy_t *policy,
                             bool test_extension_headers,
                             bool use_mki,
@@ -1110,17 +1075,20 @@ srtp_err_status_t srtp_test(const srtp_policy_t *policy,
     size_t len, len2;
     size_t tag_length;
     uint32_t ssrc;
-    srtp_policy_t *rcvr_policy;
-    srtp_policy_t tmp_policy;
+    srtp_policy_t send_policy;
+    srtp_policy_t rcvr_policy;
     uint8_t header = 1;
 
+    memcpy(&send_policy, policy, sizeof(srtp_policy_t));
+
+    send_policy.use_mki = use_mki;
+
     if (test_extension_headers) {
-        memcpy(&tmp_policy, policy, sizeof(srtp_policy_t));
-        tmp_policy.enc_xtn_hdr = &header;
-        tmp_policy.enc_xtn_hdr_count = 1;
-        err_check(srtp_create(&srtp_sender, &tmp_policy));
+        send_policy.enc_xtn_hdr = &header;
+        send_policy.enc_xtn_hdr_count = 1;
+        err_check(srtp_create(&srtp_sender, &send_policy));
     } else {
-        err_check(srtp_create(&srtp_sender, policy));
+        err_check(srtp_create(&srtp_sender, &send_policy));
     }
 
     /* print out policy */
@@ -1164,8 +1132,7 @@ srtp_err_status_t srtp_test(const srtp_policy_t *policy,
     debug_print(mod_driver, "reference packet before protection:\n%s",
                 octet_string_hex_string(hdr, len));
 #endif
-    err_check(
-        srtp_test_call_protect(srtp_sender, hdr, &len, use_mki, mki_index));
+    err_check(srtp_protect(srtp_sender, hdr, &len, mki_index));
 
     debug_print(mod_driver, "after protection:\n%s",
                 srtp_packet_to_string(hdr, len));
@@ -1185,8 +1152,8 @@ srtp_err_status_t srtp_test(const srtp_policy_t *policy,
      * data following the packet is different, then we know that the
      * protect function is overwriting the end of the packet.
      */
-    err_check(srtp_get_protect_trailer_length(srtp_sender, use_mki, mki_index,
-                                              &tag_length));
+    err_check(
+        srtp_get_protect_trailer_length(srtp_sender, mki_index, &tag_length));
     pkt_end = hdr + msg_len + tag_length;
     for (i = 0; i < 4; i++) {
         if (pkt_end[i] != 0xff) {
@@ -1226,34 +1193,12 @@ srtp_err_status_t srtp_test(const srtp_policy_t *policy,
         printf("passed\n");
     }
 
-    /*
-     * if the policy uses a 'wildcard' ssrc, then we need to make a copy
-     * of the policy that changes the direction to inbound
-     *
-     * we always copy the policy into the rcvr_policy, since otherwise
-     * the compiler would fret about the constness of the policy
-     */
-    rcvr_policy = (srtp_policy_t *)malloc(sizeof(srtp_policy_t));
-    if (rcvr_policy == NULL) {
-        free(hdr);
-        free(hdr2);
-        return srtp_err_status_alloc_fail;
-    }
-    if (test_extension_headers) {
-        memcpy(rcvr_policy, &tmp_policy, sizeof(srtp_policy_t));
-        if (tmp_policy.ssrc.type == ssrc_any_outbound) {
-            rcvr_policy->ssrc.type = ssrc_any_inbound;
-        }
-    } else {
-        memcpy(rcvr_policy, policy, sizeof(srtp_policy_t));
-        if (policy->ssrc.type == ssrc_any_outbound) {
-            rcvr_policy->ssrc.type = ssrc_any_inbound;
-        }
-    }
+    memcpy(&rcvr_policy, &send_policy, sizeof(srtp_policy_t));
+    rcvr_policy.ssrc.type = ssrc_any_inbound;
 
-    err_check(srtp_create(&srtp_rcvr, rcvr_policy));
+    err_check(srtp_create(&srtp_rcvr, &rcvr_policy));
 
-    err_check(srtp_test_call_unprotect(srtp_rcvr, hdr, &len, use_mki));
+    err_check(srtp_unprotect(srtp_rcvr, hdr, &len));
 
     debug_print(mod_driver, "after unprotection:\n%s",
                 srtp_packet_to_string(hdr, len));
@@ -1268,7 +1213,6 @@ srtp_err_status_t srtp_test(const srtp_policy_t *policy,
     if (status) {
         free(hdr);
         free(hdr2);
-        free(rcvr_policy);
         return status;
     }
 
@@ -1281,13 +1225,11 @@ srtp_err_status_t srtp_test(const srtp_policy_t *policy,
         printf("testing for false positives in replay check...");
 
         /* unprotect a second time - should fail with a replay error */
-        status =
-            srtp_test_call_unprotect(srtp_rcvr, hdr, &msg_len_enc, use_mki);
+        status = srtp_unprotect(srtp_rcvr, hdr, &msg_len_enc);
         if (status != srtp_err_status_replay_fail) {
             printf("failed with error code %d\n", status);
             free(hdr);
             free(hdr2);
-            free(rcvr_policy);
             return srtp_err_status_algo_fail;
         } else {
             printf("passed\n");
@@ -1299,20 +1241,18 @@ srtp_err_status_t srtp_test(const srtp_policy_t *policy,
         ((srtp_hdr_t *)hdr)->seq++;
 
         /* apply protection */
-        err_check(
-            srtp_test_call_protect(srtp_sender, hdr, &len, use_mki, mki_index));
+        err_check(srtp_protect(srtp_sender, hdr, &len, mki_index));
 
         /* flip bits in packet */
         data[0] ^= 0xff;
 
         /* unprotect, and check for authentication failure */
-        status = srtp_test_call_unprotect(srtp_rcvr, hdr, &len, use_mki);
+        status = srtp_unprotect(srtp_rcvr, hdr, &len);
         if (status != srtp_err_status_auth_fail) {
             printf("failed with error code %d\n", status);
             printf("failed\n");
             free(hdr);
             free(hdr2);
-            free(rcvr_policy);
             return srtp_err_status_algo_fail;
         } else {
             printf("passed\n");
@@ -1324,7 +1264,6 @@ srtp_err_status_t srtp_test(const srtp_policy_t *policy,
 
     free(hdr);
     free(hdr2);
-    free(rcvr_policy);
     return srtp_err_status_ok;
 }
 
@@ -1342,9 +1281,14 @@ srtp_err_status_t srtcp_test(const srtp_policy_t *policy,
     size_t len, len2;
     size_t tag_length;
     uint32_t ssrc;
-    srtp_policy_t *rcvr_policy;
+    srtp_policy_t send_policy;
+    srtp_policy_t rcvr_policy;
 
-    err_check(srtp_create(&srtcp_sender, policy));
+    memcpy(&send_policy, policy, sizeof(srtp_policy_t));
+
+    send_policy.use_mki = use_mki;
+
+    err_check(srtp_create(&srtcp_sender, &send_policy));
 
     /* print out policy */
     err_check(srtp_session_print_policy(srtcp_sender));
@@ -1380,8 +1324,7 @@ srtp_err_status_t srtcp_test(const srtp_policy_t *policy,
     debug_print(mod_driver, "reference packet before protection:\n%s",
                 octet_string_hex_string(hdr, len));
 #endif
-    err_check(srtp_test_call_protect_rtcp(srtcp_sender, hdr, &len, use_mki,
-                                          mki_index));
+    err_check(srtp_protect_rtcp(srtcp_sender, hdr, &len, mki_index));
 
     debug_print(mod_driver, "after protection:\n%s",
                 srtp_rtcp_packet_to_string(hdr, len));
@@ -1401,8 +1344,7 @@ srtp_err_status_t srtcp_test(const srtp_policy_t *policy,
      * data following the packet is different, then we know that the
      * protect function is overwriting the end of the packet.
      */
-    srtp_get_protect_rtcp_trailer_length(srtcp_sender, use_mki, mki_index,
-                                         &tag_length);
+    srtp_get_protect_rtcp_trailer_length(srtcp_sender, mki_index, &tag_length);
     pkt_end = hdr + msg_len + tag_length;
     for (size_t i = 0; i < 4; i++) {
         if (pkt_end[i] != 0xff) {
@@ -1442,27 +1384,14 @@ srtp_err_status_t srtcp_test(const srtp_policy_t *policy,
         printf("passed\n");
     }
 
-    /*
-     * if the policy uses a 'wildcard' ssrc, then we need to make a copy
-     * of the policy that changes the direction to inbound
-     *
-     * we always copy the policy into the rcvr_policy, since otherwise
-     * the compiler would fret about the constness of the policy
-     */
-    rcvr_policy = (srtp_policy_t *)malloc(sizeof(srtp_policy_t));
-    if (rcvr_policy == NULL) {
-        free(hdr);
-        free(hdr2);
-        return srtp_err_status_alloc_fail;
-    }
-    memcpy(rcvr_policy, policy, sizeof(srtp_policy_t));
-    if (policy->ssrc.type == ssrc_any_outbound) {
-        rcvr_policy->ssrc.type = ssrc_any_inbound;
+    memcpy(&rcvr_policy, &send_policy, sizeof(srtp_policy_t));
+    if (send_policy.ssrc.type == ssrc_any_outbound) {
+        rcvr_policy.ssrc.type = ssrc_any_inbound;
     }
 
-    err_check(srtp_create(&srtcp_rcvr, rcvr_policy));
+    err_check(srtp_create(&srtcp_rcvr, &rcvr_policy));
 
-    err_check(srtp_test_call_unprotect_rtcp(srtcp_rcvr, hdr, &len, use_mki));
+    err_check(srtp_unprotect_rtcp(srtcp_rcvr, hdr, &len));
 
     debug_print(mod_driver, "after unprotection:\n%s",
                 srtp_rtcp_packet_to_string(hdr, len));
@@ -1477,7 +1406,6 @@ srtp_err_status_t srtcp_test(const srtp_policy_t *policy,
     if (status) {
         free(hdr);
         free(hdr2);
-        free(rcvr_policy);
         return status;
     }
 
@@ -1490,13 +1418,11 @@ srtp_err_status_t srtcp_test(const srtp_policy_t *policy,
         printf("testing for false positives in replay check...");
 
         /* unprotect a second time - should fail with a replay error */
-        status = srtp_test_call_unprotect_rtcp(srtcp_rcvr, hdr, &msg_len_enc,
-                                               use_mki);
+        status = srtp_unprotect_rtcp(srtcp_rcvr, hdr, &msg_len_enc);
         if (status != srtp_err_status_replay_fail) {
             printf("failed with error code %d\n", status);
             free(hdr);
             free(hdr2);
-            free(rcvr_policy);
             return srtp_err_status_algo_fail;
         } else {
             printf("passed\n");
@@ -1505,20 +1431,18 @@ srtp_err_status_t srtcp_test(const srtp_policy_t *policy,
         printf("testing for false positives in auth check...");
 
         /* apply protection */
-        err_check(srtp_test_call_protect_rtcp(srtcp_sender, hdr, &len, use_mki,
-                                              mki_index));
+        err_check(srtp_protect_rtcp(srtcp_sender, hdr, &len, mki_index));
 
         /* flip bits in packet */
         data[0] ^= 0xff;
 
         /* unprotect, and check for authentication failure */
-        status = srtp_test_call_unprotect_rtcp(srtcp_rcvr, hdr, &len, use_mki);
+        status = srtp_unprotect_rtcp(srtcp_rcvr, hdr, &len);
         if (status != srtp_err_status_auth_fail) {
             printf("failed with error code %d\n", status);
             printf("failed\n");
             free(hdr);
             free(hdr2);
-            free(rcvr_policy);
             return srtp_err_status_algo_fail;
         } else {
             printf("passed\n");
@@ -1530,7 +1454,6 @@ srtp_err_status_t srtcp_test(const srtp_policy_t *policy,
 
     free(hdr);
     free(hdr2);
-    free(rcvr_policy);
     return srtp_err_status_ok;
 }
 
@@ -1572,6 +1495,8 @@ bool srtp_session_print_stream(srtp_stream_t stream, void *raw_data)
            "# rtcp cipher:   %s\r\n"
            "# rtcp auth:     %s\r\n"
            "# rtcp services: %s\r\n"
+           "# num keys:      %zu\r\n"
+           "# use mki:       %s\r\n"
            "# window size:   %zu\r\n"
            "# tx rtx allowed:%s\r\n",
            ssrc_text, session_keys->rtp_cipher->type->description,
@@ -1579,7 +1504,8 @@ bool srtp_session_print_stream(srtp_stream_t stream, void *raw_data)
            serv_descr[stream->rtp_services],
            session_keys->rtcp_cipher->type->description,
            session_keys->rtcp_auth->type->description,
-           serv_descr[stream->rtcp_services],
+           serv_descr[stream->rtcp_services], stream->num_master_keys,
+           stream->use_mki ? "true" : "false",
            srtp_rdbx_get_window_size(&stream->rtp_rdbx),
            stream->allow_repeat_tx ? "true" : "false");
 
@@ -1827,7 +1753,7 @@ srtp_err_status_t srtp_validate(void)
      * protect plaintext, then compare with ciphertext
      */
     len = 28;
-    status = srtp_protect(srtp_snd, srtp_plaintext, &len);
+    status = srtp_protect(srtp_snd, srtp_plaintext, &len, 0);
     if (status || (len != 38)) {
         return srtp_err_status_fail;
     }
@@ -1845,7 +1771,7 @@ srtp_err_status_t srtp_validate(void)
      * protect plaintext rtcp, then compare with srtcp ciphertext
      */
     len = 24;
-    status = srtp_protect_rtcp(srtp_snd, rtcp_plaintext, &len);
+    status = srtp_protect_rtcp(srtp_snd, rtcp_plaintext, &len, 0);
     if (status || (len != 38)) {
         return srtp_err_status_fail;
     }
@@ -1885,6 +1811,181 @@ srtp_err_status_t srtp_validate(void)
      * unprotect srtcp ciphertext, then compare with rtcp plaintext
      */
     len = 38;
+    status = srtp_unprotect_rtcp(srtp_recv, srtcp_ciphertext, &len);
+    if (status || (len != 24)) {
+        return status;
+    }
+
+    if (!srtp_octet_string_equal(srtcp_ciphertext, rtcp_plaintext_ref, len)) {
+        return srtp_err_status_fail;
+    }
+
+    status = srtp_dealloc(srtp_snd);
+    if (status) {
+        return status;
+    }
+
+    status = srtp_dealloc(srtp_recv);
+    if (status) {
+        return status;
+    }
+
+    return srtp_err_status_ok;
+}
+
+/*
+ * srtp_validate_mki() verifies the correctness of libsrtp by comparing
+ * some computed packets against some pre-computed reference values.
+ * These packets were made with the default SRTP policy.
+ */
+
+srtp_err_status_t srtp_validate_mki(void)
+{
+    // clang-format off
+    uint8_t srtp_plaintext_ref[28] = {
+        0x80, 0x0f, 0x12, 0x34, 0xde, 0xca, 0xfb, 0xad,
+        0xca, 0xfe, 0xba, 0xbe, 0xab, 0xab, 0xab, 0xab,
+        0xab, 0xab, 0xab, 0xab, 0xab, 0xab, 0xab, 0xab,
+        0xab, 0xab, 0xab, 0xab
+    };
+    uint8_t srtp_plaintext[42] = {
+        0x80, 0x0f, 0x12, 0x34, 0xde, 0xca, 0xfb, 0xad,
+        0xca, 0xfe, 0xba, 0xbe, 0xab, 0xab, 0xab, 0xab,
+        0xab, 0xab, 0xab, 0xab, 0xab, 0xab, 0xab, 0xab,
+        0xab, 0xab, 0xab, 0xab, 0x00, 0x00, 0x00, 0x00,
+        0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+        0x00, 0x00
+    };
+    uint8_t srtp_ciphertext[42] = {
+        0x80, 0x0f, 0x12, 0x34, 0xde, 0xca, 0xfb, 0xad,
+        0xca, 0xfe, 0xba, 0xbe, 0x4e, 0x55, 0xdc, 0x4c,
+        0xe7, 0x99, 0x78, 0xd8, 0x8c, 0xa4, 0xd2, 0x15,
+        0x94, 0x9d, 0x24, 0x02, 0xe1, 0xf9, 0x7a, 0x0d,
+        0xb7, 0x8d, 0x6a, 0xcc, 0x99, 0xea, 0x17, 0x9b,
+        0x8d, 0xbb
+    };
+    uint8_t rtcp_plaintext_ref[24] = {
+        0x81, 0xc8, 0x00, 0x0b, 0xca, 0xfe, 0xba, 0xbe,
+        0xab, 0xab, 0xab, 0xab, 0xab, 0xab, 0xab, 0xab,
+        0xab, 0xab, 0xab, 0xab, 0xab, 0xab, 0xab, 0xab,
+    };
+    uint8_t rtcp_plaintext[42] = {
+        0x81, 0xc8, 0x00, 0x0b, 0xca, 0xfe, 0xba, 0xbe,
+        0xab, 0xab, 0xab, 0xab, 0xab, 0xab, 0xab, 0xab,
+        0xab, 0xab, 0xab, 0xab, 0xab, 0xab, 0xab, 0xab,
+        0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+        0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+        0x00, 0x00
+    };
+    uint8_t srtcp_ciphertext[42] = {
+        0x81, 0xc8, 0x00, 0x0b, 0xca, 0xfe, 0xba, 0xbe,
+        0x71, 0x28, 0x03, 0x5b, 0xe4, 0x87, 0xb9, 0xbd,
+        0xbe, 0xf8, 0x90, 0x41, 0xf9, 0x77, 0xa5, 0xa8,
+        0x80, 0x00, 0x00, 0x01, 0xe1, 0xf9, 0x7a, 0x0d,
+        0x99, 0x3e, 0x08, 0xcd, 0x54, 0xd6, 0xc1, 0x23,
+        0x07, 0x98
+    };
+    // clang-format on
+
+    srtp_t srtp_snd, srtp_recv;
+    srtp_err_status_t status;
+    size_t len;
+    srtp_policy_t policy;
+
+    /*
+     * create a session with a single stream using the default srtp
+     * policy and with the SSRC value 0xcafebabe
+     */
+    memset(&policy, 0, sizeof(policy));
+    srtp_crypto_policy_set_rtp_default(&policy.rtp);
+    srtp_crypto_policy_set_rtcp_default(&policy.rtcp);
+    policy.ssrc.type = ssrc_specific;
+    policy.ssrc.value = 0xcafebabe;
+    policy.keys = test_keys;
+    policy.num_master_keys = 2;
+    policy.use_mki = true;
+    policy.window_size = 128;
+    policy.allow_repeat_tx = false;
+    policy.next = NULL;
+
+    status = srtp_create(&srtp_snd, &policy);
+    if (status) {
+        return status;
+    }
+
+    /*
+     * protect plaintext, then compare with ciphertext
+     */
+    len = 28;
+    status = srtp_protect(srtp_snd, srtp_plaintext, &len, 0);
+    if (status) {
+        return status;
+    }
+
+    debug_print(mod_driver, "ciphertext:\n  %s",
+                octet_string_hex_string(srtp_plaintext, len));
+    debug_print(
+        mod_driver, "ciphertext reference:\n  %s",
+        octet_string_hex_string(srtp_ciphertext, sizeof(srtp_ciphertext)));
+
+    if (len != sizeof(srtp_ciphertext)) {
+        return srtp_err_status_fail;
+    }
+
+    if (!srtp_octet_string_equal(srtp_plaintext, srtp_ciphertext, len)) {
+        return srtp_err_status_fail;
+    }
+
+    /*
+     * protect plaintext rtcp, then compare with srtcp ciphertext
+     */
+    len = 24;
+    status = srtp_protect_rtcp(srtp_snd, rtcp_plaintext, &len, 0);
+    if (status) {
+        return status;
+    }
+
+    debug_print(mod_driver, "srtcp ciphertext:\n  %s",
+                octet_string_hex_string(rtcp_plaintext, len));
+    debug_print(
+        mod_driver, "srtcp ciphertext reference:\n  %s",
+        octet_string_hex_string(srtcp_ciphertext, sizeof(srtcp_ciphertext)));
+
+    if (len != sizeof(srtcp_ciphertext)) {
+        return srtp_err_status_fail;
+    }
+
+    if (!srtp_octet_string_equal(rtcp_plaintext, srtcp_ciphertext, len)) {
+        return srtp_err_status_fail;
+    }
+
+    /*
+     * create a receiver session context comparable to the one created
+     * above - we need to do this so that the replay checking doesn't
+     * complain
+     */
+    status = srtp_create(&srtp_recv, &policy);
+    if (status) {
+        return status;
+    }
+
+    /*
+     * unprotect ciphertext, then compare with plaintext
+     */
+    len = 42;
+    status = srtp_unprotect(srtp_recv, srtp_ciphertext, &len);
+    if (status || (len != 28)) {
+        return status;
+    }
+
+    if (!srtp_octet_string_equal(srtp_ciphertext, srtp_plaintext_ref, len)) {
+        return srtp_err_status_fail;
+    }
+
+    /*
+     * unprotect srtcp ciphertext, then compare with rtcp plaintext
+     */
+    len = 42;
     status = srtp_unprotect_rtcp(srtp_recv, srtcp_ciphertext, &len);
     if (status || (len != 24)) {
         return status;
@@ -1986,7 +2087,7 @@ srtp_err_status_t srtp_validate_null(void)
      * protect plaintext, then compare with ciphertext
      */
     len = 28;
-    status = srtp_protect(srtp_snd, srtp_plaintext, &len);
+    status = srtp_protect(srtp_snd, srtp_plaintext, &len, 0);
     if (status || (len != 38)) {
         return srtp_err_status_fail;
     }
@@ -2004,7 +2105,7 @@ srtp_err_status_t srtp_validate_null(void)
      * protect plaintext rtcp, then compare with srtcp ciphertext
      */
     len = 24;
-    status = srtp_protect_rtcp(srtp_snd, rtcp_plaintext, &len);
+    status = srtp_protect_rtcp(srtp_snd, rtcp_plaintext, &len, 0);
     if (status || (len != 38)) {
         return srtp_err_status_fail;
     }
@@ -2147,7 +2248,7 @@ srtp_err_status_t srtp_validate_gcm(void)
      * protect plaintext rtp, then compare with srtp ciphertext
      */
     len = 28;
-    status = srtp_protect(srtp_snd, rtp_plaintext, &len);
+    status = srtp_protect(srtp_snd, rtp_plaintext, &len, 0);
     if (status || (len != 44)) {
         return srtp_err_status_fail;
     }
@@ -2165,7 +2266,7 @@ srtp_err_status_t srtp_validate_gcm(void)
      * protect plaintext rtcp, then compare with srtcp ciphertext
      */
     len = 24;
-    status = srtp_protect_rtcp(srtp_snd, rtcp_plaintext, &len);
+    status = srtp_protect_rtcp(srtp_snd, rtcp_plaintext, &len, 0);
     if (status || (len != 44)) {
         return srtp_err_status_fail;
     }
@@ -2311,7 +2412,7 @@ srtp_err_status_t srtp_validate_encrypted_extensions_headers(void)
      * protect plaintext, then compare with ciphertext
      */
     len = sizeof(srtp_plaintext_ref);
-    status = srtp_protect(srtp_snd, srtp_plaintext, &len);
+    status = srtp_protect(srtp_snd, srtp_plaintext, &len, 0);
     if (status || (len != sizeof(srtp_plaintext))) {
         return srtp_err_status_fail;
     }
@@ -2440,7 +2541,7 @@ srtp_err_status_t srtp_validate_encrypted_extensions_headers_gcm(void)
      * protect plaintext, then compare with ciphertext
      */
     len = sizeof(srtp_plaintext_ref);
-    status = srtp_protect(srtp_snd, srtp_plaintext, &len);
+    status = srtp_protect(srtp_snd, srtp_plaintext, &len, 0);
     if (status || (len != sizeof(srtp_plaintext))) {
         return srtp_err_status_fail;
     }
@@ -2560,7 +2661,7 @@ srtp_err_status_t srtp_validate_aes_256(void)
      * protect plaintext, then compare with ciphertext
      */
     len = 28;
-    status = srtp_protect(srtp_snd, srtp_plaintext, &len);
+    status = srtp_protect(srtp_snd, srtp_plaintext, &len, 0);
     if (status || (len != 38)) {
         return srtp_err_status_fail;
     }
@@ -2688,7 +2789,7 @@ srtp_err_status_t srtp_test_empty_payload(void)
         return srtp_err_status_fail;
     }
 
-    status = srtp_protect(srtp_snd, mesg, &len);
+    status = srtp_protect(srtp_snd, mesg, &len, 0);
     if (status) {
         return status;
     } else if (len != 12 + 10) {
@@ -2763,7 +2864,7 @@ srtp_err_status_t srtp_test_empty_payload_gcm(void)
         return srtp_err_status_fail;
     }
 
-    status = srtp_protect(srtp_snd, mesg, &len);
+    status = srtp_protect(srtp_snd, mesg, &len, 0);
     if (status) {
         return status;
     } else if (len != 12 + 16) {
@@ -2958,7 +3059,7 @@ srtp_err_status_t srtp_test_update(void)
     }
     ((srtp_hdr_t *)msg)->seq = htons(65535);
 
-    status = srtp_protect(srtp_snd, msg, &protected_msg_len_octets);
+    status = srtp_protect(srtp_snd, msg, &protected_msg_len_octets, 0);
     if (status) {
         return srtp_err_status_fail;
     }
@@ -2977,7 +3078,7 @@ srtp_err_status_t srtp_test_update(void)
     }
     ((srtp_hdr_t *)msg)->seq = htons(1);
 
-    status = srtp_protect(srtp_snd, msg, &protected_msg_len_octets);
+    status = srtp_protect(srtp_snd, msg, &protected_msg_len_octets, 0);
     if (status) {
         return srtp_err_status_fail;
     }
@@ -3004,7 +3105,7 @@ srtp_err_status_t srtp_test_update(void)
     }
     ((srtp_hdr_t *)msg)->seq = htons(2);
 
-    status = srtp_protect(srtp_snd, msg, &protected_msg_len_octets);
+    status = srtp_protect(srtp_snd, msg, &protected_msg_len_octets, 0);
     if (status) {
         return srtp_err_status_fail;
     }
@@ -3032,7 +3133,7 @@ srtp_err_status_t srtp_test_update(void)
     }
     ((srtp_hdr_t *)msg)->seq = htons(3);
 
-    status = srtp_protect(srtp_snd, msg, &protected_msg_len_octets);
+    status = srtp_protect(srtp_snd, msg, &protected_msg_len_octets, 0);
     if (status) {
         return srtp_err_status_fail;
     }
@@ -3136,6 +3237,7 @@ srtp_err_status_t srtp_test_setup_protect_trailer_streams(
     policy_mki.key = NULL;
     policy_mki.keys = test_keys;
     policy_mki.num_master_keys = 2;
+    policy_mki.use_mki = true;
 
 #ifdef GCM
     memset(&policy_aes_gcm, 0, sizeof(policy_aes_gcm));
@@ -3157,6 +3259,7 @@ srtp_err_status_t srtp_test_setup_protect_trailer_streams(
     policy_aes_gcm_mki.key = NULL;
     policy_aes_gcm_mki.keys = test_keys;
     policy_aes_gcm_mki.num_master_keys = 2;
+    policy_aes_gcm_mki.use_mki = true;
 #endif // GCM
 
     /* create a send ctx with defualt profile and test_key */
@@ -3197,7 +3300,7 @@ srtp_err_status_t srtp_test_protect_trailer_length(void)
     srtp_test_setup_protect_trailer_streams(
         &srtp_send, &srtp_send_mki, &srtp_send_aes_gcm, &srtp_send_aes_gcm_mki);
 
-    status = srtp_get_protect_trailer_length(srtp_send, 0, 0, &length);
+    status = srtp_get_protect_trailer_length(srtp_send, 0, &length);
     if (status) {
         return status;
     }
@@ -3207,7 +3310,7 @@ srtp_err_status_t srtp_test_protect_trailer_length(void)
         return srtp_err_status_fail;
     }
 
-    status = srtp_get_protect_trailer_length(srtp_send_mki, 1, 1, &length);
+    status = srtp_get_protect_trailer_length(srtp_send_mki, 1, &length);
     if (status) {
         return status;
     }
@@ -3218,7 +3321,7 @@ srtp_err_status_t srtp_test_protect_trailer_length(void)
     }
 
 #ifdef GCM
-    status = srtp_get_protect_trailer_length(srtp_send_aes_gcm, 0, 0, &length);
+    status = srtp_get_protect_trailer_length(srtp_send_aes_gcm, 0, &length);
     if (status) {
         return status;
     }
@@ -3228,8 +3331,7 @@ srtp_err_status_t srtp_test_protect_trailer_length(void)
         return srtp_err_status_fail;
     }
 
-    status =
-        srtp_get_protect_trailer_length(srtp_send_aes_gcm_mki, 1, 1, &length);
+    status = srtp_get_protect_trailer_length(srtp_send_aes_gcm_mki, 1, &length);
     if (status) {
         return status;
     }
@@ -3262,7 +3364,7 @@ srtp_err_status_t srtp_test_protect_rtcp_trailer_length(void)
     srtp_test_setup_protect_trailer_streams(
         &srtp_send, &srtp_send_mki, &srtp_send_aes_gcm, &srtp_send_aes_gcm_mki);
 
-    status = srtp_get_protect_rtcp_trailer_length(srtp_send, 0, 0, &length);
+    status = srtp_get_protect_rtcp_trailer_length(srtp_send, 0, &length);
     if (status) {
         return status;
     }
@@ -3272,7 +3374,7 @@ srtp_err_status_t srtp_test_protect_rtcp_trailer_length(void)
         return srtp_err_status_fail;
     }
 
-    status = srtp_get_protect_rtcp_trailer_length(srtp_send_mki, 1, 1, &length);
+    status = srtp_get_protect_rtcp_trailer_length(srtp_send_mki, 1, &length);
     if (status) {
         return status;
     }
@@ -3284,7 +3386,7 @@ srtp_err_status_t srtp_test_protect_rtcp_trailer_length(void)
 
 #ifdef GCM
     status =
-        srtp_get_protect_rtcp_trailer_length(srtp_send_aes_gcm, 0, 0, &length);
+        srtp_get_protect_rtcp_trailer_length(srtp_send_aes_gcm, 0, &length);
     if (status) {
         return status;
     }
@@ -3294,8 +3396,8 @@ srtp_err_status_t srtp_test_protect_rtcp_trailer_length(void)
         return srtp_err_status_fail;
     }
 
-    status = srtp_get_protect_rtcp_trailer_length(srtp_send_aes_gcm_mki, 1, 1,
-                                                  &length);
+    status =
+        srtp_get_protect_rtcp_trailer_length(srtp_send_aes_gcm_mki, 1, &length);
     if (status) {
         return status;
     }
@@ -3376,7 +3478,7 @@ srtp_err_status_t srtp_test_out_of_order_after_rollover(void)
     /* Create and protect packets to get to get roc == 1 */
     pkts[0] = srtp_create_test_packet_extended(64, sender_policy.ssrc.value,
                                                65534, 0, &pkt_len_octets[0]);
-    status = srtp_protect(sender_session, pkts[0], &pkt_len_octets[0]);
+    status = srtp_protect(sender_session, pkts[0], &pkt_len_octets[0], 0);
     if (status) {
         return status;
     }
@@ -3391,7 +3493,7 @@ srtp_err_status_t srtp_test_out_of_order_after_rollover(void)
 
     pkts[1] = srtp_create_test_packet_extended(64, sender_policy.ssrc.value,
                                                65535, 1, &pkt_len_octets[1]);
-    status = srtp_protect(sender_session, pkts[1], &pkt_len_octets[1]);
+    status = srtp_protect(sender_session, pkts[1], &pkt_len_octets[1], 0);
     if (status) {
         return status;
     }
@@ -3406,7 +3508,7 @@ srtp_err_status_t srtp_test_out_of_order_after_rollover(void)
 
     pkts[2] = srtp_create_test_packet_extended(64, sender_policy.ssrc.value, 0,
                                                2, &pkt_len_octets[2]);
-    status = srtp_protect(sender_session, pkts[2], &pkt_len_octets[2]);
+    status = srtp_protect(sender_session, pkts[2], &pkt_len_octets[2], 0);
     if (status) {
         return status;
     }
@@ -3421,7 +3523,7 @@ srtp_err_status_t srtp_test_out_of_order_after_rollover(void)
 
     pkts[3] = srtp_create_test_packet_extended(64, sender_policy.ssrc.value, 1,
                                                3, &pkt_len_octets[3]);
-    status = srtp_protect(sender_session, pkts[3], &pkt_len_octets[3]);
+    status = srtp_protect(sender_session, pkts[3], &pkt_len_octets[3], 0);
     if (status) {
         return status;
     }
@@ -3436,7 +3538,7 @@ srtp_err_status_t srtp_test_out_of_order_after_rollover(void)
 
     pkts[4] = srtp_create_test_packet_extended(64, sender_policy.ssrc.value, 2,
                                                4, &pkt_len_octets[4]);
-    status = srtp_protect(sender_session, pkts[4], &pkt_len_octets[4]);
+    status = srtp_protect(sender_session, pkts[4], &pkt_len_octets[4], 0);
     if (status) {
         return status;
     }
@@ -3570,7 +3672,7 @@ srtp_err_status_t srtp_test_get_roc(void)
         pkt = srtp_create_test_packet_extended(msg_len_octets,
                                                policy.ssrc.value, seq, ts,
                                                &protected_msg_len_octets);
-        status = srtp_protect(session, pkt, &protected_msg_len_octets);
+        status = srtp_protect(session, pkt, &protected_msg_len_octets, 0);
         free(pkt);
         if (status) {
             return status;
@@ -3655,7 +3757,7 @@ static srtp_err_status_t test_set_receiver_roc(uint32_t packets,
 
         tmp_pkt = srtp_create_test_packet_extended(
             msg_len_octets, sender_policy.ssrc.value, seq, ts, &tmp_len);
-        status = srtp_protect(sender_session, tmp_pkt, &tmp_len);
+        status = srtp_protect(sender_session, tmp_pkt, &tmp_len, 0);
         free(tmp_pkt);
         if (status) {
             return status;
@@ -3674,7 +3776,8 @@ static srtp_err_status_t test_set_receiver_roc(uint32_t packets,
     pkt_1 = srtp_create_test_packet_extended(msg_len_octets,
                                              sender_policy.ssrc.value, seq, ts,
                                              &protected_msg_len_octets_1);
-    status = srtp_protect(sender_session, pkt_1, &protected_msg_len_octets_1);
+    status =
+        srtp_protect(sender_session, pkt_1, &protected_msg_len_octets_1, 0);
     if (status) {
         return status;
     }
@@ -3685,7 +3788,8 @@ static srtp_err_status_t test_set_receiver_roc(uint32_t packets,
     pkt_2 = srtp_create_test_packet_extended(msg_len_octets,
                                              sender_policy.ssrc.value, seq, ts,
                                              &protected_msg_len_octets_2);
-    status = srtp_protect(sender_session, pkt_2, &protected_msg_len_octets_2);
+    status =
+        srtp_protect(sender_session, pkt_2, &protected_msg_len_octets_2, 0);
     if (status) {
         return status;
     }
@@ -3814,7 +3918,7 @@ static srtp_err_status_t test_set_sender_roc(uint16_t seq, uint32_t roc_to_set)
     pkt = srtp_create_test_packet_extended(msg_len_octets,
                                            sender_policy.ssrc.value, seq, ts,
                                            &protected_msg_len_octets);
-    status = srtp_protect(sender_session, pkt, &protected_msg_len_octets);
+    status = srtp_protect(sender_session, pkt, &protected_msg_len_octets, 0);
     if (status) {
         return status;
     }
@@ -4041,11 +4145,12 @@ const srtp_policy_t default_policy = {
     },
     NULL,
     (srtp_master_key_t **)test_keys,
-    2,    /* indicates the number of Master keys          */
-    128,  /* replay window size                           */
-    0,    /* retransmission not allowed                   */
-    NULL, /* no encrypted extension headers               */
-    0,    /* list of encrypted extension headers is empty */
+    2,     /* indicates the number of Master keys          */
+    false, /* no mki */
+    128,   /* replay window size                           */
+    0,     /* retransmission not allowed                   */
+    NULL,  /* no encrypted extension headers               */
+    0,     /* list of encrypted extension headers is empty */
     NULL
 };
 
@@ -4069,11 +4174,12 @@ const srtp_policy_t aes_only_policy = {
     },
     NULL,
     (srtp_master_key_t **)test_keys,
-    2,    /* indicates the number of Master keys          */
-    128,  /* replay window size                           */
-    0,    /* retransmission not allowed                   */
-    NULL, /* no encrypted extension headers               */
-    0,    /* list of encrypted extension headers is empty */
+    2,     /* indicates the number of Master keys          */
+    false, /* no mki */
+    128,   /* replay window size                           */
+    0,     /* retransmission not allowed                   */
+    NULL,  /* no encrypted extension headers               */
+    0,     /* list of encrypted extension headers is empty */
     NULL
 };
 
@@ -4097,11 +4203,12 @@ const srtp_policy_t hmac_only_policy = {
     },
     NULL,
     (srtp_master_key_t **)test_keys,
-    2,    /* Number of Master keys associated with the policy */
-    128,  /* replay window size                               */
-    0,    /* retransmission not allowed                       */
-    NULL, /* no encrypted extension headers                   */
-    0,    /* list of encrypted extension headers is empty     */
+    2,     /* Number of Master keys associated with the policy */
+    false, /* no mki */
+    128,   /* replay window size                               */
+    0,     /* retransmission not allowed                       */
+    NULL,  /* no encrypted extension headers                   */
+    0,     /* list of encrypted extension headers is empty     */
     NULL
 };
 
@@ -4128,11 +4235,12 @@ const srtp_policy_t aes128_gcm_8_policy = {
     },
     NULL,
     (srtp_master_key_t **)test_keys,
-    2,    /* indicates the number of Master keys          */
-    128,  /* replay window size                           */
-    0,    /* retransmission not allowed                   */
-    NULL, /* no encrypted extension headers               */
-    0,    /* list of encrypted extension headers is empty */
+    2,     /* indicates the number of Master keys          */
+    false, /* no mki */
+    128,   /* replay window size                           */
+    0,     /* retransmission not allowed                   */
+    NULL,  /* no encrypted extension headers               */
+    0,     /* list of encrypted extension headers is empty */
     NULL
 };
 
@@ -4158,11 +4266,12 @@ const srtp_policy_t aes128_gcm_8_cauth_policy = {
     },
     NULL,
     (srtp_master_key_t **)test_keys,
-    2,    /* indicates the number of Master keys          */
-    128,  /* replay window size                           */
-    0,    /* retransmission not allowed                   */
-    NULL, /* no encrypted extension headers               */
-    0,    /* list of encrypted extension headers is empty */
+    2,     /* indicates the number of Master keys          */
+    false, /* no mki */
+    128,   /* replay window size                           */
+    0,     /* retransmission not allowed                   */
+    NULL,  /* no encrypted extension headers               */
+    0,     /* list of encrypted extension headers is empty */
     NULL
 };
 
@@ -4188,11 +4297,12 @@ const srtp_policy_t aes256_gcm_8_policy = {
     },
     NULL,
     (srtp_master_key_t **)test_keys,
-    2,    /* indicates the number of Master keys          */
-    128,  /* replay window size                           */
-    0,    /* retransmission not allowed                   */
-    NULL, /* no encrypted extension headers               */
-    0,    /* list of encrypted extension headers is empty */
+    2,     /* indicates the number of Master keys          */
+    false, /* no mki */
+    128,   /* replay window size                           */
+    0,     /* retransmission not allowed                   */
+    NULL,  /* no encrypted extension headers               */
+    0,     /* list of encrypted extension headers is empty */
     NULL
 };
 
@@ -4218,11 +4328,12 @@ const srtp_policy_t aes256_gcm_8_cauth_policy = {
     },
     NULL,
     (srtp_master_key_t **)test_keys,
-    2,    /* indicates the number of Master keys          */
-    128,  /* replay window size                           */
-    0,    /* retransmission not allowed                   */
-    NULL, /* no encrypted extension headers               */
-    0,    /* list of encrypted extension headers is empty */
+    2,     /* indicates the number of Master keys          */
+    false, /* no mki */
+    128,   /* replay window size                           */
+    0,     /* retransmission not allowed                   */
+    NULL,  /* no encrypted extension headers               */
+    0,     /* list of encrypted extension headers is empty */
     NULL
 };
 #endif
@@ -4247,11 +4358,12 @@ const srtp_policy_t null_policy = {
     },
     NULL,
     (srtp_master_key_t **)test_keys,
-    2,    /* indicates the number of Master keys          */
-    128,  /* replay window size                           */
-    0,    /* retransmission not allowed                   */
-    NULL, /* no encrypted extension headers               */
-    0,    /* list of encrypted extension headers is empty */
+    2,     /* indicates the number of Master keys          */
+    false, /* no mki */
+    128,   /* replay window size                           */
+    0,     /* retransmission not allowed                   */
+    NULL,  /* no encrypted extension headers               */
+    0,     /* list of encrypted extension headers is empty */
     NULL
 };
 
@@ -4315,11 +4427,12 @@ const srtp_policy_t aes_256_hmac_policy = {
     },
     NULL,
     (srtp_master_key_t **)test_256_keys,
-    2,    /* indicates the number of Master keys          */
-    128,  /* replay window size                           */
-    0,    /* retransmission not allowed                   */
-    NULL, /* no encrypted extension headers               */
-    0,    /* list of encrypted extension headers is empty */
+    2,     /* indicates the number of Master keys          */
+    false, /* no mki */
+    128,   /* replay window size                           */
+    0,     /* retransmission not allowed                   */
+    NULL,  /* no encrypted extension headers               */
+    0,     /* list of encrypted extension headers is empty */
     NULL
 };
 
@@ -4342,12 +4455,13 @@ const srtp_policy_t hmac_only_with_no_master_key = {
         sec_serv_auth     /* security services flag      */
     },
     NULL,
-    NULL, /* no master keys*/
-    0,    /* indicates the number of Master keys          */
-    128,  /* replay window size                           */
-    0,    /* retransmission not allowed                   */
-    NULL, /* no encrypted extension headers               */
-    0,    /* list of encrypted extension headers is empty */
+    NULL,  /* no master keys*/
+    0,     /* indicates the number of Master keys          */
+    false, /* no mki */
+    128,   /* replay window size                           */
+    false, /* retransmission not allowed                   */
+    NULL,  /* no encrypted extension headers               */
+    0,     /* list of encrypted extension headers is empty */
     NULL
 };
 
@@ -4407,6 +4521,7 @@ const srtp_policy_t wildcard_policy = {
     },
     test_key,
     NULL,
+    false, /* no mki */
     0,
     128,  /* replay window size                           */
     0,    /* retransmission not allowed                   */


### PR DESCRIPTION
Move "use_mki" from a per packet parameter to a stream wide value. When using MKI all master keys need to have a valid MKI id.

Merge the MKI protect & unprotect functions. The MKI index is currently still passed per packet, this could also be moved up to stream level with a srtp_set_mki(ssrc) api as this is not likely to change per packet.