### PR TITLE
Enables the use of wolfSSL for crypto primitives

### DIFF
--- a/.github/workflows/autotools.yml
+++ b/.github/workflows/autotools.yml
@@ -12,12 +12,14 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, macos-latest]
-        crypto: [internal, openssl, nss]
+        crypto: [internal, openssl, wolfssl, nss]
         include:
           - crypto: internal
             configure-crypto-enable: ""
           - crypto: openssl
             configure-crypto-enable: "--enable-openssl"
+          - crypto: wolfssl
+            configure-crypto-enable: "--enable-wolfssl"
           - crypto: nss
             configure-crypto-enable: "--enable-nss"
 
@@ -30,6 +32,18 @@ jobs:
         sudo apt-get update
         sudo apt-get install valgrind
 
+    - name: Setup Ubuntu wolfSSL
+      if: matrix.os == 'ubuntu-latest' && matrix.crypto == 'wolfssl'
+      run: |
+        git clone https://github.com/wolfSSL/wolfssl
+        cd wolfssl
+        ./autogen.sh
+        ./configure '--enable-srtp-kdf' '--enable-aesctr' '--enable-intelasm' '--enable-aesgcm-stream'
+        make
+        sudo make install
+        sudo ldconfig
+        cd ..
+
     - name: Setup Ubuntu NSS
       if: matrix.os == 'ubuntu-latest' && matrix.crypto == 'nss'
       run: sudo apt-get install libnss3-dev
@@ -37,6 +51,18 @@ jobs:
     - name: Setup macOS OpenSSL
       if: matrix.os == 'macos-latest' && matrix.crypto == 'openssl'
       run: echo "configure-env=PKG_CONFIG_PATH=$(brew --prefix openssl@1.1)/lib/pkgconfig" >> $GITHUB_ENV
+
+    - name: Setup macOS wolfSSL
+      if: matrix.os == 'macos-latest' && matrix.crypto == 'wolfssl'
+      run: |
+        brew install autoconf automake libtool
+        git clone https://github.com/wolfSSL/wolfssl
+        cd wolfssl
+        ./autogen.sh
+        ./configure '--enable-srtp-kdf' '--enable-aesctr' '--enable-intelasm' '--enable-aesgcm-stream'
+        make
+        sudo make install
+        cd ..
 
     - name: Setup macOS NSS
       if:  matrix.os == 'macos-latest' && matrix.crypto == 'nss'

--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -14,10 +14,12 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        crypto: [internal, openssl, openssl3, nss, mbedtls]
+        crypto: [internal, openssl, openssl3, wolfssl, nss, mbedtls]
         exclude:
           - os: windows-latest
             crypto: openssl
+          - os: windows-latest
+            crypto: wolfssl
           - os: windows-latest
             crypto: openssl3
           - os: windows-latest
@@ -33,6 +35,8 @@ jobs:
             cmake-crypto-enable: "-DENABLE_OPENSSL=ON"
           - crypto: openssl3
             cmake-crypto-enable: "-DENABLE_OPENSSL=ON"
+          - crypto: wolfssl
+            cmake-crypto-enable: "-DENABLE_WOLFSSL=ON"
           - crypto: nss
             cmake-crypto-enable: "-DENABLE_NSS=ON"
           - crypto: mbedtls
@@ -44,6 +48,17 @@ jobs:
       CTEST_OUTPUT_ON_FAILURE: 1
 
     steps:
+    - name: Setup Ubuntu wolfSSL
+      if: matrix.os == 'ubuntu-latest' && matrix.crypto == 'wolfssl'
+      run: |
+        git clone https://github.com/wolfSSL/wolfssl
+        cd wolfssl
+        ./autogen.sh
+        ./configure '--enable-srtp-kdf' '--enable-aesctr' '--enable-intelasm' '--enable-aesgcm-stream'
+        make
+        sudo make install
+        cd ..
+
     - name: Setup Ubuntu NSS
       if: matrix.os == 'ubuntu-latest' && matrix.crypto == 'nss'
       run: |
@@ -63,6 +78,18 @@ jobs:
       run: |
         brew install openssl@3
         echo "cmake-crypto-dir=-DOPENSSL_ROOT_DIR=$(brew --prefix openssl@3)" >> $GITHUB_ENV
+
+    - name: Setup macOS wolfSSL
+      if: matrix.os == 'macos-latest' && matrix.crypto == 'wolfssl'
+      run: |
+        brew install autoconf automake libtool
+        git clone https://github.com/wolfSSL/wolfssl
+        cd wolfssl
+        ./autogen.sh
+        ./configure '--enable-srtp-kdf' '--enable-aesctr' '--enable-intelasm' '--enable-aesgcm-stream'
+        make
+        sudo make install
+        cd ..
 
     - name: Setup macOS NSS
       if:  matrix.os == 'macos-latest' && matrix.crypto == 'nss'

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -82,27 +82,38 @@ set(ENABLE_DEBUG_LOGGING OFF CACHE BOOL "Enable debug logging in all modules")
 set(ERR_REPORTING_STDOUT OFF CACHE BOOL "Enable logging to stdout")
 set(ERR_REPORTING_FILE "" CACHE FILEPATH "Use file for logging")
 set(ENABLE_OPENSSL OFF CACHE BOOL "Enable OpenSSL crypto engine")
+set(ENABLE_WOLFSSL OFF CACHE BOOL "Enable wolfSSL crypto engine")
 set(ENABLE_MBEDTLS OFF CACHE BOOL "Enable MbedTLS crypto engine")
 set(ENABLE_NSS OFF CACHE BOOL "Enable NSS crypto engine")
 
-if(ENABLE_OPENSSL OR ENABLE_MBEDTLS OR ENABLE_NSS)
+if(ENABLE_OPENSSL OR ENABLE_WOLFSSL OR ENABLE_MBEDTLS OR ENABLE_NSS)
   set(USE_EXTERNAL_CRYPTO TRUE)
 else()
   set(USE_EXTERNAL_CRYPTO FALSE)
 endif()
 
 if(ENABLE_OPENSSL)
-  if(ENABLE_NSS OR ENABLE_MBEDTLS)
-    message(FATAL_ERROR "ssl conflict. can not enable openssl and mbedtls or nss simultaneously.")
+  if(ENABLE_WOLFSSL OR ENABLE_NSS OR ENABLE_MBEDTLS)
+    message(FATAL_ERROR "ssl conflict. can not enable openssl and wolfssl, mbedtls or nss simultaneously.")
   endif()
   find_package(OpenSSL 1.1.0 REQUIRED)
   set(OPENSSL ${ENABLE_OPENSSL} CACHE BOOL INTERNAL)
   set(GCM ${ENABLE_OPENSSL} CACHE BOOL INTERNAL)
 endif()
 
+if(ENABLE_WOLFSSL)
+  if(ENABLE_OPENSSL OR ENABLE_NSS OR ENABLE_MBEDTLS)
+    message(FATAL_ERROR "ssl conflict. can not enable wolfssl and openssl, mbedtls or nss simultaneously.")
+  endif()
+  find_package(wolfSSL REQUIRED)
+  set(WOLFSSL ${ENABLE_WOLFSSL} CACHE BOOL INTERNAL)
+  set(WOLFSSL_KDF ${ENABLE_WOLFSSL} CACHE BOOL INTERNAL)
+  set(GCM ${ENABLE_WOLFSSL} CACHE BOOL INTERNAL)
+endif()
+
 if(ENABLE_MBEDTLS)
-  if(ENABLE_OPENSSL OR ENABLE_NSS)
-    message(FATAL_ERROR "ssl conflict. can not enable mbedtls and openssl or nss simultaneously.")
+  if(ENABLE_OPENSSL OR ENABLE_WOLFSSL OR ENABLE_NSS)
+    message(FATAL_ERROR "ssl conflict. can not enable mbedtls and openssl, wolfssl or nss simultaneously.")
   endif()
   find_package(MbedTLS REQUIRED)
   set(MBEDTLS ${ENABLE_MBEDTLS} CACHE BOOL INTERNAL)
@@ -110,8 +121,8 @@ if(ENABLE_MBEDTLS)
 endif()
 
 if(ENABLE_NSS)
-  if(ENABLE_OPENSSL OR ENABLE_MBEDTLS)
-    message(FATAL_ERROR "ssl conflict. can not enable nss and openssl or mbedtls simultaneously.")
+  if(ENABLE_OPENSSL OR ENABLE_WOLFSSL OR ENABLE_MBEDTLS)
+    message(FATAL_ERROR "ssl conflict. can not enable nss and openssl, wolfssl or mbedtls simultaneously.")
   endif()
   find_package(NSS REQUIRED)
   set(NSS ${ENABLE_NSS} CACHE BOOL INTERNAL)
@@ -149,6 +160,11 @@ if(ENABLE_OPENSSL)
     crypto/cipher/aes_icm_ossl.c
     crypto/cipher/aes_gcm_ossl.c
   )
+elseif(ENABLE_WOLFSSL)
+  list(APPEND CIPHERS_SOURCES_C
+    crypto/cipher/aes_icm_wssl.c
+    crypto/cipher/aes_gcm_wssl.c
+  )
 elseif(ENABLE_MBEDTLS)
   list(APPEND CIPHERS_SOURCES_C
     crypto/cipher/aes_icm_mbedtls.c
@@ -176,6 +192,10 @@ set(HASHES_SOURCES_C
 if(ENABLE_OPENSSL)
   list(APPEND HASHES_SOURCES_C
     crypto/hash/hmac_ossl.c
+  )
+elseif(ENABLE_WOLFSSL)
+  list(APPEND HASHES_SOURCES_C
+    crypto/hash/hmac_wssl.c
   )
 elseif(ENABLE_MBEDTLS)
   list(APPEND HASHES_SOURCES_C
@@ -285,6 +305,9 @@ target_include_directories(srtp2 PUBLIC
 if(ENABLE_OPENSSL)
   target_include_directories(srtp2 PRIVATE ${OPENSSL_INCLUDE_DIR})
   target_link_libraries(srtp2 OpenSSL::Crypto)
+elseif(ENABLE_WOLFSSL)
+  target_include_directories(srtp2 PRIVATE ${WOLFSSL_INCLUDE_DIR})
+  target_link_libraries(srtp2 ${WOLFSSL_LIBRARY})
 elseif(ENABLE_MBEDTLS)
   target_include_directories(srtp2 PRIVATE ${MBEDTLS_INCLUDE_DIRS})
   target_link_libraries(srtp2 ${MBEDTLS_LIBRARIES})
@@ -443,6 +466,8 @@ if(LIBSRTP_TEST_APPS)
             ${ENABLE_WARNINGS_AS_ERRORS})
     if(ENABLE_OPENSSL)
       target_include_directories(test_srtp PRIVATE ${OPENSSL_INCLUDE_DIR})
+    elseif(ENABLE_WOLFSSL)
+      target_include_directories(test_srtp PRIVATE ${WOLFSSL_INCLUDE_DIR})
     elseif(ENABLE_MBEDTLS)
       target_include_directories(test_srtp PRIVATE ${MBEDTLS_INCLUDE_DIRS})
     elseif(ENABLE_NSS)

--- a/cmake/FindwolfSSL.cmake
+++ b/cmake/FindwolfSSL.cmake
@@ -1,0 +1,18 @@
+find_path(WOLFSSL_INCLUDE_DIR wolfssl/ssl.h)
+
+find_library(WOLFSSL_LIBRARY wolfssl)
+
+include(FindPackageHandleStandardArgs)
+find_package_handle_standard_args(wolfSSL DEFAULT_MSG
+    WOLFSSL_LIBRARY WOLFSSL_INCLUDE_DIR)
+
+mark_as_advanced(WOLFSSL_INCLUDE_DIR WOLFSSL_LIBRARY)
+
+if(NOT TARGET wolfSSL)
+    add_library(wolfSSL UNKNOWN IMPORTED)
+    set_target_properties(wolfSSL PROPERTIES
+                          INTERFACE_INCLUDE_DIRECTORIES "${WOLFSSL_INCLUDE_DIR}"
+                          IMPORTED_LINK_INTERFACE_LANGUAGES "C"
+                          IMPORTED_LOCATION "${WOLFSSL_LIBRARY}")
+endif()
+

--- a/config_in.h
+++ b/config_in.h
@@ -171,6 +171,12 @@
 /* Define to 1 if you have the ANSI C header files. */
 #undef STDC_HEADERS
 
+/* Define this to use wolfSSL crypto. */
+#undef WOLFSSL
+
+/* Define this to use wolfSSL KDF for SRTP. */
+#undef WOLFSSL_KDF
+
 /* Define WORDS_BIGENDIAN to 1 if your processor stores words with the most
    significant byte first (like Motorola and SPARC, unlike Intel). */
 #if defined AC_APPLE_UNIVERSAL_BUILD

--- a/config_in_cmake.h
+++ b/config_in_cmake.h
@@ -18,6 +18,12 @@
 /* Define this to use OpenSSL crypto. */
 #cmakedefine OPENSSL 1
 
+/* Define this to use wolfSSL crypto. */
+#cmakedefine WOLFSSL 1
+
+/* Define this to use wolfSSL SRTP-KDF. */
+#cmakedefine WOLFSSL_KDF 1
+
 /* Define this to use MBEDTLS. */
 #cmakedefine MBEDTLS 1
 

--- a/configure
+++ b/configure
@@ -710,9 +710,11 @@ ac_user_opts='
 enable_option_checking
 enable_debug_logging
 enable_openssl
+enable_wolfssl
 enable_nss
 with_openssl_dir
 enable_openssl_kdf
+with_wolfssl_dir
 with_nss_dir
 enable_pcap
 enable_log_stdout
@@ -1364,6 +1366,7 @@ Optional Features:
   --enable-FEATURE[=ARG]  include FEATURE [ARG=yes]
   --enable-debug-logging  Enable debug logging in all modules
   --enable-openssl        compile in OpenSSL crypto engine
+  --enable-wolfssl        compile in wolfSSL crypto engine
   --enable-nss            compile in NSS crypto engine
   --enable-openssl-kdf    Use OpenSSL KDF algorithm
   --disable-pcap          Build without `pcap' library (-lpcap)
@@ -1373,6 +1376,7 @@ Optional Packages:
   --with-PACKAGE[=ARG]    use PACKAGE [ARG=yes]
   --without-PACKAGE       do not use PACKAGE (same as --with-PACKAGE=no)
   --with-openssl-dir      Location of OpenSSL installation
+  --with-wolfssl-dir      Location of wolfSSL installation
   --with-nss-dir          Location of NSS installation
   --with-log-file         Use file for logging
 
@@ -5461,6 +5465,18 @@ fi
 { $as_echo "$as_me:${as_lineno-$LINENO}: result: $enable_openssl" >&5
 $as_echo "$enable_openssl" >&6; }
 
+{ $as_echo "$as_me:${as_lineno-$LINENO}: checking whether to leverage wolfSSL crypto" >&5
+$as_echo_n "checking whether to leverage wolfSSL crypto... " >&6; }
+# Check whether --enable-wolfssl was given.
+if test "${enable_wolfssl+set}" = set; then :
+  enableval=$enable_wolfssl;
+else
+  enable_wolfssl=no
+fi
+
+{ $as_echo "$as_me:${as_lineno-$LINENO}: result: $enable_wolfssl" >&5
+$as_echo "$enable_wolfssl" >&6; }
+
 { $as_echo "$as_me:${as_lineno-$LINENO}: checking whether to leverage NSS crypto" >&5
 $as_echo_n "checking whether to leverage NSS crypto... " >&6; }
 # Check whether --enable-nss was given.
@@ -6035,6 +6051,161 @@ fi
 $as_echo "#define OPENSSL_KDF 1" >>confdefs.h
 
    fi
+elif test "$enable_wolfssl" = "yes"; then
+   { $as_echo "$as_me:${as_lineno-$LINENO}: checking for user specified wolfSSL directory" >&5
+$as_echo_n "checking for user specified wolfSSL directory... " >&6; }
+
+# Check whether --with-wolfssl-dir was given.
+if test "${with_wolfssl_dir+set}" = set; then :
+  withval=$with_wolfssl_dir; if test -d $with_wolfssl_dir/lib; then
+         CFLAGS="$CFLAGS -I$with_wolfssl_dir/include -I$with_wolfssl_dir/include/wolfssl"
+         if test "x$LDFLAGS" = "x"; then
+           LDFLAGS="-L$with_wolfssl_dir/lib"
+         else
+           LDFLAGS="$LDFLAGS -L$with_wolfssl_dir/lib"
+         fi
+         { $as_echo "$as_me:${as_lineno-$LINENO}: result: $with_wolfssl_dir" >&5
+$as_echo "$with_wolfssl_dir" >&6; }
+       else
+         { $as_echo "$as_me:${as_lineno-$LINENO}: result: invalid" >&5
+$as_echo "invalid" >&6; }
+         { { $as_echo "$as_me:${as_lineno-$LINENO}: error: in \`$ac_pwd':" >&5
+$as_echo "$as_me: error: in \`$ac_pwd':" >&2;}
+as_fn_error $? "Invalid wolfSSL location: $with_wolfssl_dir
+See \`config.log' for more details" "$LINENO" 5; }
+       fi
+else
+  { $as_echo "$as_me:${as_lineno-$LINENO}: result: no" >&5
+$as_echo "no" >&6; }
+fi
+
+
+   { $as_echo "$as_me:${as_lineno-$LINENO}: checking for dlopen in -ldl" >&5
+$as_echo_n "checking for dlopen in -ldl... " >&6; }
+if ${ac_cv_lib_dl_dlopen+:} false; then :
+  $as_echo_n "(cached) " >&6
+else
+  ac_check_lib_save_LIBS=$LIBS
+LIBS="-ldl  $LIBS"
+cat confdefs.h - <<_ACEOF >conftest.$ac_ext
+/* end confdefs.h.  */
+
+/* Override any GCC internal prototype to avoid an error.
+   Use char because int might match the return type of a GCC
+   builtin and then its argument prototype would still apply.  */
+#ifdef __cplusplus
+extern "C"
+#endif
+char dlopen ();
+int
+main ()
+{
+return dlopen ();
+  ;
+  return 0;
+}
+_ACEOF
+if ac_fn_c_try_link "$LINENO"; then :
+  ac_cv_lib_dl_dlopen=yes
+else
+  ac_cv_lib_dl_dlopen=no
+fi
+rm -f core conftest.err conftest.$ac_objext \
+    conftest$ac_exeext conftest.$ac_ext
+LIBS=$ac_check_lib_save_LIBS
+fi
+{ $as_echo "$as_me:${as_lineno-$LINENO}: result: $ac_cv_lib_dl_dlopen" >&5
+$as_echo "$ac_cv_lib_dl_dlopen" >&6; }
+if test "x$ac_cv_lib_dl_dlopen" = xyes; then :
+  cat >>confdefs.h <<_ACEOF
+#define HAVE_LIBDL 1
+_ACEOF
+
+  LIBS="-ldl $LIBS"
+
+else
+  { $as_echo "$as_me:${as_lineno-$LINENO}: WARNING: can't find libdl" >&5
+$as_echo "$as_me: WARNING: can't find libdl" >&2;}
+fi
+
+
+
+$as_echo "#define GCM 1" >>confdefs.h
+
+
+$as_echo "#define WOLFSSL 1" >>confdefs.h
+
+   AES_ICM_OBJS="crypto/cipher/aes_icm_wssl.o crypto/cipher/aes_gcm_wssl.o"
+   HMAC_OBJS=crypto/hash/hmac_wssl.o
+   USE_EXTERNAL_CRYPTO=1
+
+
+   { $as_echo "$as_me:${as_lineno-$LINENO}: checking whether to leverage wolfSSL KDF algorithm" >&5
+$as_echo_n "checking whether to leverage wolfSSL KDF algorithm... " >&6; }
+   { $as_echo "$as_me:${as_lineno-$LINENO}: checking for library containing wc_SRTCP_KDF" >&5
+$as_echo_n "checking for library containing wc_SRTCP_KDF... " >&6; }
+if ${ac_cv_search_wc_SRTCP_KDF+:} false; then :
+  $as_echo_n "(cached) " >&6
+else
+  ac_func_search_save_LIBS=$LIBS
+cat confdefs.h - <<_ACEOF >conftest.$ac_ext
+/* end confdefs.h.  */
+
+/* Override any GCC internal prototype to avoid an error.
+   Use char because int might match the return type of a GCC
+   builtin and then its argument prototype would still apply.  */
+#ifdef __cplusplus
+extern "C"
+#endif
+char wc_SRTCP_KDF ();
+int
+main ()
+{
+return wc_SRTCP_KDF ();
+  ;
+  return 0;
+}
+_ACEOF
+for ac_lib in '' wolfssl; do
+  if test -z "$ac_lib"; then
+    ac_res="none required"
+  else
+    ac_res=-l$ac_lib
+    LIBS="-l$ac_lib  $ac_func_search_save_LIBS"
+  fi
+  if ac_fn_c_try_link "$LINENO"; then :
+  ac_cv_search_wc_SRTCP_KDF=$ac_res
+fi
+rm -f core conftest.err conftest.$ac_objext \
+    conftest$ac_exeext
+  if ${ac_cv_search_wc_SRTCP_KDF+:} false; then :
+  break
+fi
+done
+if ${ac_cv_search_wc_SRTCP_KDF+:} false; then :
+
+else
+  ac_cv_search_wc_SRTCP_KDF=no
+fi
+rm conftest.$ac_ext
+LIBS=$ac_func_search_save_LIBS
+fi
+{ $as_echo "$as_me:${as_lineno-$LINENO}: result: $ac_cv_search_wc_SRTCP_KDF" >&5
+$as_echo "$ac_cv_search_wc_SRTCP_KDF" >&6; }
+ac_res=$ac_cv_search_wc_SRTCP_KDF
+if test "$ac_res" != no; then :
+  test "$ac_res" = "none required" || LIBS="$ac_res $LIBS"
+
+else
+  { { $as_echo "$as_me:${as_lineno-$LINENO}: error: in \`$ac_pwd':" >&5
+$as_echo "$as_me: error: in \`$ac_pwd':" >&2;}
+as_fn_error $? "can't find wolfssl KDF lib
+See \`config.log' for more details" "$LINENO" 5; }
+fi
+
+
+$as_echo "#define WOLFSSL_KDF 1" >>confdefs.h
+
 elif test "$enable_nss" = "yes"; then
    { $as_echo "$as_me:${as_lineno-$LINENO}: checking for user specified NSS directory" >&5
 $as_echo_n "checking for user specified NSS directory... " >&6; }

--- a/configure.ac
+++ b/configure.ac
@@ -210,6 +210,12 @@ AC_ARG_ENABLE([openssl],
   [], [enable_openssl=no])
 AC_MSG_RESULT([$enable_openssl])
 
+AC_MSG_CHECKING([whether to leverage wolfSSL crypto])
+AC_ARG_ENABLE([wolfssl],
+  [AS_HELP_STRING([--enable-wolfssl], [compile in wolfSSL crypto engine])],
+  [], [enable_wolfssl=no])
+AC_MSG_RESULT([$enable_wolfssl])
+
 AC_MSG_CHECKING([whether to leverage NSS crypto])
 AC_ARG_ENABLE([nss],
   [AS_HELP_STRING([--enable-nss], [compile in NSS crypto engine])],
@@ -275,6 +281,36 @@ if test "$enable_openssl" = "yes"; then
        [], [AC_MSG_FAILURE([can't find openssl KDF lib])])
      AC_DEFINE([OPENSSL_KDF], [1], [Define this to use OpenSSL KDF for SRTP.])
    fi
+elif test "$enable_wolfssl" = "yes"; then
+   AC_MSG_CHECKING([for user specified wolfSSL directory])
+   AC_ARG_WITH([wolfssl-dir],
+      [AS_HELP_STRING([--with-wolfssl-dir], [Location of wolfSSL installation])],
+       [if test -d $with_wolfssl_dir/lib; then
+         CFLAGS="$CFLAGS -I$with_wolfssl_dir/include -I$with_wolfssl_dir/include/wolfssl"
+         if test "x$LDFLAGS" = "x"; then
+           LDFLAGS="-L$with_wolfssl_dir/lib"
+         else
+           LDFLAGS="$LDFLAGS -L$with_wolfssl_dir/lib"
+         fi
+         AC_MSG_RESULT([$with_wolfssl_dir])
+       else
+         AC_MSG_RESULT([invalid])
+         AC_MSG_FAILURE([Invalid wolfSSL location: $with_wolfssl_dir])
+       fi],
+      [AC_MSG_RESULT([no])])
+
+   AC_CHECK_LIB([dl], [dlopen], [], [AC_MSG_WARN([can't find libdl])])
+
+   AC_DEFINE([GCM], [1], [Define this to use AES-GCM.])
+   AC_DEFINE([WOLFSSL], [1], [Define this to use wolfSSL crypto.])
+   AES_ICM_OBJS="crypto/cipher/aes_icm_wssl.o crypto/cipher/aes_gcm_wssl.o"
+   HMAC_OBJS=crypto/hash/hmac_wssl.o
+   AC_SUBST([USE_EXTERNAL_CRYPTO], [1])
+
+   AC_MSG_CHECKING([whether to leverage wolfSSL KDF algorithm])
+   AC_SEARCH_LIBS([wc_SRTCP_KDF], [wolfssl],
+     [], [AC_MSG_FAILURE([can't find wolfssl KDF lib])])
+   AC_DEFINE([WOLFSSL_KDF], [1], [Define this to use wolfSSL KDF for SRTP.])
 elif test "$enable_nss" = "yes"; then
    AC_MSG_CHECKING([for user specified NSS directory])
    AC_ARG_WITH([nss-dir],

--- a/crypto/cipher/aes_gcm_wssl.c
+++ b/crypto/cipher/aes_gcm_wssl.c
@@ -1,0 +1,478 @@
+/*
+ * aes_gcm_wssl.c
+ *
+ * AES Galois Counter Mode using wolfSSL
+ *
+ * Sean Parkinson, wolfSSL
+ *
+ */
+
+/*
+ *
+ * Copyright (c) 2013-2017, Cisco Systems, Inc.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ *   Redistributions of source code must retain the above copyright
+ *   notice, this list of conditions and the following disclaimer.
+ *
+ *   Redistributions in binary form must reproduce the above
+ *   copyright notice, this list of conditions and the following
+ *   disclaimer in the documentation and/or other materials provided
+ *   with the distribution.
+ *
+ *   Neither the name of the Cisco Systems, Inc. nor the names of its
+ *   contributors may be used to endorse or promote products derived
+ *   from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT HOLDERS OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+ * INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+ * STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED
+ * OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ */
+
+#ifdef HAVE_CONFIG_H
+#include <config.h>
+#endif
+#ifndef WOLFSSL_USER_SETTINGS
+#include <wolfssl/options.h>
+#endif
+#include <wolfssl/wolfcrypt/settings.h>
+#include <wolfssl/wolfcrypt/aes.h>
+#include "aes_gcm.h"
+#include "alloc.h"
+#include "err.h" /* for srtp_debug */
+#include "crypto_types.h"
+#include "cipher_types.h"
+#include "cipher_test_cases.h"
+
+srtp_debug_module_t srtp_mod_aes_gcm = {
+    0,             /* debugging is off by default */
+    "aes gcm wssl" /* printable module name       */
+};
+
+/**
+ * SRTP IV Formation for AES-GCM
+ * https://tools.ietf.org/html/rfc7714#section-8.1
+ *   0  0  0  0  0  0  0  0  0  0  1  1
+ *   0  1  2  3  4  5  6  7  8  9  0  1
+ *  +--+--+--+--+--+--+--+--+--+--+--+--+
+ *  |00|00| SSRC      | ROC       | SEQ |---+
+ *  +--+--+--+--+--+--+--+--+--+--+--+--+   |
+ *  |
+ *  +--+--+--+--+--+--+--+--+--+--+--+--+   |
+ *  | Encryption Salt                   |->(+)
+ *  +--+--+--+--+--+--+--+--+--+--+--+--+   |
+ *                                          |
+ *  +--+--+--+--+--+--+--+--+--+--+--+--+   |
+ *  | Initialization Vector             |<--+
+ *  +--+--+--+--+--+--+--+--+--+--+--+--+
+ *
+ * SRTCP IV Formation for AES-GCM
+ * https://tools.ietf.org/html/rfc7714#section-9.1
+ *
+ */
+
+/*
+ * For now we only support 8 and 16 octet tags.  The spec allows for
+ * optional 12 byte tag, which may be supported in the future.
+ */
+#define GCM_AUTH_TAG_LEN AES_BLOCK_SIZE
+#define GCM_AUTH_TAG_LEN_8 8
+
+#define FUNC_ENTRY() debug_print(srtp_mod_aes_gcm, "%s entry", __func__);
+
+/*
+ * This function allocates a new instance of this crypto engine.
+ * The key_len parameter should be one of 28 or 44 for
+ * AES-128-GCM or AES-256-GCM respectively.  Note that the
+ * key length includes the 14 byte salt value that is used when
+ * initializing the KDF.
+ */
+static srtp_err_status_t srtp_aes_gcm_wolfssl_alloc(srtp_cipher_t **c,
+                                                    size_t key_len,
+                                                    size_t tlen)
+{
+    FUNC_ENTRY();
+    srtp_aes_gcm_ctx_t *gcm;
+
+    debug_print(srtp_mod_aes_gcm, "allocating cipher with key length %zu",
+                key_len);
+    debug_print(srtp_mod_aes_gcm, "allocating cipher with tag length %zu",
+                tlen);
+
+    /*
+     * Verify the key_len is valid for one of: AES-128/256
+     */
+    if (key_len != SRTP_AES_GCM_128_KEY_LEN_WSALT &&
+        key_len != SRTP_AES_GCM_256_KEY_LEN_WSALT) {
+        return (srtp_err_status_bad_param);
+    }
+
+    if (tlen != GCM_AUTH_TAG_LEN && tlen != GCM_AUTH_TAG_LEN_8) {
+        return (srtp_err_status_bad_param);
+    }
+
+    /* allocate memory a cipher of type aes_gcm */
+    *c = (srtp_cipher_t *)srtp_crypto_alloc(sizeof(srtp_cipher_t));
+    if (*c == NULL) {
+        return (srtp_err_status_alloc_fail);
+    }
+
+    gcm = (srtp_aes_gcm_ctx_t *)srtp_crypto_alloc(sizeof(srtp_aes_gcm_ctx_t));
+    if (gcm == NULL) {
+        srtp_crypto_free(*c);
+        *c = NULL;
+        return (srtp_err_status_alloc_fail);
+    }
+    gcm->ctx = NULL;
+
+    /* set pointers */
+    (*c)->state = gcm;
+
+    /* setup cipher attributes */
+    switch (key_len) {
+    case SRTP_AES_GCM_128_KEY_LEN_WSALT:
+        (*c)->type = &srtp_aes_gcm_128;
+        (*c)->algorithm = SRTP_AES_GCM_128;
+        gcm->key_size = SRTP_AES_128_KEY_LEN;
+        gcm->tag_len = tlen;
+        break;
+    case SRTP_AES_GCM_256_KEY_LEN_WSALT:
+        (*c)->type = &srtp_aes_gcm_256;
+        (*c)->algorithm = SRTP_AES_GCM_256;
+        gcm->key_size = SRTP_AES_256_KEY_LEN;
+        gcm->tag_len = tlen;
+        break;
+    }
+
+    /* set key size        */
+    (*c)->key_len = key_len;
+
+    return (srtp_err_status_ok);
+}
+
+/*
+ * This function deallocates a GCM session
+ */
+static srtp_err_status_t srtp_aes_gcm_wolfssl_dealloc(srtp_cipher_t *c)
+{
+    srtp_aes_gcm_ctx_t *ctx;
+    FUNC_ENTRY();
+    ctx = (srtp_aes_gcm_ctx_t *)c->state;
+    if (ctx != NULL) {
+        if (ctx->ctx != NULL) {
+            wc_AesFree(ctx->ctx);
+            srtp_crypto_free(ctx->ctx);
+        }
+        /* zeroize the key material */
+        octet_string_set_to_zero(ctx, sizeof(srtp_aes_gcm_ctx_t));
+        srtp_crypto_free(ctx);
+    }
+
+    /* free memory */
+    srtp_crypto_free(c);
+
+    return (srtp_err_status_ok);
+}
+
+static srtp_err_status_t srtp_aes_gcm_wolfssl_context_init(void *cv,
+                                                           const uint8_t *key)
+{
+    FUNC_ENTRY();
+    srtp_aes_gcm_ctx_t *c = (srtp_aes_gcm_ctx_t *)cv;
+    int err;
+
+    c->dir = srtp_direction_any;
+#ifndef WOLFSSL_AESGCM_STREAM
+    c->aad_size = 0;
+#endif
+
+    debug_print(srtp_mod_aes_gcm, "key:  %s",
+                srtp_octet_string_hex_string(key, c->key_size));
+    switch (c->key_size) {
+    case SRTP_AES_256_KEY_LEN:
+    case SRTP_AES_128_KEY_LEN:
+        break;
+    default:
+        return (srtp_err_status_bad_param);
+        break;
+    }
+
+    if (c->ctx == NULL) {
+        c->ctx = (Aes *)srtp_crypto_alloc(sizeof(Aes));
+        if (c->ctx == NULL) {
+            return srtp_err_status_alloc_fail;
+        }
+        err = wc_AesInit(c->ctx, NULL, INVALID_DEVID);
+        if (err < 0) {
+            srtp_crypto_free(c->ctx);
+            c->ctx = NULL;
+            debug_print(srtp_mod_aes_gcm, "wolfSSL error code:  %d", err);
+            return srtp_err_status_init_fail;
+        }
+    }
+
+    err = wc_AesGcmSetKey(c->ctx, (const unsigned char *)key, c->key_size);
+    if (err < 0) {
+        debug_print(srtp_mod_aes_gcm, "wolfSSL error code:  %d", err);
+        return srtp_err_status_init_fail;
+    }
+
+    return (srtp_err_status_ok);
+}
+
+static srtp_err_status_t srtp_aes_gcm_wolfssl_set_iv(
+    void *cv,
+    uint8_t *iv,
+    srtp_cipher_direction_t direction)
+{
+    FUNC_ENTRY();
+    srtp_aes_gcm_ctx_t *c = (srtp_aes_gcm_ctx_t *)cv;
+#ifdef WOLFSSL_AESGCM_STREAM
+    int err;
+#endif
+
+    if (direction != srtp_direction_encrypt &&
+        direction != srtp_direction_decrypt) {
+        return (srtp_err_status_bad_param);
+    }
+    c->dir = direction;
+
+    debug_print(srtp_mod_aes_gcm, "setting iv: %s",
+                srtp_octet_string_hex_string(iv, GCM_NONCE_MID_SZ));
+#ifndef WOLFSSL_AESGCM_STREAM
+    c->iv_len = GCM_NONCE_MID_SZ;
+    memcpy(c->iv, iv, c->iv_len);
+
+    c->aad_size = 0;
+#else
+    err = wc_AesGcmInit(c->ctx, NULL, 0, iv, GCM_NONCE_MID_SZ);
+    if (err < 0) {
+        debug_print(srtp_mod_aes_gcm, "wolfSSL error code:  %d", err);
+        return srtp_err_status_init_fail;
+    }
+#endif
+
+    return (srtp_err_status_ok);
+}
+
+/*
+ * This function processes the AAD
+ *
+ * Parameters:
+ *	c	Crypto context
+ *	aad	Additional data to process for AEAD cipher suites
+ *	aad_len	length of aad buffer
+ */
+static srtp_err_status_t srtp_aes_gcm_wolfssl_set_aad(void *cv,
+                                                      const uint8_t *aad,
+                                                      size_t aad_len)
+{
+    FUNC_ENTRY();
+    srtp_aes_gcm_ctx_t *c = (srtp_aes_gcm_ctx_t *)cv;
+#ifdef WOLFSSL_AESGCM_STREAM
+    int err;
+#endif
+
+    debug_print(srtp_mod_aes_gcm, "setting AAD: %s",
+                srtp_octet_string_hex_string(aad, aad_len));
+
+#ifndef WOLFSSL_AESGCM_STREAM
+    if (aad_len + c->aad_size > MAX_AD_SIZE) {
+        return srtp_err_status_bad_param;
+    }
+
+    memcpy(c->aad + c->aad_size, aad, aad_len);
+    c->aad_size += aad_len;
+#else
+    if (c->dir == srtp_direction_encrypt) {
+        err = wc_AesGcmEncryptUpdate(c->ctx, NULL, NULL, 0, aad, aad_len);
+    } else {
+        err = wc_AesGcmDecryptUpdate(c->ctx, NULL, NULL, 0, aad, aad_len);
+    }
+    if (err < 0) {
+        debug_print(srtp_mod_aes_gcm, "wolfSSL error code:  %d", err);
+        return srtp_err_status_algo_fail;
+    }
+#endif
+
+    return (srtp_err_status_ok);
+}
+
+/*
+ * This function encrypts a buffer using AES GCM mode
+ *
+ * Parameters:
+ *	c	Crypto context
+ *	buf	data to encrypt
+ *	enc_len	length of encrypt buffer
+ */
+static srtp_err_status_t srtp_aes_gcm_wolfssl_encrypt(void *cv,
+                                                      unsigned char *buf,
+                                                      size_t *enc_len)
+{
+    FUNC_ENTRY();
+    srtp_aes_gcm_ctx_t *c = (srtp_aes_gcm_ctx_t *)cv;
+    int err;
+
+    if (c->dir != srtp_direction_encrypt && c->dir != srtp_direction_decrypt) {
+        return (srtp_err_status_bad_param);
+    }
+
+#ifndef WOLFSSL_AESGCM_STREAM
+    err = wc_AesGcmEncrypt(c->ctx, buf, buf, *enc_len, c->iv, c->iv_len, c->tag,
+                           c->tag_len, c->aad, c->aad_size);
+
+    c->aad_size = 0;
+#else
+    err = wc_AesGcmEncryptUpdate(c->ctx, buf, buf, *enc_len, NULL, 0);
+#endif
+    if (err < 0) {
+        debug_print(srtp_mod_aes_gcm, "wolfSSL error code:  %d", err);
+        return srtp_err_status_bad_param;
+    }
+
+    return (srtp_err_status_ok);
+}
+
+/*
+ * This function calculates and returns the GCM tag for a given context.
+ * This should be called after encrypting the data.  The *len value
+ * is increased by the tag size.  The caller must ensure that *buf has
+ * enough room to accept the appended tag.
+ *
+ * Parameters:
+ *	c	Crypto context
+ *	buf	data to encrypt
+ *	len	length of encrypt buffer
+ */
+static srtp_err_status_t srtp_aes_gcm_wolfssl_get_tag(void *cv,
+                                                      uint8_t *buf,
+                                                      size_t *len)
+{
+    FUNC_ENTRY();
+    srtp_aes_gcm_ctx_t *c = (srtp_aes_gcm_ctx_t *)cv;
+#ifdef WOLFSSL_AESGCM_STREAM
+    int err;
+#endif
+
+    debug_print(srtp_mod_aes_gcm, "appended tag size:  %d", c->tag_len);
+    *len = c->tag_len;
+#ifndef WOLFSSL_AESGCM_STREAM
+    memcpy(buf, c->tag, c->tag_len);
+#else
+    err = wc_AesGcmEncryptFinal(c->ctx, buf, c->tag_len);
+    if (err < 0) {
+        debug_print(srtp_mod_aes_gcm, "wolfSSL error code:  %d", err);
+        return srtp_err_status_algo_fail;
+    }
+#endif
+    return (srtp_err_status_ok);
+}
+
+/*
+ * This function decrypts a buffer using AES GCM mode
+ *
+ * Parameters:
+ *	c	Crypto context
+ *	buf	data to encrypt
+ *	enc_len	length of encrypt buffer
+ */
+static srtp_err_status_t srtp_aes_gcm_wolfssl_decrypt(void *cv,
+                                                      unsigned char *buf,
+                                                      size_t *enc_len)
+{
+    FUNC_ENTRY();
+    srtp_aes_gcm_ctx_t *c = (srtp_aes_gcm_ctx_t *)cv;
+    int err;
+
+    if (c->dir != srtp_direction_encrypt && c->dir != srtp_direction_decrypt) {
+        return (srtp_err_status_bad_param);
+    }
+
+#ifndef WOLFSSL_AESGCM_STREAM
+    debug_print(srtp_mod_aes_gcm, "AAD: %s",
+                srtp_octet_string_hex_string(c->aad, c->aad_size));
+
+    err = wc_AesGcmDecrypt(c->ctx, buf, buf, (*enc_len - c->tag_len), c->iv,
+                           c->iv_len, buf + (*enc_len - c->tag_len), c->tag_len,
+                           c->aad, c->aad_size);
+    c->aad_size = 0;
+#else
+    err = wc_AesGcmDecryptUpdate(c->ctx, buf, buf, (*enc_len - c->tag_len),
+                                 NULL, 0);
+    if (err < 0) {
+        debug_print(srtp_mod_aes_gcm, "wolfSSL error code:  %d", err);
+        return (srtp_err_status_algo_fail);
+    }
+    err = wc_AesGcmDecryptFinal(c->ctx, buf + (*enc_len - c->tag_len),
+                                c->tag_len);
+#endif
+    if (err < 0) {
+        debug_print(srtp_mod_aes_gcm, "wolfSSL error code:  %d", err);
+        return (srtp_err_status_auth_fail);
+    }
+
+    /*
+     * Reduce the buffer size by the tag length since the tag
+     * is not part of the original payload
+     */
+    *enc_len -= c->tag_len;
+
+    return (srtp_err_status_ok);
+}
+
+/*
+ * Name of this crypto engine
+ */
+static const char srtp_aes_gcm_128_wolfssl_description[] =
+    "AES-128 GCM using wolfssl";
+static const char srtp_aes_gcm_256_wolfssl_description[] =
+    "AES-256 GCM using wolfssl";
+
+/*
+ * This is the vector function table for this crypto engine.
+ */
+const srtp_cipher_type_t srtp_aes_gcm_128 = {
+    srtp_aes_gcm_wolfssl_alloc,
+    srtp_aes_gcm_wolfssl_dealloc,
+    srtp_aes_gcm_wolfssl_context_init,
+    srtp_aes_gcm_wolfssl_set_aad,
+    srtp_aes_gcm_wolfssl_encrypt,
+    srtp_aes_gcm_wolfssl_decrypt,
+    srtp_aes_gcm_wolfssl_set_iv,
+    srtp_aes_gcm_wolfssl_get_tag,
+    srtp_aes_gcm_128_wolfssl_description,
+    &srtp_aes_gcm_128_test_case_0,
+    SRTP_AES_GCM_128
+};
+
+/*
+ * This is the vector function table for this crypto engine.
+ */
+const srtp_cipher_type_t srtp_aes_gcm_256 = {
+    srtp_aes_gcm_wolfssl_alloc,
+    srtp_aes_gcm_wolfssl_dealloc,
+    srtp_aes_gcm_wolfssl_context_init,
+    srtp_aes_gcm_wolfssl_set_aad,
+    srtp_aes_gcm_wolfssl_encrypt,
+    srtp_aes_gcm_wolfssl_decrypt,
+    srtp_aes_gcm_wolfssl_set_iv,
+    srtp_aes_gcm_wolfssl_get_tag,
+    srtp_aes_gcm_256_wolfssl_description,
+    &srtp_aes_gcm_256_test_case_0,
+    SRTP_AES_GCM_256
+};

--- a/crypto/cipher/aes_icm_wssl.c
+++ b/crypto/cipher/aes_icm_wssl.c
@@ -1,0 +1,390 @@
+/*
+ * aes_icm_wssl.c
+ *
+ * AES Integer Counter Mode using wolfSSL
+ *
+ * Sean Parkinson, wolfSSL
+ */
+
+/*
+ *
+ * Copyright (c) 2013-2017, Cisco Systems, Inc.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ *   Redistributions of source code must retain the above copyright
+ *   notice, this list of conditions and the following disclaimer.
+ *
+ *   Redistributions in binary form must reproduce the above
+ *   copyright notice, this list of conditions and the following
+ *   disclaimer in the documentation and/or other materials provided
+ *   with the distribution.
+ *
+ *   Neither the name of the Cisco Systems, Inc. nor the names of its
+ *   contributors may be used to endorse or promote products derived
+ *   from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT HOLDERS OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+ * INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+ * STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED
+ * OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ */
+
+#ifdef HAVE_CONFIG_H
+#include <config.h>
+#endif
+#ifndef WOLFSSL_USER_SETTINGS
+#include <wolfssl/options.h>
+#endif
+#include <wolfssl/wolfcrypt/settings.h>
+#include <wolfssl/wolfcrypt/aes.h>
+#include "aes_icm_ext.h"
+#include "crypto_types.h"
+#include "err.h" /* for srtp_debug */
+#include "alloc.h"
+#include "cipher_types.h"
+#include "cipher_test_cases.h"
+
+srtp_debug_module_t srtp_mod_aes_icm = {
+    0,             /* debugging is off by default */
+    "aes icm wssl" /* printable module name       */
+};
+
+/*
+ * integer counter mode works as follows:
+ *
+ * https://tools.ietf.org/html/rfc3711#section-4.1.1
+ *
+ * E(k, IV) || E(k, IV + 1 mod 2^128) || E(k, IV + 2 mod 2^128) ...
+ * IV = (k_s * 2^16) XOR (SSRC * 2^64) XOR (i * 2^16)
+ *
+ * IV SHALL be defined by the SSRC, the SRTP packet index i,
+ * and the SRTP session salting key k_s.
+ *
+ * SSRC: 32bits.
+ * Sequence number: 16bits.
+ * nonce is 64bits. .
+ * packet index = ROC || SEQ. (ROC: Rollover counter)
+ *
+ * 16 bits
+ * <----->
+ * +------+------+------+------+------+------+------+------+
+ * |           nonce           |    packet index    |  ctr |---+
+ * +------+------+------+------+------+------+------+------+   |
+ *                                                             |
+ * +------+------+------+------+------+------+------+------+   v
+ * |                      salt                      |000000|->(+)
+ * +------+------+------+------+------+------+------+------+   |
+ *                                                             |
+ *                                                        +---------+
+ *                                                        | encrypt |
+ *                                                        +---------+
+ *                                                             |
+ * +------+------+------+------+------+------+------+------+   |
+ * |                    keystream block                    |<--+
+ * +------+------+------+------+------+------+------+------+
+ *
+ * All fields are big-endian
+ *
+ * ctr is the block counter, which increments from zero for
+ * each packet (16 bits wide)
+ *
+ * packet index is distinct for each packet (48 bits wide)
+ *
+ * nonce can be distinct across many uses of the same key, or
+ * can be a fixed value per key, or can be per-packet randomness
+ * (64 bits)
+ *
+ */
+
+/*
+ * This function allocates a new instance of this crypto engine.
+ * The key_len parameter should be one of 30, 38, or 46 for
+ * AES-128, AES-192, and AES-256 respectively.  Note, this key_len
+ * value is inflated, as it also accounts for the 112 bit salt
+ * value.  The tlen argument is for the AEAD tag length, which
+ * isn't used in counter mode.
+ */
+static srtp_err_status_t srtp_aes_icm_wolfssl_alloc(srtp_cipher_t **c,
+                                                    size_t key_len,
+                                                    size_t tlen)
+{
+    srtp_aes_icm_ctx_t *icm;
+    (void)tlen;
+
+    debug_print(srtp_mod_aes_icm, "allocating cipher with key length %zu",
+                key_len);
+
+    /*
+     * Verify the key_len is valid for one of: AES-128/192/256
+     */
+    if (key_len != SRTP_AES_ICM_128_KEY_LEN_WSALT &&
+        key_len != SRTP_AES_ICM_192_KEY_LEN_WSALT &&
+        key_len != SRTP_AES_ICM_256_KEY_LEN_WSALT) {
+        return srtp_err_status_bad_param;
+    }
+
+    /* allocate memory a cipher of type aes_icm */
+    *c = (srtp_cipher_t *)srtp_crypto_alloc(sizeof(srtp_cipher_t));
+    if (*c == NULL) {
+        return srtp_err_status_alloc_fail;
+    }
+
+    icm = (srtp_aes_icm_ctx_t *)srtp_crypto_alloc(sizeof(srtp_aes_icm_ctx_t));
+    if (icm == NULL) {
+        srtp_crypto_free(*c);
+        *c = NULL;
+        return srtp_err_status_alloc_fail;
+    }
+    icm->ctx = NULL;
+
+    (*c)->state = icm;
+
+    /* setup cipher parameters */
+    switch (key_len) {
+    case SRTP_AES_ICM_128_KEY_LEN_WSALT:
+        (*c)->algorithm = SRTP_AES_ICM_128;
+        (*c)->type = &srtp_aes_icm_128;
+        icm->key_size = SRTP_AES_128_KEY_LEN;
+        break;
+    case SRTP_AES_ICM_192_KEY_LEN_WSALT:
+        (*c)->algorithm = SRTP_AES_ICM_192;
+        (*c)->type = &srtp_aes_icm_192;
+        icm->key_size = SRTP_AES_192_KEY_LEN;
+        break;
+    case SRTP_AES_ICM_256_KEY_LEN_WSALT:
+        (*c)->algorithm = SRTP_AES_ICM_256;
+        (*c)->type = &srtp_aes_icm_256;
+        icm->key_size = SRTP_AES_256_KEY_LEN;
+        break;
+    }
+
+    /* set key size        */
+    (*c)->key_len = key_len;
+
+    return srtp_err_status_ok;
+}
+
+/*
+ * This function deallocates an instance of this engine
+ */
+static srtp_err_status_t srtp_aes_icm_wolfssl_dealloc(srtp_cipher_t *c)
+{
+    srtp_aes_icm_ctx_t *ctx;
+
+    if (c == NULL) {
+        return srtp_err_status_bad_param;
+    }
+
+    /*
+     * Free the aes context
+     */
+    ctx = (srtp_aes_icm_ctx_t *)c->state;
+    if (ctx != NULL) {
+        if (ctx->ctx != NULL) {
+            wc_AesFree(ctx->ctx);
+            srtp_crypto_free(ctx->ctx);
+        }
+        /* zeroize the key material */
+        octet_string_set_to_zero(ctx, sizeof(srtp_aes_icm_ctx_t));
+        srtp_crypto_free(ctx);
+    }
+
+    /* free memory */
+    srtp_crypto_free(c);
+
+    return srtp_err_status_ok;
+}
+
+static srtp_err_status_t srtp_aes_icm_wolfssl_context_init(void *cv,
+                                                           const uint8_t *key)
+{
+    srtp_aes_icm_ctx_t *c = (srtp_aes_icm_ctx_t *)cv;
+    int err;
+
+    if (c->ctx == NULL) {
+        c->ctx = (Aes *)srtp_crypto_alloc(sizeof(Aes));
+        if (c->ctx == NULL) {
+            return srtp_err_status_alloc_fail;
+        }
+
+        err = wc_AesInit(c->ctx, NULL, INVALID_DEVID);
+        if (err < 0) {
+            debug_print(srtp_mod_aes_icm, "wolfSSL error code: %d", err);
+            srtp_crypto_free(c->ctx);
+            c->ctx = NULL;
+            return srtp_err_status_init_fail;
+        }
+    }
+
+    /* set pointers */
+    /*
+     * set counter and initial values to 'offset' value, being careful not to
+     * go past the end of the key buffer
+     */
+    v128_set_to_zero(&c->counter);
+    v128_set_to_zero(&c->offset);
+    memcpy(&c->counter, key + c->key_size, SRTP_SALT_LEN);
+    memcpy(&c->offset, key + c->key_size, SRTP_SALT_LEN);
+
+    /* force last two octets of the offset to zero (for srtp compatibility) */
+    c->offset.v8[SRTP_SALT_LEN] = c->offset.v8[SRTP_SALT_LEN + 1] = 0;
+    c->counter.v8[SRTP_SALT_LEN] = c->counter.v8[SRTP_SALT_LEN + 1] = 0;
+    debug_print(srtp_mod_aes_icm, "key:  %s",
+                srtp_octet_string_hex_string(key, c->key_size));
+    debug_print(srtp_mod_aes_icm, "offset: %s", v128_hex_string(&c->offset));
+
+    switch (c->key_size) {
+    case SRTP_AES_256_KEY_LEN:
+    case SRTP_AES_192_KEY_LEN:
+    case SRTP_AES_128_KEY_LEN:
+        break;
+    default:
+        return srtp_err_status_bad_param;
+        break;
+    }
+
+    /* Counter mode always encrypts. */
+    err = wc_AesSetKey(c->ctx, key, c->key_size, NULL, AES_ENCRYPTION);
+    if (err < 0) {
+        debug_print(srtp_mod_aes_icm, "wolfSSL error code: %d", err);
+        return srtp_err_status_fail;
+    }
+
+    return srtp_err_status_ok;
+}
+
+/*
+ * aes_icm_set_iv(c, iv) sets the counter value to the exor of iv with
+ * the offset
+ */
+static srtp_err_status_t srtp_aes_icm_wolfssl_set_iv(
+    void *cv,
+    uint8_t *iv,
+    srtp_cipher_direction_t dir)
+{
+    srtp_aes_icm_ctx_t *c = (srtp_aes_icm_ctx_t *)cv;
+    v128_t nonce;
+    int err;
+    (void)dir;
+
+    /* set nonce (for alignment) */
+    v128_copy_octet_string(&nonce, iv);
+
+    debug_print(srtp_mod_aes_icm, "setting iv: %s", v128_hex_string(&nonce));
+
+    v128_xor(&c->counter, &c->offset, &nonce);
+
+    debug_print(srtp_mod_aes_icm, "set_counter: %s",
+                v128_hex_string(&c->counter));
+
+    err = wc_AesSetIV(c->ctx, c->counter.v8);
+    if (err < 0) {
+        debug_print(srtp_mod_aes_icm, "wolfSSL error code: %d", err);
+        return srtp_err_status_fail;
+    }
+
+    return srtp_err_status_ok;
+}
+
+/*
+ * This function encrypts a buffer using AES CTR mode
+ *
+ * Parameters:
+ *	c	Crypto context
+ *	buf	data to encrypt
+ *	enc_len	length of encrypt buffer
+ */
+static srtp_err_status_t srtp_aes_icm_wolfssl_encrypt(void *cv,
+                                                      uint8_t *buf,
+                                                      size_t *enc_len)
+{
+    srtp_aes_icm_ctx_t *c = (srtp_aes_icm_ctx_t *)cv;
+
+    int err;
+    debug_print(srtp_mod_aes_icm, "rs0: %s", v128_hex_string(&c->counter));
+
+    err = wc_AesCtrEncrypt(c->ctx, buf, buf, *enc_len);
+    if (err < 0) {
+        debug_print(srtp_mod_aes_icm, "wolfSSL encrypt error: %d", err);
+        return srtp_err_status_cipher_fail;
+    }
+
+    return srtp_err_status_ok;
+}
+
+/*
+ * Name of this crypto engine
+ */
+static const char srtp_aes_icm_128_wolfssl_description[] =
+    "AES-128 counter mode using wolfSSL";
+static const char srtp_aes_icm_192_wolfssl_description[] =
+    "AES-192 counter mode using wolfSSL";
+static const char srtp_aes_icm_256_wolfssl_description[] =
+    "AES-256 counter mode using wolfSSL";
+
+/*
+ * This is the function table for this crypto engine.
+ * note: the encrypt function is identical to the decrypt function
+ */
+const srtp_cipher_type_t srtp_aes_icm_128 = {
+    srtp_aes_icm_wolfssl_alloc,           /* */
+    srtp_aes_icm_wolfssl_dealloc,         /* */
+    srtp_aes_icm_wolfssl_context_init,    /* */
+    0,                                    /* set_aad */
+    srtp_aes_icm_wolfssl_encrypt,         /* */
+    srtp_aes_icm_wolfssl_encrypt,         /* */
+    srtp_aes_icm_wolfssl_set_iv,          /* */
+    0,                                    /* get_tag */
+    srtp_aes_icm_128_wolfssl_description, /* */
+    &srtp_aes_icm_128_test_case_0,        /* */
+    SRTP_AES_ICM_128                      /* */
+};
+
+/*
+ * This is the function table for this crypto engine.
+ * note: the encrypt function is identical to the decrypt function
+ */
+const srtp_cipher_type_t srtp_aes_icm_192 = {
+    srtp_aes_icm_wolfssl_alloc,           /* */
+    srtp_aes_icm_wolfssl_dealloc,         /* */
+    srtp_aes_icm_wolfssl_context_init,    /* */
+    0,                                    /* set_aad */
+    srtp_aes_icm_wolfssl_encrypt,         /* */
+    srtp_aes_icm_wolfssl_encrypt,         /* */
+    srtp_aes_icm_wolfssl_set_iv,          /* */
+    0,                                    /* get_tag */
+    srtp_aes_icm_192_wolfssl_description, /* */
+    &srtp_aes_icm_192_test_case_0,        /* */
+    SRTP_AES_ICM_192                      /* */
+};
+
+/*
+ * This is the function table for this crypto engine.
+ * note: the encrypt function is identical to the decrypt function
+ */
+const srtp_cipher_type_t srtp_aes_icm_256 = {
+    srtp_aes_icm_wolfssl_alloc,           /* */
+    srtp_aes_icm_wolfssl_dealloc,         /* */
+    srtp_aes_icm_wolfssl_context_init,    /* */
+    0,                                    /* set_aad */
+    srtp_aes_icm_wolfssl_encrypt,         /* */
+    srtp_aes_icm_wolfssl_encrypt,         /* */
+    srtp_aes_icm_wolfssl_set_iv,          /* */
+    0,                                    /* get_tag */
+    srtp_aes_icm_256_wolfssl_description, /* */
+    &srtp_aes_icm_256_test_case_0,        /* */
+    SRTP_AES_ICM_256                      /* */
+};

--- a/crypto/hash/hmac_wssl.c
+++ b/crypto/hash/hmac_wssl.c
@@ -1,0 +1,228 @@
+/*
+ * hmac_wssl.c
+ *
+ * Implementation of hmac srtp_auth_type_t that uses wolfSSL
+ *
+ * Sean Parkinson, wolfSSL
+ */
+/*
+ *
+ * Copyright(c) 2013-2017, Cisco Systems, Inc.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ *   Redistributions of source code must retain the above copyright
+ *   notice, this list of conditions and the following disclaimer.
+ *
+ *   Redistributions in binary form must reproduce the above
+ *   copyright notice, this list of conditions and the following
+ *   disclaimer in the documentation and/or other materials provided
+ *   with the distribution.
+ *
+ *   Neither the name of the Cisco Systems, Inc. nor the names of its
+ *   contributors may be used to endorse or promote products derived
+ *   from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT HOLDERS OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+ * INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+ * STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED
+ * OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ */
+
+#ifdef HAVE_CONFIG_H
+#include <config.h>
+#endif
+#ifndef WOLFSSL_USER_SETTINGS
+#include <wolfssl/options.h>
+#endif
+#include <wolfssl/wolfcrypt/settings.h>
+#include <wolfssl/wolfcrypt/hmac.h>
+#include "auth.h"
+#include "alloc.h"
+#include "err.h" /* for srtp_debug */
+#include "auth_test_cases.h"
+
+#define SHA1_DIGEST_SIZE 20
+
+/* the debug module for authentiation */
+
+srtp_debug_module_t srtp_mod_hmac = {
+    0,                /* debugging is off by default */
+    "hmac sha-1 wssl" /* printable name for module   */
+};
+
+static srtp_err_status_t srtp_hmac_wolfssl_alloc(srtp_auth_t **a,
+                                                 size_t key_len,
+                                                 size_t out_len)
+{
+    extern const srtp_auth_type_t srtp_hmac;
+    int err;
+
+    debug_print(srtp_mod_hmac, "allocating auth func with key length %zu",
+                key_len);
+    debug_print(srtp_mod_hmac, "                          tag length %zu",
+                out_len);
+
+    /* check output length - should be less than 20 bytes */
+    if (out_len > SHA1_DIGEST_SIZE) {
+        return srtp_err_status_bad_param;
+    }
+
+    *a = (srtp_auth_t *)srtp_crypto_alloc(sizeof(srtp_auth_t));
+    if (*a == NULL) {
+        return srtp_err_status_alloc_fail;
+    }
+    // allocate the buffer of wolfssl context.
+    (*a)->state = srtp_crypto_alloc(sizeof(Hmac));
+    if ((*a)->state == NULL) {
+        srtp_crypto_free(*a);
+        *a = NULL;
+        return srtp_err_status_alloc_fail;
+    }
+    err = wc_HmacInit((Hmac *)(*a)->state, NULL, INVALID_DEVID);
+    if (err < 0) {
+        srtp_crypto_free((*a)->state);
+        srtp_crypto_free(*a);
+        *a = NULL;
+        debug_print(srtp_mod_hmac, "wolfSSL error code: %d", err);
+        return srtp_err_status_init_fail;
+    }
+
+    /* set pointers */
+    (*a)->type = &srtp_hmac;
+    (*a)->out_len = out_len;
+    (*a)->key_len = key_len;
+    (*a)->prefix_len = 0;
+
+    return srtp_err_status_ok;
+}
+
+static srtp_err_status_t srtp_hmac_wolfssl_dealloc(srtp_auth_t *a)
+{
+    wc_HmacFree((Hmac *)a->state);
+    srtp_crypto_free(a->state);
+    /* zeroize entire state*/
+    octet_string_set_to_zero(a, sizeof(srtp_auth_t));
+
+    /* free memory */
+    srtp_crypto_free(a);
+
+    return srtp_err_status_ok;
+}
+
+static srtp_err_status_t srtp_hmac_wolfssl_start(void *statev)
+{
+    (void)statev;
+    return srtp_err_status_ok;
+}
+
+static srtp_err_status_t srtp_hmac_wolfssl_init(void *statev,
+                                                const uint8_t *key,
+                                                size_t key_len)
+{
+    Hmac *state = (Hmac *)statev;
+    int err;
+
+    err = wc_HmacSetKey(state, WC_SHA, key, key_len);
+    if (err < 0) {
+        debug_print(srtp_mod_hmac, "wolfSSL error code: %d", err);
+        return srtp_err_status_auth_fail;
+    }
+
+    return srtp_err_status_ok;
+}
+
+static srtp_err_status_t srtp_hmac_wolfssl_update(void *statev,
+                                                  const uint8_t *message,
+                                                  size_t msg_octets)
+{
+    Hmac *state = (Hmac *)statev;
+    int err;
+
+    debug_print(srtp_mod_hmac, "input: %s",
+                srtp_octet_string_hex_string(message, msg_octets));
+
+    err = wc_HmacUpdate(state, message, msg_octets);
+    if (err < 0) {
+        debug_print(srtp_mod_hmac, "wolfSSL error code: %d", err);
+        return srtp_err_status_auth_fail;
+    }
+
+    return srtp_err_status_ok;
+}
+
+static srtp_err_status_t srtp_hmac_wolfssl_compute(void *statev,
+                                                   const uint8_t *message,
+                                                   size_t msg_octets,
+                                                   size_t tag_len,
+                                                   uint8_t *result)
+{
+    Hmac *state = (Hmac *)statev;
+    uint8_t hash_value[WC_SHA_DIGEST_SIZE];
+    int err;
+    int i;
+
+    debug_print(srtp_mod_hmac, "input: %s",
+                srtp_octet_string_hex_string(message, msg_octets));
+
+    /* check tag length, return error if we can't provide the value expected */
+    if (tag_len > WC_SHA_DIGEST_SIZE) {
+        return srtp_err_status_bad_param;
+    }
+
+    /* hash message, copy output into H */
+    err = wc_HmacUpdate(state, message, msg_octets);
+    if (err < 0) {
+        debug_print(srtp_mod_hmac, "wolfSSL error code: %d", err);
+        return srtp_err_status_auth_fail;
+    }
+
+    err = wc_HmacFinal(state, hash_value);
+    if (err < 0) {
+        debug_print(srtp_mod_hmac, "wolfSSL error code: %d", err);
+        return srtp_err_status_auth_fail;
+    }
+
+    /* copy hash_value to *result */
+    for (i = 0; i < (int)tag_len; i++) {
+        result[i] = hash_value[i];
+    }
+
+    debug_print(srtp_mod_hmac, "output: %s",
+                srtp_octet_string_hex_string(hash_value, tag_len));
+
+    return srtp_err_status_ok;
+}
+
+/* end test case 0 */
+
+static const char srtp_hmac_wolfssl_description[] =
+    "hmac sha-1 authentication function using wolfSSL";
+
+/*
+ * srtp_auth_type_t hmac is the hmac metaobject
+ */
+
+const srtp_auth_type_t srtp_hmac = {
+    srtp_hmac_wolfssl_alloc,       /* */
+    srtp_hmac_wolfssl_dealloc,     /* */
+    srtp_hmac_wolfssl_init,        /* */
+    srtp_hmac_wolfssl_compute,     /* */
+    srtp_hmac_wolfssl_update,      /* */
+    srtp_hmac_wolfssl_start,       /* */
+    srtp_hmac_wolfssl_description, /* */
+    &srtp_hmac_test_case_0,        /* */
+    SRTP_HMAC_SHA1                 /* */
+};

--- a/crypto/include/aes_gcm.h
+++ b/crypto/include/aes_gcm.h
@@ -64,6 +64,33 @@ typedef struct {
 
 #endif /* OPENSSL */
 
+#ifdef WOLFSSL
+#define MAX_AD_SIZE 2048
+#ifdef HAVE_CONFIG_H
+#include <config.h>
+#endif
+#ifndef WOLFSSL_USER_SETTINGS
+#include <wolfssl/options.h>
+#endif
+#include <wolfssl/wolfcrypt/settings.h>
+#include <wolfssl/wolfcrypt/aes.h>
+
+typedef struct {
+    int key_size;
+    int tag_len;
+#ifndef WOLFSSL_AESGCM_STREAM
+    int aad_size;
+    int iv_len;
+    uint8_t iv[GCM_NONCE_MID_SZ];
+    uint8_t tag[AES_BLOCK_SIZE];
+    uint8_t aad[MAX_AD_SIZE];
+#endif
+    Aes *ctx;
+    srtp_cipher_direction_t dir;
+} srtp_aes_gcm_ctx_t;
+
+#endif /* WOLFSSL */
+
 #ifdef MBEDTLS
 #define MAX_AD_SIZE 2048
 #include <mbedtls/aes.h>

--- a/crypto/include/aes_icm_ext.h
+++ b/crypto/include/aes_icm_ext.h
@@ -63,6 +63,18 @@ typedef struct {
 
 #endif /* OPENSSL */
 
+#ifdef WOLFSSL
+
+#include <wolfssl/wolfcrypt/aes.h>
+typedef struct {
+    v128_t counter; /* holds the counter value          */
+    v128_t offset;  /* initial offset value             */
+    int key_size;
+    Aes *ctx;
+} srtp_aes_icm_ctx_t;
+
+#endif /* WOLFSSL */
+
 #ifdef MBEDTLS
 
 #include <mbedtls/aes.h>

--- a/crypto/include/cipher_types.h
+++ b/crypto/include/cipher_types.h
@@ -71,7 +71,7 @@ extern srtp_debug_module_t srtp_mod_alloc;
 /* debug modules for cipher types */
 extern srtp_debug_module_t srtp_mod_aes_icm;
 
-#if defined(OPENSSL) || defined(MBEDTLS) || defined(NSS)
+#if defined(OPENSSL) || defined(WOLFSSL) || defined(MBEDTLS) || defined(NSS)
 extern srtp_debug_module_t srtp_mod_aes_gcm;
 #endif
 

--- a/srtp/srtp.c
+++ b/srtp/srtp.c
@@ -60,6 +60,19 @@
 #include "aes_icm_ext.h"
 #endif
 
+#ifdef WOLFSSL
+#ifdef HAVE_CONFIG_H
+#include <config.h>
+#endif
+#ifndef WOLFSSL_USER_SETTINGS
+#include <wolfssl/options.h>
+#endif
+#include <wolfssl/wolfcrypt/settings.h>
+#ifdef WOLFSSL_KDF
+#include <wolfssl/wolfcrypt/kdf.h>
+#endif
+#endif
+
 #include <limits.h>
 #ifdef HAVE_NETINET_IN_H
 #include <netinet/in.h>
@@ -774,7 +787,87 @@ static srtp_err_status_t srtp_kdf_clear(srtp_kdf_t *kdf)
     return srtp_err_status_ok;
 }
 
-#else  /* if OPENSSL_KDF */
+#elif defined(WOLFSSL) && defined(WOLFSSL_KDF)
+#define MAX_SRTP_AESKEY_LEN AES_256_KEY_SIZE
+#define MAX_SRTP_SALT_LEN WC_SRTP_MAX_SALT
+
+/*
+ * srtp_kdf_t represents a key derivation function.  The SRTP
+ * default KDF is the only one implemented at present.
+ */
+typedef struct {
+    uint8_t master_key[MAX_SRTP_AESKEY_LEN];
+    int master_key_len;
+    uint8_t master_salt[MAX_SRTP_SALT_LEN];
+} srtp_kdf_t;
+
+static srtp_err_status_t srtp_kdf_init(srtp_kdf_t *kdf,
+                                       const uint8_t *key,
+                                       size_t key_len)
+{
+    size_t salt_len;
+
+    memset(kdf, 0x0, sizeof(srtp_kdf_t));
+
+    switch (key_len) {
+    case SRTP_AES_ICM_256_KEY_LEN_WSALT:
+        kdf->master_key_len = AES_256_KEY_SIZE;
+        break;
+    case SRTP_AES_ICM_192_KEY_LEN_WSALT:
+        kdf->master_key_len = AES_192_KEY_SIZE;
+        break;
+    case SRTP_AES_ICM_128_KEY_LEN_WSALT:
+        kdf->master_key_len = AES_128_KEY_SIZE;
+        break;
+    default:
+        return srtp_err_status_bad_param;
+        break;
+    }
+
+    memcpy(kdf->master_key, key, kdf->master_key_len);
+    salt_len = key_len - kdf->master_key_len;
+    memcpy(kdf->master_salt, key + kdf->master_key_len, salt_len);
+    memset(kdf->master_salt + salt_len, 0, MAX_SRTP_SALT_LEN - salt_len);
+
+    return srtp_err_status_ok;
+}
+
+static srtp_err_status_t srtp_kdf_generate(srtp_kdf_t *kdf,
+                                           srtp_prf_label label,
+                                           uint8_t *key,
+                                           size_t length)
+{
+    int err;
+
+    if (length == 0) {
+        return srtp_err_status_ok;
+    }
+    if (kdf->master_key_len == 0) {
+        return srtp_err_status_ok;
+    }
+    octet_string_set_to_zero(key, length);
+
+    err = wc_SRTP_KDF_label(kdf->master_key, kdf->master_key_len,
+                            kdf->master_salt, MAX_SRTP_SALT_LEN, -1, NULL,
+                            label, key, length);
+    if (err < 0) {
+        debug_print(mod_srtp, "wolfSSL SRTP KDF error: %d", err);
+        return (srtp_err_status_algo_fail);
+    }
+
+    return srtp_err_status_ok;
+}
+
+static srtp_err_status_t srtp_kdf_clear(srtp_kdf_t *kdf)
+{
+    octet_string_set_to_zero(kdf->master_key, MAX_SRTP_AESKEY_LEN);
+    kdf->master_key_len = 0;
+    octet_string_set_to_zero(kdf->master_salt, MAX_SRTP_SALT_LEN);
+
+    return srtp_err_status_ok;
+}
+
+#else  /* if OPENSSL_KDF || WOLFSSL_KDF */
 
 /*
  * srtp_kdf_t represents a key derivation function.  The SRTP
@@ -857,7 +950,7 @@ static srtp_err_status_t srtp_kdf_clear(srtp_kdf_t *kdf)
     kdf->cipher = NULL;
     return srtp_err_status_ok;
 }
-#endif /* else OPENSSL_KDF */
+#endif /* else OPENSSL_KDF || WOLFSSL_KDF */
 
 /*
  *  end of key derivation functions

--- a/test/srtp_driver.c
+++ b/test/srtp_driver.c
@@ -2482,7 +2482,6 @@ srtp_err_status_t srtp_validate_encrypted_extensions_headers(void)
 }
 
 #ifdef GCM
-
 /*
  * Headers of test vectors taken from RFC 6904, Appendix A
  */


### PR DESCRIPTION
To configure:
    ./configure --enable-wolfssl --with-wolfssl-dir=<wolfssl dir>

Add implementations of SRTP KDF, HMAC, AES-GCM and AES-CTR using wolfSSL.