### PR TITLE
Meson build ci fix

### DIFF
--- a/.github/workflows/meson.yml
+++ b/.github/workflows/meson.yml
@@ -13,7 +13,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, macos-latest, windows-latest]
+        os: [ubuntu-latest, macos-12, windows-latest]
         crypto: [internal, openssl, openssl3, wolfssl, nss, mbedtls]
         exclude:
           - os: windows-latest
@@ -55,7 +55,7 @@ jobs:
         sudo apt-get install meson
 
     - name: Setup macOS Meson
-      if: matrix.os == 'macos-latest'
+      if: matrix.os == 'macos-12'
       run: |
         brew install meson
 
@@ -88,17 +88,17 @@ jobs:
       run: sudo apt-get install libmbedtls-dev
 
     - name: Setup macOS OpenSSL
-      if: matrix.os == 'macos-latest' && matrix.crypto == 'openssl'
+      if: matrix.os == 'macos-12' && matrix.crypto == 'openssl'
       run: echo "pkgconfig-crypto-dir=PKG_CONFIG_PATH=$(brew --prefix openssl@1.1)/lib/pkgconfig" >> $GITHUB_ENV
 
     - name: Setup macOS OpenSSL3
-      if: matrix.os == 'macos-latest' && matrix.crypto == 'openssl3'
+      if: matrix.os == 'macos-12' && matrix.crypto == 'openssl3'
       run: |
         brew install openssl@3
         echo "pkgconfig-crypto-dir=PKG_CONFIG_PATH=$(brew --prefix openssl@3)/lib/pkgconfig" >> $GITHUB_ENV
 
     - name: Setup macOS wolfSSL
-      if: matrix.os == 'macos-latest' && matrix.crypto == 'wolfssl'
+      if: matrix.os == 'macos-12' && matrix.crypto == 'wolfssl'
       run: |
         brew install autoconf automake libtool
         git clone https://github.com/wolfSSL/wolfssl
@@ -116,11 +116,11 @@ jobs:
         cd ..
 
     - name: Setup macOS NSS
-      if:  matrix.os == 'macos-latest' && matrix.crypto == 'nss'
+      if:  matrix.os == 'macos-12' && matrix.crypto == 'nss'
       run: brew install nss
 
     - name: Setup macOS MbedTLS
-      if:  matrix.os == 'macos-latest' && matrix.crypto == 'mbedtls'
+      if:  matrix.os == 'macos-12' && matrix.crypto == 'mbedtls'
       run: brew install mbedtls
 
     - uses: actions/checkout@v2

--- a/meson.build
+++ b/meson.build
@@ -306,7 +306,6 @@ libsrtp2_static = static_library('srtp2', sources, ciphers_sources, hashes_sourc
 
 if default_library != 'static'
   libsrtp2 = shared_library('srtp2',
-    dependencies: [srtp2_deps, syslibs],
     soversion : soversion,
     vs_module_defs: 'srtp.def',
     link_whole: libsrtp2_static,


### PR DESCRIPTION
This fixes the current broken ci builds for meson by hard coding the use of macos-12 runner. Not sure why macos-latest is broken but until that is fixed it is better that something runs.

#705