### PR TITLE
disable test if include from a separate project

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -33,6 +33,10 @@ include(CheckTypeSize)
 include(CheckCSourceCompiles)
 include(ConfigSafeGuards)
 
+if(NOT PROJECT_IS_TOP_LEVEL)
+  set(LIBSRTP_TEST_APPS OFF)
+endif()
+
 if(ENABLE_WARNINGS)
     include(Warnings)
 endif()


### PR DESCRIPTION
When this cmake project is included by another project then only build the libsrtp library.