### PR TITLE
[code] fix type conversion (XCode + arm64)

### DIFF
--- a/crypto/cipher/aes_gcm_ossl.c
+++ b/crypto/cipher/aes_gcm_ossl.c
@@ -270,13 +270,13 @@ static srtp_err_status_t srtp_aes_gcm_openssl_set_aad(void *cv,
          */
         uint8_t dummy_tag[GCM_AUTH_TAG_LEN];
         memset(dummy_tag, 0x0, GCM_AUTH_TAG_LEN);
-        if (!EVP_CIPHER_CTX_ctrl(c->ctx, EVP_CTRL_GCM_SET_TAG, c->tag_len,
+        if (!EVP_CIPHER_CTX_ctrl(c->ctx, EVP_CTRL_GCM_SET_TAG, (int)c->tag_len,
                                  &dummy_tag)) {
             return (srtp_err_status_algo_fail);
         }
     }
 
-    rv = EVP_Cipher(c->ctx, NULL, aad, aad_len);
+    rv = EVP_Cipher(c->ctx, NULL, aad, (unsigned int)aad_len);
     if (rv < 0 || (uint32_t)rv != aad_len) {
         return (srtp_err_status_algo_fail);
     } else {
@@ -304,7 +304,7 @@ static srtp_err_status_t srtp_aes_gcm_openssl_encrypt(void *cv,
     /*
      * Encrypt the data
      */
-    EVP_Cipher(c->ctx, buf, buf, *enc_len);
+    EVP_Cipher(c->ctx, buf, buf, (unsigned int)*enc_len);
 
     return (srtp_err_status_ok);
 }
@@ -333,7 +333,7 @@ static srtp_err_status_t srtp_aes_gcm_openssl_get_tag(void *cv,
     /*
      * Retreive the tag
      */
-    if (!EVP_CIPHER_CTX_ctrl(c->ctx, EVP_CTRL_GCM_GET_TAG, c->tag_len, buf)) {
+    if (!EVP_CIPHER_CTX_ctrl(c->ctx, EVP_CTRL_GCM_GET_TAG, (int)c->tag_len, buf)) {
         return (srtp_err_status_algo_fail);
     }
 
@@ -365,11 +365,11 @@ static srtp_err_status_t srtp_aes_gcm_openssl_decrypt(void *cv,
     /*
      * Set the tag before decrypting
      */
-    if (!EVP_CIPHER_CTX_ctrl(c->ctx, EVP_CTRL_GCM_SET_TAG, c->tag_len,
+    if (!EVP_CIPHER_CTX_ctrl(c->ctx, EVP_CTRL_GCM_SET_TAG, (int)c->tag_len,
                              buf + (*enc_len - c->tag_len))) {
         return (srtp_err_status_auth_fail);
     }
-    EVP_Cipher(c->ctx, buf, buf, *enc_len - c->tag_len);
+    EVP_Cipher(c->ctx, buf, buf, (unsigned int)(*enc_len - c->tag_len));
 
     /*
      * Check the tag

--- a/crypto/cipher/aes_gcm_ossl.c
+++ b/crypto/cipher/aes_gcm_ossl.c
@@ -333,7 +333,8 @@ static srtp_err_status_t srtp_aes_gcm_openssl_get_tag(void *cv,
     /*
      * Retreive the tag
      */
-    if (!EVP_CIPHER_CTX_ctrl(c->ctx, EVP_CTRL_GCM_GET_TAG, (int)c->tag_len, buf)) {
+    if (!EVP_CIPHER_CTX_ctrl(c->ctx, EVP_CTRL_GCM_GET_TAG, (int)c->tag_len,
+                             buf)) {
         return (srtp_err_status_algo_fail);
     }
 

--- a/crypto/cipher/aes_icm_ossl.c
+++ b/crypto/cipher/aes_icm_ossl.c
@@ -306,7 +306,7 @@ static srtp_err_status_t srtp_aes_icm_openssl_encrypt(void *cv,
 
     debug_print(srtp_mod_aes_icm, "rs0: %s", v128_hex_string(&c->counter));
 
-    if (!EVP_EncryptUpdate(c->ctx, buf, &len, buf, *enc_len)) {
+    if (!EVP_EncryptUpdate(c->ctx, buf, &len, buf, (int)*enc_len)) {
         return srtp_err_status_cipher_fail;
     }
     *enc_len = len;


### PR DESCRIPTION
Compiling the lib for iOS, I got some warnings, the PR contains missing explicit conversions

 
```
/Users/engine/engine/builder-iOS.master/build/arm64/libs/libsrtp/crypto/cipher/aes_icm_ossl.c:309:52: error: implicit conversion loses integer precision: 'size_t' (aka 'unsigned long') to 'int' [-Werror,-Wshorten-64-to-32]
    if (!EVP_EncryptUpdate(c->ctx, buf, &len, buf, *enc_len)) {
         ~~~~~~~~~~~~~~~~~                         ^~~~~~~~
1 error generated.


...


/Users/engine/engine/builder-iOS.master/build/arm64/libs/libsrtp/crypto/cipher/aes_gcm_ossl.c:273:67: error: implicit conversion loses integer precision: 'size_t' (aka 'unsigned long') to 'int' [-Werror,-Wshorten-64-to-32]
        if (!EVP_CIPHER_CTX_ctrl(c->ctx, EVP_CTRL_GCM_SET_TAG, c->tag_len,
             ~~~~~~~~~~~~~~~~~~~                               ~~~^~~~~~~
/Users/engine/engine/builder-iOS.master/build/arm64/libs/libsrtp/crypto/cipher/aes_gcm_ossl.c:279:40: error: implicit conversion loses integer precision: 'size_t' (aka 'unsigned long') to 'unsigned int' [-Werror,-Wshorten-64-to-32]
    rv = EVP_Cipher(c->ctx, NULL, aad, aad_len);
         ~~~~~~~~~~                    ^~~~~~~
/Users/engine/engine/builder-iOS.master/build/arm64/libs/libsrtp/crypto/cipher/aes_gcm_ossl.c:307:34: error: implicit conversion loses integer precision: 'size_t' (aka 'unsigned long') to 'unsigned int' [-Werror,-Wshorten-64-to-32]
    EVP_Cipher(c->ctx, buf, buf, *enc_len);
    ~~~~~~~~~~                   ^~~~~~~~
/Users/engine/engine/builder-iOS.master/build/arm64/libs/libsrtp/crypto/cipher/aes_gcm_ossl.c:336:63: error: implicit conversion loses integer precision: 'size_t' (aka 'unsigned long') to 'int' [-Werror,-Wshorten-64-to-32]
    if (!EVP_CIPHER_CTX_ctrl(c->ctx, EVP_CTRL_GCM_GET_TAG, c->tag_len, buf)) {
         ~~~~~~~~~~~~~~~~~~~                               ~~~^~~~~~~
/Users/engine/engine/builder-iOS.master/build/arm64/libs/libsrtp/crypto/cipher/aes_gcm_ossl.c:368:63: error: implicit conversion loses integer precision: 'size_t' (aka 'unsigned long') to 'int' [-Werror,-Wshorten-64-to-32]
    if (!EVP_CIPHER_CTX_ctrl(c->ctx, EVP_CTRL_GCM_SET_TAG, c->tag_len,
         ~~~~~~~~~~~~~~~~~~~                               ~~~^~~~~~~
/Users/engine/engine/builder-iOS.master/build/arm64/libs/libsrtp/crypto/cipher/aes_gcm_ossl.c:372:43: error: implicit conversion loses integer precision: 'size_t' (aka 'unsigned long') to 'unsigned int' [-Werror,-Wshorten-64-to-32]
    EVP_Cipher(c->ctx, buf, buf, *enc_len - c->tag_len);
    ~~~~~~~~~~                   ~~~~~~~~~^~~~~~~~~~~~
6 errors generated.


```