### PR TITLE
change srtp_cipher_encrypt to append the tag generated

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -386,7 +386,7 @@ if(LIBSRTP_TEST_APPS)
     target_link_libraries(datatypes_driver srtp3)
     add_test(datatypes_driver datatypes_driver -v)
 
-    add_executable(cipher_driver crypto/test/cipher_driver.c test/getopt_s.c)
+    add_executable(cipher_driver crypto/test/cipher_driver.c test/getopt_s.c test/util.c)
     target_set_warnings(
             TARGET
             cipher_driver

--- a/Makefile.in
+++ b/Makefile.in
@@ -229,7 +229,7 @@ test/roc_driver$(EXE): test/roc_driver.c test/ut_sim.c
 test/replay_driver$(EXE): test/replay_driver.c test/ut_sim.c
 	$(COMPILE) -I$(srcdir)/test $(LDFLAGS) -o $@ $^ $(LIBS) $(SRTPLIB)
 
-crypto/test/cipher_driver$(EXE): crypto/test/cipher_driver.c test/getopt_s.c
+crypto/test/cipher_driver$(EXE): crypto/test/cipher_driver.c test/getopt_s.c test/util.c
 	$(COMPILE) -I$(srcdir)/test $(LDFLAGS) -o $@ $^ $(LIBS) $(SRTPLIB)
 
 crypto/test/kernel_driver$(EXE): crypto/test/kernel_driver.c test/getopt_s.c

--- a/crypto/cipher/aes_gcm_mbedtls.c
+++ b/crypto/cipher/aes_gcm_mbedtls.c
@@ -290,7 +290,7 @@ static srtp_err_status_t srtp_aes_gcm_mbedtls_encrypt(void *cv,
     srtp_aes_gcm_ctx_t *c = (srtp_aes_gcm_ctx_t *)cv;
     int errCode = 0;
 
-    if (c->dir != srtp_direction_encrypt && c->dir != srtp_direction_decrypt) {
+    if (c->dir != srtp_direction_encrypt) {
         return srtp_err_status_bad_param;
     }
 
@@ -331,8 +331,12 @@ static srtp_err_status_t srtp_aes_gcm_mbedtls_decrypt(void *cv,
     srtp_aes_gcm_ctx_t *c = (srtp_aes_gcm_ctx_t *)cv;
     int errCode = 0;
 
-    if (c->dir != srtp_direction_encrypt && c->dir != srtp_direction_decrypt) {
-        return (srtp_err_status_bad_param);
+    if (c->dir != srtp_direction_decrypt) {
+        return srtp_err_status_bad_param;
+    }
+
+    if (src_len < c->tag_len) {
+        return srtp_err_status_bad_param;
     }
 
     if (*dst_len < (src_len - c->tag_len)) {
@@ -347,7 +351,7 @@ static srtp_err_status_t srtp_aes_gcm_mbedtls_decrypt(void *cv,
         src + (src_len - c->tag_len), c->tag_len, src, dst);
     c->aad_size = 0;
     if (errCode != 0) {
-        return (srtp_err_status_auth_fail);
+        return srtp_err_status_auth_fail;
     }
 
     /*
@@ -356,7 +360,7 @@ static srtp_err_status_t srtp_aes_gcm_mbedtls_decrypt(void *cv,
      */
     *dst_len = (src_len - c->tag_len);
 
-    return (srtp_err_status_ok);
+    return srtp_err_status_ok;
 }
 
 /*

--- a/crypto/cipher/aes_gcm_ossl.c
+++ b/crypto/cipher/aes_gcm_ossl.c
@@ -300,7 +300,7 @@ static srtp_err_status_t srtp_aes_gcm_openssl_encrypt(void *cv,
 {
     srtp_aes_gcm_ctx_t *c = (srtp_aes_gcm_ctx_t *)cv;
 
-    if (c->dir != srtp_direction_encrypt && c->dir != srtp_direction_decrypt) {
+    if (c->dir != srtp_direction_encrypt) {
         return srtp_err_status_bad_param;
     }
 
@@ -347,7 +347,11 @@ static srtp_err_status_t srtp_aes_gcm_openssl_decrypt(void *cv,
 {
     srtp_aes_gcm_ctx_t *c = (srtp_aes_gcm_ctx_t *)cv;
 
-    if (c->dir != srtp_direction_encrypt && c->dir != srtp_direction_decrypt) {
+    if (c->dir != srtp_direction_decrypt) {
+        return srtp_err_status_bad_param;
+    }
+
+    if (src_len < c->tag_len) {
         return srtp_err_status_bad_param;
     }
 

--- a/crypto/cipher/aes_gcm_ossl.c
+++ b/crypto/cipher/aes_gcm_ossl.c
@@ -299,51 +299,34 @@ static srtp_err_status_t srtp_aes_gcm_openssl_encrypt(void *cv,
                                                       size_t *dst_len)
 {
     srtp_aes_gcm_ctx_t *c = (srtp_aes_gcm_ctx_t *)cv;
+
     if (c->dir != srtp_direction_encrypt && c->dir != srtp_direction_decrypt) {
-        return (srtp_err_status_bad_param);
+        return srtp_err_status_bad_param;
+    }
+
+    if (*dst_len < src_len + c->tag_len) {
+        return srtp_err_status_buffer_small;
     }
 
     /*
      * Encrypt the data
      */
     EVP_Cipher(c->ctx, dst, src, src_len);
-    *dst_len = src_len;
 
-    return (srtp_err_status_ok);
-}
-
-/*
- * This function calculates and returns the GCM tag for a given context.
- * This should be called after encrypting the data.  The *len value
- * is increased by the tag size.  The caller must ensure that *buf has
- * enough room to accept the appended tag.
- *
- * Parameters:
- *	c	Crypto context
- *	buf	data to encrypt
- *	len	length of encrypt buffer
- */
-static srtp_err_status_t srtp_aes_gcm_openssl_get_tag(void *cv,
-                                                      uint8_t *buf,
-                                                      size_t *len)
-{
-    srtp_aes_gcm_ctx_t *c = (srtp_aes_gcm_ctx_t *)cv;
     /*
      * Calculate the tag
      */
     EVP_Cipher(c->ctx, NULL, NULL, 0);
 
     /*
-     * Retreive the tag
+     * Retrieve the tag
      */
-    if (!EVP_CIPHER_CTX_ctrl(c->ctx, EVP_CTRL_GCM_GET_TAG, c->tag_len, buf)) {
-        return (srtp_err_status_algo_fail);
+    if (!EVP_CIPHER_CTX_ctrl(c->ctx, EVP_CTRL_GCM_GET_TAG, c->tag_len,
+                             dst + src_len)) {
+        return srtp_err_status_algo_fail;
     }
 
-    /*
-     * Increase encryption length by desired tag size
-     */
-    *len = c->tag_len;
+    *dst_len = src_len + c->tag_len;
 
     return (srtp_err_status_ok);
 }
@@ -363,8 +346,13 @@ static srtp_err_status_t srtp_aes_gcm_openssl_decrypt(void *cv,
                                                       size_t *dst_len)
 {
     srtp_aes_gcm_ctx_t *c = (srtp_aes_gcm_ctx_t *)cv;
+
     if (c->dir != srtp_direction_encrypt && c->dir != srtp_direction_decrypt) {
-        return (srtp_err_status_bad_param);
+        return srtp_err_status_bad_param;
+    }
+
+    if (*dst_len < src_len - c->tag_len) {
+        return srtp_err_status_buffer_small;
     }
 
     /*
@@ -375,7 +363,7 @@ static srtp_err_status_t srtp_aes_gcm_openssl_decrypt(void *cv,
     if (!EVP_CIPHER_CTX_ctrl(
             c->ctx, EVP_CTRL_GCM_SET_TAG, c->tag_len,
             (void *)(uintptr_t)(src + (src_len - c->tag_len)))) {
-        return (srtp_err_status_auth_fail);
+        return srtp_err_status_auth_fail;
     }
     EVP_Cipher(c->ctx, dst, src, src_len - c->tag_len);
 
@@ -383,7 +371,7 @@ static srtp_err_status_t srtp_aes_gcm_openssl_decrypt(void *cv,
      * Check the tag
      */
     if (EVP_Cipher(c->ctx, NULL, NULL, 0)) {
-        return (srtp_err_status_auth_fail);
+        return srtp_err_status_auth_fail;
     }
 
     /*
@@ -406,6 +394,7 @@ static const char srtp_aes_gcm_256_openssl_description[] =
 /*
  * This is the vector function table for this crypto engine.
  */
+/* clang-format off */
 const srtp_cipher_type_t srtp_aes_gcm_128 = {
     srtp_aes_gcm_openssl_alloc,
     srtp_aes_gcm_openssl_dealloc,
@@ -414,15 +403,16 @@ const srtp_cipher_type_t srtp_aes_gcm_128 = {
     srtp_aes_gcm_openssl_encrypt,
     srtp_aes_gcm_openssl_decrypt,
     srtp_aes_gcm_openssl_set_iv,
-    srtp_aes_gcm_openssl_get_tag,
     srtp_aes_gcm_128_openssl_description,
     &srtp_aes_gcm_128_test_case_0,
     SRTP_AES_GCM_128
 };
+/* clang-format on */
 
 /*
  * This is the vector function table for this crypto engine.
  */
+/* clang-format off */
 const srtp_cipher_type_t srtp_aes_gcm_256 = {
     srtp_aes_gcm_openssl_alloc,
     srtp_aes_gcm_openssl_dealloc,
@@ -431,8 +421,8 @@ const srtp_cipher_type_t srtp_aes_gcm_256 = {
     srtp_aes_gcm_openssl_encrypt,
     srtp_aes_gcm_openssl_decrypt,
     srtp_aes_gcm_openssl_set_iv,
-    srtp_aes_gcm_openssl_get_tag,
     srtp_aes_gcm_256_openssl_description,
     &srtp_aes_gcm_256_test_case_0,
     SRTP_AES_GCM_256
 };
+/* clang-format on */

--- a/crypto/cipher/aes_gcm_wssl.c
+++ b/crypto/cipher/aes_gcm_wssl.c
@@ -330,7 +330,7 @@ static srtp_err_status_t srtp_aes_gcm_wolfssl_encrypt(void *cv,
     srtp_aes_gcm_ctx_t *c = (srtp_aes_gcm_ctx_t *)cv;
     int err;
 
-    if (c->dir != srtp_direction_encrypt && c->dir != srtp_direction_decrypt) {
+    if (c->dir != srtp_direction_encrypt) {
         return srtp_err_status_bad_param;
     }
 
@@ -385,7 +385,11 @@ static srtp_err_status_t srtp_aes_gcm_wolfssl_decrypt(void *cv,
     srtp_aes_gcm_ctx_t *c = (srtp_aes_gcm_ctx_t *)cv;
     int err;
 
-    if (c->dir != srtp_direction_encrypt && c->dir != srtp_direction_decrypt) {
+    if (c->dir != srtp_direction_decrypt) {
+        return srtp_err_status_bad_param;
+    }
+
+    if (src_len < c->tag_len) {
         return srtp_err_status_bad_param;
     }
 

--- a/crypto/cipher/aes_gcm_wssl.c
+++ b/crypto/cipher/aes_gcm_wssl.c
@@ -331,59 +331,40 @@ static srtp_err_status_t srtp_aes_gcm_wolfssl_encrypt(void *cv,
     int err;
 
     if (c->dir != srtp_direction_encrypt && c->dir != srtp_direction_decrypt) {
-        return (srtp_err_status_bad_param);
-    }
-
-#ifndef WOLFSSL_AESGCM_STREAM
-    err = wc_AesGcmEncrypt(c->ctx, dst, src, src_len, c->iv, c->iv_len, c->tag,
-                           c->tag_len, c->aad, c->aad_size);
-
-    c->aad_size = 0;
-#else
-    err = wc_AesGcmEncryptUpdate(c->ctx, dst, src, src_len, NULL, 0);
-#endif
-    if (err < 0) {
-        debug_print(srtp_mod_aes_gcm, "wolfSSL error code:  %d", err);
         return srtp_err_status_bad_param;
     }
-    *dst_len = src_len;
 
-    return (srtp_err_status_ok);
-}
+    if (*dst_len < src_len + c->tag_len) {
+        return srtp_err_status_buffer_small;
+    }
 
-/*
- * This function calculates and returns the GCM tag for a given context.
- * This should be called after encrypting the data.  The *len value
- * is increased by the tag size.  The caller must ensure that *buf has
- * enough room to accept the appended tag.
- *
- * Parameters:
- *	c	Crypto context
- *	buf	data to encrypt
- *	len	length of encrypt buffer
- */
-static srtp_err_status_t srtp_aes_gcm_wolfssl_get_tag(void *cv,
-                                                      uint8_t *buf,
-                                                      size_t *len)
-{
-    FUNC_ENTRY();
-    srtp_aes_gcm_ctx_t *c = (srtp_aes_gcm_ctx_t *)cv;
-#ifdef WOLFSSL_AESGCM_STREAM
-    int err;
-#endif
-
-    debug_print(srtp_mod_aes_gcm, "appended tag size:  %d", c->tag_len);
-    *len = c->tag_len;
 #ifndef WOLFSSL_AESGCM_STREAM
-    memcpy(buf, c->tag, c->tag_len);
+    // tag must always be 16 bytes when passed to wc_AesGcmEncrypt, can truncate
+    // to c->tag_len after
+    uint8_t tag[GCM_AUTH_TAG_LEN];
+    err = wc_AesGcmEncrypt(c->ctx, dst, src, src_len, c->iv, c->iv_len, tag,
+                           sizeof(tag), c->aad, c->aad_size);
+    c->aad_size = 0;
+    if (err == 0) {
+        memcpy(dst + src_len, tag, c->tag_len);
+    }
 #else
-    err = wc_AesGcmEncryptFinal(c->ctx, buf, c->tag_len);
+    err = wc_AesGcmEncryptUpdate(c->ctx, dst, src, src_len, NULL, 0);
     if (err < 0) {
         debug_print(srtp_mod_aes_gcm, "wolfSSL error code:  %d", err);
         return srtp_err_status_algo_fail;
     }
+    err = wc_AesGcmEncryptFinal(c->ctx, dst + src_len, c->tag_len);
 #endif
-    return (srtp_err_status_ok);
+    if (err < 0) {
+        debug_print(srtp_mod_aes_gcm, "wolfSSL error code:  %d", err);
+        printf("wolfSSL error code:  %d\n", err);
+        return srtp_err_status_algo_fail;
+    }
+
+    *dst_len = src_len + c->tag_len;
+
+    return srtp_err_status_ok;
 }
 
 /*
@@ -405,7 +386,11 @@ static srtp_err_status_t srtp_aes_gcm_wolfssl_decrypt(void *cv,
     int err;
 
     if (c->dir != srtp_direction_encrypt && c->dir != srtp_direction_decrypt) {
-        return (srtp_err_status_bad_param);
+        return srtp_err_status_bad_param;
+    }
+
+    if (*dst_len < src_len - c->tag_len) {
+        return srtp_err_status_buffer_small;
     }
 
 #ifndef WOLFSSL_AESGCM_STREAM
@@ -421,14 +406,14 @@ static srtp_err_status_t srtp_aes_gcm_wolfssl_decrypt(void *cv,
                                  0);
     if (err < 0) {
         debug_print(srtp_mod_aes_gcm, "wolfSSL error code:  %d", err);
-        return (srtp_err_status_algo_fail);
+        return srtp_err_status_algo_fail;
     }
     err =
         wc_AesGcmDecryptFinal(c->ctx, src + (src_len - c->tag_len), c->tag_len);
 #endif
     if (err < 0) {
         debug_print(srtp_mod_aes_gcm, "wolfSSL error code:  %d", err);
-        return (srtp_err_status_auth_fail);
+        return srtp_err_status_auth_fail;
     }
 
     /*
@@ -437,7 +422,7 @@ static srtp_err_status_t srtp_aes_gcm_wolfssl_decrypt(void *cv,
      */
     *dst_len = src_len -= c->tag_len;
 
-    return (srtp_err_status_ok);
+    return srtp_err_status_ok;
 }
 
 /*
@@ -451,6 +436,7 @@ static const char srtp_aes_gcm_256_wolfssl_description[] =
 /*
  * This is the vector function table for this crypto engine.
  */
+/* clang-format off */
 const srtp_cipher_type_t srtp_aes_gcm_128 = {
     srtp_aes_gcm_wolfssl_alloc,
     srtp_aes_gcm_wolfssl_dealloc,
@@ -459,15 +445,16 @@ const srtp_cipher_type_t srtp_aes_gcm_128 = {
     srtp_aes_gcm_wolfssl_encrypt,
     srtp_aes_gcm_wolfssl_decrypt,
     srtp_aes_gcm_wolfssl_set_iv,
-    srtp_aes_gcm_wolfssl_get_tag,
     srtp_aes_gcm_128_wolfssl_description,
     &srtp_aes_gcm_128_test_case_0,
     SRTP_AES_GCM_128
 };
+/* clang-format on */
 
 /*
  * This is the vector function table for this crypto engine.
  */
+/* clang-format off */
 const srtp_cipher_type_t srtp_aes_gcm_256 = {
     srtp_aes_gcm_wolfssl_alloc,
     srtp_aes_gcm_wolfssl_dealloc,
@@ -476,8 +463,8 @@ const srtp_cipher_type_t srtp_aes_gcm_256 = {
     srtp_aes_gcm_wolfssl_encrypt,
     srtp_aes_gcm_wolfssl_decrypt,
     srtp_aes_gcm_wolfssl_set_iv,
-    srtp_aes_gcm_wolfssl_get_tag,
     srtp_aes_gcm_256_wolfssl_description,
     &srtp_aes_gcm_256_test_case_0,
     SRTP_AES_GCM_256
 };
+/* clang-format on */

--- a/crypto/cipher/aes_icm.c
+++ b/crypto/cipher/aes_icm.c
@@ -430,7 +430,6 @@ const srtp_cipher_type_t srtp_aes_icm_128 = {
     srtp_aes_icm_encrypt,          /* */
     srtp_aes_icm_encrypt,          /* */
     srtp_aes_icm_set_iv,           /* */
-    0,                             /* get_tag */
     srtp_aes_icm_128_description,  /* */
     &srtp_aes_icm_128_test_case_0, /* */
     SRTP_AES_ICM_128               /* */
@@ -444,7 +443,6 @@ const srtp_cipher_type_t srtp_aes_icm_256 = {
     srtp_aes_icm_encrypt,          /* */
     srtp_aes_icm_encrypt,          /* */
     srtp_aes_icm_set_iv,           /* */
-    0,                             /* get_tag */
     srtp_aes_icm_256_description,  /* */
     &srtp_aes_icm_256_test_case_0, /* */
     SRTP_AES_ICM_256               /* */

--- a/crypto/cipher/aes_icm_mbedtls.c
+++ b/crypto/cipher/aes_icm_mbedtls.c
@@ -339,7 +339,6 @@ const srtp_cipher_type_t srtp_aes_icm_128 = {
     srtp_aes_icm_mbedtls_encrypt,         /* */
     srtp_aes_icm_mbedtls_encrypt,         /* */
     srtp_aes_icm_mbedtls_set_iv,          /* */
-    0,                                    /* get_tag */
     srtp_aes_icm_128_mbedtls_description, /* */
     &srtp_aes_icm_128_test_case_0,        /* */
     SRTP_AES_ICM_128                      /* */
@@ -357,7 +356,6 @@ const srtp_cipher_type_t srtp_aes_icm_192 = {
     srtp_aes_icm_mbedtls_encrypt,         /* */
     srtp_aes_icm_mbedtls_encrypt,         /* */
     srtp_aes_icm_mbedtls_set_iv,          /* */
-    0,                                    /* get_tag */
     srtp_aes_icm_192_mbedtls_description, /* */
     &srtp_aes_icm_192_test_case_0,        /* */
     SRTP_AES_ICM_192                      /* */
@@ -375,7 +373,6 @@ const srtp_cipher_type_t srtp_aes_icm_256 = {
     srtp_aes_icm_mbedtls_encrypt,         /* */
     srtp_aes_icm_mbedtls_encrypt,         /* */
     srtp_aes_icm_mbedtls_set_iv,          /* */
-    0,                                    /* get_tag */
     srtp_aes_icm_256_mbedtls_description, /* */
     &srtp_aes_icm_256_test_case_0,        /* */
     SRTP_AES_ICM_256                      /* */

--- a/crypto/cipher/aes_icm_nss.c
+++ b/crypto/cipher/aes_icm_nss.c
@@ -367,7 +367,6 @@ const srtp_cipher_type_t srtp_aes_icm_128 = {
     srtp_aes_icm_nss_encrypt,         /* */
     srtp_aes_icm_nss_encrypt,         /* */
     srtp_aes_icm_nss_set_iv,          /* */
-    0,                                /* get_tag */
     srtp_aes_icm_128_nss_description, /* */
     &srtp_aes_icm_128_test_case_0,    /* */
     SRTP_AES_ICM_128                  /* */
@@ -385,7 +384,6 @@ const srtp_cipher_type_t srtp_aes_icm_192 = {
     srtp_aes_icm_nss_encrypt,         /* */
     srtp_aes_icm_nss_encrypt,         /* */
     srtp_aes_icm_nss_set_iv,          /* */
-    0,                                /* get_tag */
     srtp_aes_icm_192_nss_description, /* */
     &srtp_aes_icm_192_test_case_0,    /* */
     SRTP_AES_ICM_192                  /* */
@@ -403,7 +401,6 @@ const srtp_cipher_type_t srtp_aes_icm_256 = {
     srtp_aes_icm_nss_encrypt,         /* */
     srtp_aes_icm_nss_encrypt,         /* */
     srtp_aes_icm_nss_set_iv,          /* */
-    0,                                /* get_tag */
     srtp_aes_icm_256_nss_description, /* */
     &srtp_aes_icm_256_test_case_0,    /* */
     SRTP_AES_ICM_256                  /* */

--- a/crypto/cipher/aes_icm_nss.c
+++ b/crypto/cipher/aes_icm_nss.c
@@ -334,12 +334,20 @@ static srtp_err_status_t srtp_aes_icm_nss_encrypt(void *cv,
         return srtp_err_status_bad_param;
     }
 
+    if (dst_len == NULL) {
+        return srtp_err_status_bad_param;
+    }
+
+    if (*dst_len < src_len) {
+        return srtp_err_status_buffer_small;
+    }
+
     int out_len = 0;
     int rv = PK11_CipherOp(c->ctx, dst, &out_len, *dst_len, src, src_len);
     *dst_len = out_len;
-    srtp_err_status_t status = (srtp_err_status_ok);
+    srtp_err_status_t status = srtp_err_status_ok;
     if (rv != SECSuccess) {
-        status = (srtp_err_status_cipher_fail);
+        status = srtp_err_status_cipher_fail;
     }
 
     return status;

--- a/crypto/cipher/aes_icm_ossl.c
+++ b/crypto/cipher/aes_icm_ossl.c
@@ -308,6 +308,14 @@ static srtp_err_status_t srtp_aes_icm_openssl_encrypt(void *cv,
 
     debug_print(srtp_mod_aes_icm, "rs0: %s", v128_hex_string(&c->counter));
 
+    if (dst_len == NULL) {
+        return srtp_err_status_bad_param;
+    }
+
+    if (*dst_len < src_len) {
+        return srtp_err_status_buffer_small;
+    }
+
     if (!EVP_EncryptUpdate(c->ctx, dst, &len, src, src_len)) {
         return srtp_err_status_cipher_fail;
     }

--- a/crypto/cipher/aes_icm_ossl.c
+++ b/crypto/cipher/aes_icm_ossl.c
@@ -343,7 +343,6 @@ const srtp_cipher_type_t srtp_aes_icm_128 = {
     srtp_aes_icm_openssl_encrypt,         /* */
     srtp_aes_icm_openssl_encrypt,         /* */
     srtp_aes_icm_openssl_set_iv,          /* */
-    0,                                    /* get_tag */
     srtp_aes_icm_128_openssl_description, /* */
     &srtp_aes_icm_128_test_case_0,        /* */
     SRTP_AES_ICM_128                      /* */
@@ -361,7 +360,6 @@ const srtp_cipher_type_t srtp_aes_icm_192 = {
     srtp_aes_icm_openssl_encrypt,         /* */
     srtp_aes_icm_openssl_encrypt,         /* */
     srtp_aes_icm_openssl_set_iv,          /* */
-    0,                                    /* get_tag */
     srtp_aes_icm_192_openssl_description, /* */
     &srtp_aes_icm_192_test_case_0,        /* */
     SRTP_AES_ICM_192                      /* */
@@ -379,7 +377,6 @@ const srtp_cipher_type_t srtp_aes_icm_256 = {
     srtp_aes_icm_openssl_encrypt,         /* */
     srtp_aes_icm_openssl_encrypt,         /* */
     srtp_aes_icm_openssl_set_iv,          /* */
-    0,                                    /* get_tag */
     srtp_aes_icm_256_openssl_description, /* */
     &srtp_aes_icm_256_test_case_0,        /* */
     SRTP_AES_ICM_256                      /* */

--- a/crypto/cipher/aes_icm_wssl.c
+++ b/crypto/cipher/aes_icm_wssl.c
@@ -350,7 +350,6 @@ const srtp_cipher_type_t srtp_aes_icm_128 = {
     srtp_aes_icm_wolfssl_encrypt,         /* */
     srtp_aes_icm_wolfssl_encrypt,         /* */
     srtp_aes_icm_wolfssl_set_iv,          /* */
-    0,                                    /* get_tag */
     srtp_aes_icm_128_wolfssl_description, /* */
     &srtp_aes_icm_128_test_case_0,        /* */
     SRTP_AES_ICM_128                      /* */
@@ -368,7 +367,6 @@ const srtp_cipher_type_t srtp_aes_icm_192 = {
     srtp_aes_icm_wolfssl_encrypt,         /* */
     srtp_aes_icm_wolfssl_encrypt,         /* */
     srtp_aes_icm_wolfssl_set_iv,          /* */
-    0,                                    /* get_tag */
     srtp_aes_icm_192_wolfssl_description, /* */
     &srtp_aes_icm_192_test_case_0,        /* */
     SRTP_AES_ICM_192                      /* */
@@ -386,7 +384,6 @@ const srtp_cipher_type_t srtp_aes_icm_256 = {
     srtp_aes_icm_wolfssl_encrypt,         /* */
     srtp_aes_icm_wolfssl_encrypt,         /* */
     srtp_aes_icm_wolfssl_set_iv,          /* */
-    0,                                    /* get_tag */
     srtp_aes_icm_256_wolfssl_description, /* */
     &srtp_aes_icm_256_test_case_0,        /* */
     SRTP_AES_ICM_256                      /* */

--- a/crypto/cipher/aes_icm_wssl.c
+++ b/crypto/cipher/aes_icm_wssl.c
@@ -318,6 +318,14 @@ static srtp_err_status_t srtp_aes_icm_wolfssl_encrypt(void *cv,
     int err;
     debug_print(srtp_mod_aes_icm, "rs0: %s", v128_hex_string(&c->counter));
 
+    if (dst_len == NULL) {
+        return srtp_err_status_bad_param;
+    }
+
+    if (*dst_len < src_len) {
+        return srtp_err_status_buffer_small;
+    }
+
     err = wc_AesCtrEncrypt(c->ctx, dst, src, src_len);
     if (err < 0) {
         debug_print(srtp_mod_aes_icm, "wolfSSL encrypt error: %d", err);

--- a/crypto/cipher/null_cipher.c
+++ b/crypto/cipher/null_cipher.c
@@ -160,7 +160,6 @@ const srtp_cipher_type_t srtp_null_cipher = {
     srtp_null_cipher_encrypt,     /* */
     srtp_null_cipher_encrypt,     /* */
     srtp_null_cipher_set_iv,      /* */
-    0,                            /* get_tag */
     srtp_null_cipher_description, /* */
     &srtp_null_cipher_test_0,     /* */
     SRTP_NULL_CIPHER              /* */

--- a/crypto/include/aes_gcm.h
+++ b/crypto/include/aes_gcm.h
@@ -82,7 +82,6 @@ typedef struct {
     int aad_size;
     int iv_len;
     uint8_t iv[GCM_NONCE_MID_SZ];
-    uint8_t tag[AES_BLOCK_SIZE];
     uint8_t aad[MAX_AD_SIZE];
 #endif
     Aes *ctx;
@@ -102,7 +101,6 @@ typedef struct {
     size_t aad_size;
     size_t iv_len;
     uint8_t iv[12];
-    uint8_t tag[16];
     uint8_t aad[MAX_AD_SIZE];
     mbedtls_gcm_context *ctx;
     srtp_cipher_direction_t dir;
@@ -129,7 +127,6 @@ typedef struct {
     uint8_t aad[MAX_AD_SIZE];
     size_t aad_size;
     CK_GCM_PARAMS params;
-    uint8_t tag[16];
 } srtp_aes_gcm_ctx_t;
 
 #endif /* NSS */

--- a/crypto/include/aes_gcm.h
+++ b/crypto/include/aes_gcm.h
@@ -76,11 +76,11 @@ typedef struct {
 #include <wolfssl/wolfcrypt/aes.h>
 
 typedef struct {
-    int key_size;
-    int tag_len;
+    size_t key_size;
+    size_t tag_len;
 #ifndef WOLFSSL_AESGCM_STREAM
-    int aad_size;
-    int iv_len;
+    size_t aad_size;
+    size_t iv_len;
     uint8_t iv[GCM_NONCE_MID_SZ];
     uint8_t aad[MAX_AD_SIZE];
 #endif

--- a/crypto/include/cipher.h
+++ b/crypto/include/cipher.h
@@ -119,14 +119,6 @@ typedef srtp_err_status_t (*srtp_cipher_set_iv_func_t)(
     srtp_cipher_direction_t direction);
 
 /*
- * a cipher_get_tag_func_t function is used to get the authentication
- * tag that was calculated by an AEAD cipher.
- */
-typedef srtp_err_status_t (*srtp_cipher_get_tag_func_t)(void *state,
-                                                        uint8_t *tag,
-                                                        size_t *len);
-
-/*
  * srtp_cipher_test_case_t is a (list of) key, salt, plaintext, ciphertext,
  * and aad values that are known to be correct for a
  * particular cipher.  this data can be used to test an implementation
@@ -157,7 +149,6 @@ typedef struct srtp_cipher_type_t {
     srtp_cipher_encrypt_func_t encrypt;
     srtp_cipher_decrypt_func_t decrypt;
     srtp_cipher_set_iv_func_t set_iv;
-    srtp_cipher_get_tag_func_t get_tag;
     const char *description;
     const srtp_cipher_test_case_t *test_data;
     srtp_cipher_type_id_t id;
@@ -230,9 +221,6 @@ srtp_err_status_t srtp_cipher_decrypt(srtp_cipher_t *c,
                                       size_t src_len,
                                       uint8_t *dst,
                                       size_t *dst_len);
-srtp_err_status_t srtp_cipher_get_tag(srtp_cipher_t *c,
-                                      uint8_t *buffer,
-                                      size_t *tag_len);
 srtp_err_status_t srtp_cipher_set_aad(srtp_cipher_t *c,
                                       const uint8_t *aad,
                                       size_t aad_len);

--- a/crypto/test/cipher_driver.c
+++ b/crypto/test/cipher_driver.c
@@ -337,8 +337,14 @@ void cipher_driver_test_throughput(srtp_cipher_t *c)
            c->key_len);
     fflush(stdout);
     for (size_t i = min_enc_len; i <= max_enc_len; i = i * 2) {
+        uint64_t bits_per_second =
+            srtp_cipher_bits_per_second(c, i, num_trials);
+        if (bits_per_second == 0) {
+            printf("error: throughput test failed\n");
+            exit(1);
+        }
         printf("msg len: %zu\tgigabits per second: %f\n", i,
-               srtp_cipher_bits_per_second(c, i, num_trials) / 1e9);
+               bits_per_second / 1e9);
     }
 }
 
@@ -409,7 +415,7 @@ srtp_err_status_t cipher_driver_test_api(srtp_cipher_type_t *ct, int key_len)
 
 /*
  * cipher_driver_test_buffering(ct) tests the cipher's output
- * buffering for correctness by checking the consistency of succesive
+ * buffering for correctness by checking the consistency of successive
  * calls
  */
 

--- a/srtp.def
+++ b/srtp.def
@@ -56,7 +56,6 @@ srtp_cipher_set_iv
 srtp_cipher_output
 srtp_cipher_encrypt
 srtp_cipher_decrypt
-srtp_cipher_get_tag
 srtp_cipher_set_aad
 srtp_replace_cipher_type
 srtp_auth_get_key_length

--- a/test/util.h
+++ b/test/util.h
@@ -56,6 +56,11 @@ void check_impl(bool condition,
                 const char *file,
                 int line,
                 const char *condition_str);
+void check_buffer_equal_impl(const uint8_t *buffer1,
+                             const uint8_t *buffer2,
+                             size_t buffer_length,
+                             const char *file,
+                             int line);
 void check_overrun_impl(const uint8_t *buffer,
                         size_t offset,
                         size_t buffer_length,
@@ -67,6 +72,8 @@ void overrun_check_prepare(uint8_t *buffer, size_t offset, size_t buffer_len);
 #define CHECK_RETURN(status, expected)                                         \
     check_return_impl((status), (expected), __FILE__, __LINE__)
 #define CHECK(condition) check_impl((condition), __FILE__, __LINE__, #condition)
+#define CHECK_BUFFER_EQUAL(buffer1, buffer2, length)                           \
+    check_buffer_equal_impl((buffer1), (buffer2), (length), __FILE__, __LINE__)
 #define CHECK_OVERRUN(buffer, offset, length)                                  \
     check_overrun_impl((buffer), (offset), (length), __FILE__, __LINE__)
 


### PR DESCRIPTION
Change for #714.
This makes it symmetric with the srtp_cipher_decrypt function that will remove the tag.
Currently most of the backends would have cached the tag internally and returned it in the srtp_cipher_get_tag function, this removes that extra complexity.
