### PR TITLE
Meson, wolfSSL: changes to have meson builds able to use wolfSSL

### DIFF
--- a/.github/workflows/meson.yml
+++ b/.github/workflows/meson.yml
@@ -14,12 +14,14 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        crypto: [internal, openssl, openssl3, nss, mbedtls]
+        crypto: [internal, openssl, openssl3, wolfssl, nss, mbedtls]
         exclude:
           - os: windows-latest
             crypto: openssl
           - os: windows-latest
             crypto: openssl3
+          - os: windows-latest
+            crypto: wolfssl
           - os: windows-latest
             crypto: nss
           - os: windows-latest
@@ -33,6 +35,8 @@ jobs:
             meson-crypto-enable: "-Dcrypto-library=openssl"
           - crypto: openssl3
             meson-crypto-enable: "-Dcrypto-library=openssl"
+          - crypto: wolfssl
+            meson-crypto-enable: "-Dcrypto-library=wolfssl"
           - crypto: nss
             meson-crypto-enable: "-Dcrypto-library=nss"
           - crypto: mbedtls
@@ -61,6 +65,18 @@ jobs:
         choco install ninja
         pip3 install meson
 
+    - name: Setup Ubuntu wolfSSL
+      if: matrix.os == 'ubuntu-latest' && matrix.crypto == 'wolfssl'
+      run: |
+        git clone https://github.com/wolfSSL/wolfssl
+        cd wolfssl
+        git checkout v5.7.0-stable
+        ./autogen.sh
+        ./configure '--enable-srtp-kdf' '--enable-aesctr' '--enable-intelasm' '--enable-aesgcm-stream'
+        make
+        sudo make install
+        cd ..
+
     - name: Setup Ubuntu NSS
       if: matrix.os == 'ubuntu-latest' && matrix.crypto == 'nss'
       run: |
@@ -80,6 +96,24 @@ jobs:
       run: |
         brew install openssl@3
         echo "pkgconfig-crypto-dir=PKG_CONFIG_PATH=$(brew --prefix openssl@3)/lib/pkgconfig" >> $GITHUB_ENV
+
+    - name: Setup macOS wolfSSL
+      if: matrix.os == 'macos-latest' && matrix.crypto == 'wolfssl'
+      run: |
+        brew install autoconf automake libtool
+        git clone https://github.com/wolfSSL/wolfssl
+        cd wolfssl
+        git checkout v5.7.0-stable
+        ./autogen.sh
+        CPU=`sysctl -n machdep.cpu.brand_string`
+        if [[ "$CPU" =~ Intel ]]; then
+          ./configure '--enable-srtp-kdf' '--enable-aesctr' '--enable-intelasm' '--enable-aesgcm-stream'
+        else
+          ./configure '--enable-srtp-kdf' '--enable-aesctr' '--enable-armasm' '--enable-aesgcm-stream'
+        fi
+        make
+        sudo make install
+        cd ..
 
     - name: Setup macOS NSS
       if:  matrix.os == 'macos-latest' && matrix.crypto == 'nss'

--- a/crypto/test/meson.build
+++ b/crypto/test/meson.build
@@ -7,7 +7,7 @@ test_apps = [
   'env',
 ]
 
-if not use_openssl and not use_nss and not use_mbedtls
+if not use_openssl and not use_wolfssl and not use_nss and not use_mbedtls
   test_apps += ['sha1_driver']
 endif
 
@@ -20,7 +20,7 @@ foreach test_name : test_apps
   test(test_name, test_exe, args: ['-v'])
 endforeach
 
-if not use_openssl and not use_nss and not use_mbedtls
+if not use_openssl and not use_wolfssl and not use_nss and not use_mbedtls
   test_exe = executable('aes_calc',
     'aes_calc.c', '../../test/getopt_s.c', '../../test/util.c',
     include_directories: [config_incs, crypto_incs, srtp2_incs, test_incs],

--- a/meson.build
+++ b/meson.build
@@ -120,6 +120,7 @@ if get_option('debug-logging')
 endif
 
 use_openssl = false
+use_wolfssl = false
 use_nss = false
 use_mbedtls = false
 
@@ -141,6 +142,22 @@ if crypto_library == 'openssl'
     cdata.set('OPENSSL_KDF', true)
   elif get_option('crypto-library-kdf').enabled()
     error('KDF support has been enabled, but OpenSSL does not provide it')
+  endif
+elif crypto_library == 'wolfssl'
+  wolfssl_dep = dependency('wolfssl', version: '>= 5.7.0', required: true)
+  srtp2_deps += [wolfssl_dep]
+  cdata.set('GCM', true)
+  cdata.set('WOLFSSL', true)
+  cdata.set('USE_EXTERNAL_CRYPTO', true)
+  use_wolfssl = true
+  if (
+    wolfssl_dep.type_name() != 'internal' and
+    not get_option('crypto-library-kdf').disabled() and
+    cc.has_function('wc_SRTCP_KDF', dependencies: wolfssl_dep)
+  )
+    cdata.set('WOLFSSL_KDF', true)
+  elif get_option('crypto-library-kdf').enabled()
+    error('KDF support has been enabled, but wolfSSL does not provide it')
   endif
 elif crypto_library == 'nss'
   nss_dep = dependency('nss', version: '>= 1.0.1', required: true)
@@ -199,6 +216,11 @@ if use_openssl
     'crypto/cipher/aes_icm_ossl.c',
     'crypto/cipher/aes_gcm_ossl.c',
   )
+elif use_wolfssl
+  ciphers_sources += files(
+    'crypto/cipher/aes_icm_wssl.c',
+    'crypto/cipher/aes_gcm_wssl.c',
+  )
 elif use_nss
   ciphers_sources += files(
     'crypto/cipher/aes_icm_nss.c',
@@ -225,6 +247,10 @@ hashes_sources = files(
 if use_openssl
   hashes_sources += files(
     'crypto/hash/hmac_ossl.c',
+  )
+elif use_wolfssl
+  hashes_sources += files(
+    'crypto/hash/hmac_wssl.c',
   )
 elif use_nss
   hashes_sources += files(

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -4,8 +4,8 @@ option('log-stdout', type : 'boolean', value : false,
   description : 'Redirect logging to stdout')
 option('log-file', type : 'string', value : '',
   description : 'Write logging output into this file')
-option('crypto-library', type: 'combo', choices : ['none', 'openssl', 'nss', 'mbedtls'], value : 'none',
-  description : 'What external crypto library to leverage, if any (OpenSSL, NSS, or mbedtls)')
+option('crypto-library', type: 'combo', choices : ['none', 'openssl', 'wolfssl', 'nss', 'mbedtls'], value : 'none',
+  description : 'What external crypto library to leverage, if any (OpenSSL, wolfSSL, NSS, or mbedtls)')
 option('crypto-library-kdf', type : 'feature', value : 'auto',
   description : 'Use the external crypto library for Key Derivation Function support')
 option('fuzzer', type : 'feature', value : 'disabled',

--- a/test/meson.build
+++ b/test/meson.build
@@ -54,7 +54,7 @@ if can_run_rtpw
   endif
 
   rtpw_test_gcm_sh = find_program('rtpw_test_gcm.sh', required: false)
-  if (use_openssl or use_nss or use_mbedtls) and rtpw_test_gcm_sh.found()
+  if (use_openssl or use_wolfssl or use_nss or use_mbedtls) and rtpw_test_gcm_sh.found()
     test('rtpw_test_gcm', rtpw_test_gcm_sh,
          args: ['-w', words_txt],
          depends: rtpw_exe,


### PR DESCRIPTION
Change meson build files to support using wolfSSL to provide cryptographic implementations.
Added wolfSSL to meson workflow for CI loop.