### PR TITLE
Fix build issues on STM32H7 with ARM GNU toolchain

### DIFF
--- a/crypto/cipher/aes_gcm_mbedtls.c
+++ b/crypto/cipher/aes_gcm_mbedtls.c
@@ -90,6 +90,84 @@ srtp_debug_module_t srtp_mod_aes_gcm = {
 #define GCM_AUTH_TAG_LEN_8 8
 
 #define FUNC_ENTRY() debug_print(srtp_mod_aes_gcm, "%s entry", __func__);
+
+/*
+ * static function declarations.
+ */
+static srtp_err_status_t srtp_aes_gcm_mbedtls_alloc(srtp_cipher_t **c,
+                                                    size_t key_len,
+                                                    size_t tlen);
+
+static srtp_err_status_t srtp_aes_gcm_mbedtls_dealloc(srtp_cipher_t *c);
+
+static srtp_err_status_t srtp_aes_gcm_mbedtls_context_init(void *cv,
+                                                           const uint8_t *key);
+
+static srtp_err_status_t srtp_aes_gcm_mbedtls_set_iv(
+    void *cv,
+    uint8_t *iv,
+    srtp_cipher_direction_t direction);
+
+static srtp_err_status_t srtp_aes_gcm_mbedtls_set_aad(void *cv,
+                                                      const uint8_t *aad,
+                                                      size_t aad_len);
+
+static srtp_err_status_t srtp_aes_gcm_mbedtls_encrypt(void *cv,
+                                                      const uint8_t *src,
+                                                      size_t src_len,
+                                                      uint8_t *dst,
+                                                      size_t *dst_len);
+
+static srtp_err_status_t srtp_aes_gcm_mbedtls_decrypt(void *cv,
+                                                      const uint8_t *src,
+                                                      size_t src_len,
+                                                      uint8_t *dst,
+                                                      size_t *dst_len);
+
+/*
+ * Name of this crypto engine
+ */
+static const char srtp_aes_gcm_128_mbedtls_description[] =
+    "AES-128 GCM using mbedtls";
+static const char srtp_aes_gcm_256_mbedtls_description[] =
+    "AES-256 GCM using mbedtls";
+
+/*
+ * This is the vector function table for this crypto engine.
+ */
+/* clang-format off */
+const srtp_cipher_type_t srtp_aes_gcm_128 = {
+    srtp_aes_gcm_mbedtls_alloc,
+    srtp_aes_gcm_mbedtls_dealloc,
+    srtp_aes_gcm_mbedtls_context_init,
+    srtp_aes_gcm_mbedtls_set_aad,
+    srtp_aes_gcm_mbedtls_encrypt,
+    srtp_aes_gcm_mbedtls_decrypt,
+    srtp_aes_gcm_mbedtls_set_iv,
+    srtp_aes_gcm_128_mbedtls_description,
+    &srtp_aes_gcm_128_test_case_0,
+    SRTP_AES_GCM_128
+};
+/* clang-format on */
+
+/*
+ * This is the vector function table for this crypto engine.
+ */
+/* clang-format off */
+const srtp_cipher_type_t srtp_aes_gcm_256 = {
+    srtp_aes_gcm_mbedtls_alloc,
+    srtp_aes_gcm_mbedtls_dealloc,
+    srtp_aes_gcm_mbedtls_context_init,
+    srtp_aes_gcm_mbedtls_set_aad,
+    srtp_aes_gcm_mbedtls_encrypt,
+    srtp_aes_gcm_mbedtls_decrypt,
+    srtp_aes_gcm_mbedtls_set_iv,
+    srtp_aes_gcm_256_mbedtls_description,
+    &srtp_aes_gcm_256_test_case_0,
+    SRTP_AES_GCM_256
+};
+/* clang-format on */
+
 /*
  * This function allocates a new instance of this crypto engine.
  * The key_len parameter should be one of 28 or 44 for
@@ -362,47 +440,3 @@ static srtp_err_status_t srtp_aes_gcm_mbedtls_decrypt(void *cv,
 
     return srtp_err_status_ok;
 }
-
-/*
- * Name of this crypto engine
- */
-static const char srtp_aes_gcm_128_mbedtls_description[] =
-    "AES-128 GCM using mbedtls";
-static const char srtp_aes_gcm_256_mbedtls_description[] =
-    "AES-256 GCM using mbedtls";
-
-/*
- * This is the vector function table for this crypto engine.
- */
-/* clang-format off */
-const srtp_cipher_type_t srtp_aes_gcm_128 = {
-    srtp_aes_gcm_mbedtls_alloc,
-    srtp_aes_gcm_mbedtls_dealloc,
-    srtp_aes_gcm_mbedtls_context_init,
-    srtp_aes_gcm_mbedtls_set_aad,
-    srtp_aes_gcm_mbedtls_encrypt,
-    srtp_aes_gcm_mbedtls_decrypt,
-    srtp_aes_gcm_mbedtls_set_iv,
-    srtp_aes_gcm_128_mbedtls_description,
-    &srtp_aes_gcm_128_test_case_0,
-    SRTP_AES_GCM_128
-};
-/* clang-format on */
-
-/*
- * This is the vector function table for this crypto engine.
- */
-/* clang-format off */
-const srtp_cipher_type_t srtp_aes_gcm_256 = {
-    srtp_aes_gcm_mbedtls_alloc,
-    srtp_aes_gcm_mbedtls_dealloc,
-    srtp_aes_gcm_mbedtls_context_init,
-    srtp_aes_gcm_mbedtls_set_aad,
-    srtp_aes_gcm_mbedtls_encrypt,
-    srtp_aes_gcm_mbedtls_decrypt,
-    srtp_aes_gcm_mbedtls_set_iv,
-    srtp_aes_gcm_256_mbedtls_description,
-    &srtp_aes_gcm_256_test_case_0,
-    SRTP_AES_GCM_256
-};
-/* clang-format on */

--- a/crypto/cipher/aes_icm_mbedtls.c
+++ b/crypto/cipher/aes_icm_mbedtls.c
@@ -59,6 +59,90 @@ srtp_debug_module_t srtp_mod_aes_icm = {
 };
 
 /*
+ * static function declarations.
+ */
+static srtp_err_status_t srtp_aes_icm_mbedtls_alloc(srtp_cipher_t **c,
+                                                    size_t key_len,
+                                                    size_t tlen);
+
+static srtp_err_status_t srtp_aes_icm_mbedtls_dealloc(srtp_cipher_t *c);
+
+static srtp_err_status_t srtp_aes_icm_mbedtls_context_init(void *cv,
+                                                           const uint8_t *key);
+
+static srtp_err_status_t srtp_aes_icm_mbedtls_set_iv(
+    void *cv,
+    uint8_t *iv,
+    srtp_cipher_direction_t dir);
+
+static srtp_err_status_t srtp_aes_icm_mbedtls_encrypt(void *cv,
+                                                      const uint8_t *src,
+                                                      size_t src_len,
+                                                      uint8_t *dst,
+                                                      size_t *dst_len);
+
+/*
+ * Name of this crypto engine
+ */
+static const char srtp_aes_icm_128_mbedtls_description[] =
+    "AES-128 counter mode using mbedtls";
+static const char srtp_aes_icm_192_mbedtls_description[] =
+    "AES-192 counter mode using mbedtls";
+static const char srtp_aes_icm_256_mbedtls_description[] =
+    "AES-256 counter mode using mbedtls";
+
+/*
+ * This is the function table for this crypto engine.
+ * note: the encrypt function is identical to the decrypt function
+ */
+const srtp_cipher_type_t srtp_aes_icm_128 = {
+    srtp_aes_icm_mbedtls_alloc,           /* */
+    srtp_aes_icm_mbedtls_dealloc,         /* */
+    srtp_aes_icm_mbedtls_context_init,    /* */
+    0,                                    /* set_aad */
+    srtp_aes_icm_mbedtls_encrypt,         /* */
+    srtp_aes_icm_mbedtls_encrypt,         /* */
+    srtp_aes_icm_mbedtls_set_iv,          /* */
+    srtp_aes_icm_128_mbedtls_description, /* */
+    &srtp_aes_icm_128_test_case_0,        /* */
+    SRTP_AES_ICM_128                      /* */
+};
+
+/*
+ * This is the function table for this crypto engine.
+ * note: the encrypt function is identical to the decrypt function
+ */
+const srtp_cipher_type_t srtp_aes_icm_192 = {
+    srtp_aes_icm_mbedtls_alloc,           /* */
+    srtp_aes_icm_mbedtls_dealloc,         /* */
+    srtp_aes_icm_mbedtls_context_init,    /* */
+    0,                                    /* set_aad */
+    srtp_aes_icm_mbedtls_encrypt,         /* */
+    srtp_aes_icm_mbedtls_encrypt,         /* */
+    srtp_aes_icm_mbedtls_set_iv,          /* */
+    srtp_aes_icm_192_mbedtls_description, /* */
+    &srtp_aes_icm_192_test_case_0,        /* */
+    SRTP_AES_ICM_192                      /* */
+};
+
+/*
+ * This is the function table for this crypto engine.
+ * note: the encrypt function is identical to the decrypt function
+ */
+const srtp_cipher_type_t srtp_aes_icm_256 = {
+    srtp_aes_icm_mbedtls_alloc,           /* */
+    srtp_aes_icm_mbedtls_dealloc,         /* */
+    srtp_aes_icm_mbedtls_context_init,    /* */
+    0,                                    /* set_aad */
+    srtp_aes_icm_mbedtls_encrypt,         /* */
+    srtp_aes_icm_mbedtls_encrypt,         /* */
+    srtp_aes_icm_mbedtls_set_iv,          /* */
+    srtp_aes_icm_256_mbedtls_description, /* */
+    &srtp_aes_icm_256_test_case_0,        /* */
+    SRTP_AES_ICM_256                      /* */
+};
+
+/*
  * integer counter mode works as follows:
  *
  * https://tools.ietf.org/html/rfc3711#section-4.1.1
@@ -316,64 +400,3 @@ static srtp_err_status_t srtp_aes_icm_mbedtls_encrypt(void *cv,
 
     return srtp_err_status_ok;
 }
-
-/*
- * Name of this crypto engine
- */
-static const char srtp_aes_icm_128_mbedtls_description[] =
-    "AES-128 counter mode using mbedtls";
-static const char srtp_aes_icm_192_mbedtls_description[] =
-    "AES-192 counter mode using mbedtls";
-static const char srtp_aes_icm_256_mbedtls_description[] =
-    "AES-256 counter mode using mbedtls";
-
-/*
- * This is the function table for this crypto engine.
- * note: the encrypt function is identical to the decrypt function
- */
-const srtp_cipher_type_t srtp_aes_icm_128 = {
-    srtp_aes_icm_mbedtls_alloc,           /* */
-    srtp_aes_icm_mbedtls_dealloc,         /* */
-    srtp_aes_icm_mbedtls_context_init,    /* */
-    0,                                    /* set_aad */
-    srtp_aes_icm_mbedtls_encrypt,         /* */
-    srtp_aes_icm_mbedtls_encrypt,         /* */
-    srtp_aes_icm_mbedtls_set_iv,          /* */
-    srtp_aes_icm_128_mbedtls_description, /* */
-    &srtp_aes_icm_128_test_case_0,        /* */
-    SRTP_AES_ICM_128                      /* */
-};
-
-/*
- * This is the function table for this crypto engine.
- * note: the encrypt function is identical to the decrypt function
- */
-const srtp_cipher_type_t srtp_aes_icm_192 = {
-    srtp_aes_icm_mbedtls_alloc,           /* */
-    srtp_aes_icm_mbedtls_dealloc,         /* */
-    srtp_aes_icm_mbedtls_context_init,    /* */
-    0,                                    /* set_aad */
-    srtp_aes_icm_mbedtls_encrypt,         /* */
-    srtp_aes_icm_mbedtls_encrypt,         /* */
-    srtp_aes_icm_mbedtls_set_iv,          /* */
-    srtp_aes_icm_192_mbedtls_description, /* */
-    &srtp_aes_icm_192_test_case_0,        /* */
-    SRTP_AES_ICM_192                      /* */
-};
-
-/*
- * This is the function table for this crypto engine.
- * note: the encrypt function is identical to the decrypt function
- */
-const srtp_cipher_type_t srtp_aes_icm_256 = {
-    srtp_aes_icm_mbedtls_alloc,           /* */
-    srtp_aes_icm_mbedtls_dealloc,         /* */
-    srtp_aes_icm_mbedtls_context_init,    /* */
-    0,                                    /* set_aad */
-    srtp_aes_icm_mbedtls_encrypt,         /* */
-    srtp_aes_icm_mbedtls_encrypt,         /* */
-    srtp_aes_icm_mbedtls_set_iv,          /* */
-    srtp_aes_icm_256_mbedtls_description, /* */
-    &srtp_aes_icm_256_test_case_0,        /* */
-    SRTP_AES_ICM_256                      /* */
-};

--- a/crypto/include/datatypes.h
+++ b/crypto/include/datatypes.h
@@ -54,8 +54,6 @@
 #include <netinet/in.h>
 #elif defined HAVE_WINSOCK2_H
 #include <winsock2.h>
-#else
-#error "Platform not recognized"
 #endif
 
 #if defined(__SSE2__)

--- a/crypto/include/err.h
+++ b/crypto/include/err.h
@@ -47,6 +47,10 @@
 
 #include <stdio.h>
 #include <stdarg.h>
+
+#ifdef HAVE_CONFIG_H
+#include <config.h>
+#endif
 #include "srtp.h"
 
 #if defined(__clang__) || (defined(__GNUC__) && defined(__has_attribute))
@@ -121,26 +125,44 @@ typedef struct {
 
 #ifdef ENABLE_DEBUG_LOGGING
 
-#define debug_print0(mod, format)                                              \
-    srtp_err_report(srtp_err_level_debug, ("%s: " format "\n"), mod.name)
-#define debug_print(mod, format, arg)                                          \
-    srtp_err_report(srtp_err_level_debug, ("%s: " format "\n"), mod.name, arg)
-#define debug_print2(mod, format, arg1, arg2)                                  \
-    srtp_err_report(srtp_err_level_debug, ("%s: " format "\n"), mod.name,      \
-                    arg1, arg2)
+#ifndef debug_print0
+    #define debug_print0(mod, format)                                          \
+        srtp_err_report(srtp_err_level_debug, ("%s: " format "\n"), mod.name)
+#endif
+
+#ifndef debug_print
+    #define debug_print(mod, format, arg)                                      \
+        srtp_err_report(srtp_err_level_debug, ("%s: " format "\n"), mod.name,  \
+                        arg)
+#endif
+
+#ifndef debug_print2
+    #define debug_print2(mod, format, arg1, arg2)                              \
+        srtp_err_report(srtp_err_level_debug, ("%s: " format "\n"), mod.name,  \
+                        arg1, arg2)
+#endif
 
 #else
 
-#define debug_print0(mod, format)                                              \
-    if (mod.on)                                                                \
-    srtp_err_report(srtp_err_level_debug, ("%s: " format "\n"), mod.name)
-#define debug_print(mod, format, arg)                                          \
-    if (mod.on)                                                                \
-    srtp_err_report(srtp_err_level_debug, ("%s: " format "\n"), mod.name, arg)
-#define debug_print2(mod, format, arg1, arg2)                                  \
-    if (mod.on)                                                                \
-    srtp_err_report(srtp_err_level_debug, ("%s: " format "\n"), mod.name,      \
-                    arg1, arg2)
+#ifndef debug_print0
+    #define debug_print0(mod, format)                                          \
+        if (mod.on)                                                            \
+        srtp_err_report(srtp_err_level_debug, ("%s: " format "\n"), mod.name)
+#endif
+
+#ifndef debug_print
+    #define debug_print(mod, format, arg)                                      \
+        if (mod.on)                                                            \
+        srtp_err_report(srtp_err_level_debug, ("%s: " format "\n"), mod.name,  \
+                        arg)
+#endif
+
+#ifndef debug_print2
+    #define debug_print2(mod, format, arg1, arg2)                              \
+        if (mod.on)                                                            \
+        srtp_err_report(srtp_err_level_debug, ("%s: " format "\n"), mod.name,  \
+                        arg1, arg2)
+#endif
 
 #endif
 

--- a/crypto/include/err.h
+++ b/crypto/include/err.h
@@ -126,42 +126,40 @@ typedef struct {
 #ifdef ENABLE_DEBUG_LOGGING
 
 #ifndef debug_print0
-    #define debug_print0(mod, format)                                          \
-        srtp_err_report(srtp_err_level_debug, ("%s: " format "\n"), mod.name)
+#define debug_print0(mod, format)                                              \
+    srtp_err_report(srtp_err_level_debug, ("%s: " format "\n"), mod.name)
 #endif
 
 #ifndef debug_print
-    #define debug_print(mod, format, arg)                                      \
-        srtp_err_report(srtp_err_level_debug, ("%s: " format "\n"), mod.name,  \
-                        arg)
+#define debug_print(mod, format, arg)                                          \
+    srtp_err_report(srtp_err_level_debug, ("%s: " format "\n"), mod.name, arg)
 #endif
 
 #ifndef debug_print2
-    #define debug_print2(mod, format, arg1, arg2)                              \
-        srtp_err_report(srtp_err_level_debug, ("%s: " format "\n"), mod.name,  \
-                        arg1, arg2)
+#define debug_print2(mod, format, arg1, arg2)                                  \
+    srtp_err_report(srtp_err_level_debug, ("%s: " format "\n"), mod.name,      \
+                    arg1, arg2)
 #endif
 
 #else
 
 #ifndef debug_print0
-    #define debug_print0(mod, format)                                          \
-        if (mod.on)                                                            \
-        srtp_err_report(srtp_err_level_debug, ("%s: " format "\n"), mod.name)
+#define debug_print0(mod, format)                                              \
+    if (mod.on)                                                                \
+    srtp_err_report(srtp_err_level_debug, ("%s: " format "\n"), mod.name)
 #endif
 
 #ifndef debug_print
-    #define debug_print(mod, format, arg)                                      \
-        if (mod.on)                                                            \
-        srtp_err_report(srtp_err_level_debug, ("%s: " format "\n"), mod.name,  \
-                        arg)
+#define debug_print(mod, format, arg)                                          \
+    if (mod.on)                                                                \
+    srtp_err_report(srtp_err_level_debug, ("%s: " format "\n"), mod.name, arg)
 #endif
 
 #ifndef debug_print2
-    #define debug_print2(mod, format, arg1, arg2)                              \
-        if (mod.on)                                                            \
-        srtp_err_report(srtp_err_level_debug, ("%s: " format "\n"), mod.name,  \
-                        arg1, arg2)
+#define debug_print2(mod, format, arg1, arg2)                                  \
+    if (mod.on)                                                                \
+    srtp_err_report(srtp_err_level_debug, ("%s: " format "\n"), mod.name,      \
+                    arg1, arg2)
 #endif
 
 #endif

--- a/srtp/srtp.c
+++ b/srtp/srtp.c
@@ -1507,28 +1507,28 @@ static srtp_err_status_t srtp_stream_init(srtp_stream_ctx_t *srtp,
 
 void srtp_event_reporter(srtp_event_data_t *data)
 {
-    debug_print(srtp_err_level_warning,
-                "srtp: in stream 0x%x: ", data->ssrc);
+    srtp_err_report(srtp_err_level_warning,
+                    "srtp: in stream 0x%x: ", data->ssrc);
 
     switch (data->event) {
     case event_ssrc_collision:
-        debug_print0(srtp_err_level_warning, "\tSSRC collision\n");
+        srtp_err_report(srtp_err_level_warning, "\tSSRC collision\n");
         break;
     case event_key_soft_limit:
-        debug_print0(srtp_err_level_warning,
-                     "\tkey usage soft limit reached\n");
+        srtp_err_report(srtp_err_level_warning,
+                     	"\tkey usage soft limit reached\n");
         break;
     case event_key_hard_limit:
-        debug_print0(srtp_err_level_warning,
-                     "\tkey usage hard limit reached\n");
+        srtp_err_report(srtp_err_level_warning,
+                        "\tkey usage hard limit reached\n");
         break;
     case event_packet_index_limit:
-        debug_print0(srtp_err_level_warning,
-                     "\tpacket index limit reached\n");
+        srtp_err_report(srtp_err_level_warning,
+                        "\tpacket index limit reached\n");
         break;
     default:
-        debug_print0(srtp_err_level_warning,
-                     "\tunknown event reported to handler\n");
+        srtp_err_report(srtp_err_level_warning,
+                        "\tunknown event reported to handler\n");
     }
 }
 

--- a/srtp/srtp.c
+++ b/srtp/srtp.c
@@ -584,8 +584,8 @@ static srtp_err_status_t srtp_stream_clone(
     srtp_session_keys_t *session_keys = NULL;
     const srtp_session_keys_t *template_session_keys = NULL;
 
-    debug_print(mod_srtp,
-                "cloning stream (SSRC: 0x%08x)", (unsigned int) ntohl(ssrc));
+    debug_print(mod_srtp, "cloning stream (SSRC: 0x%08x)",
+                (unsigned int)ntohl(ssrc));
 
     /* allocate srtp stream and set str_ptr */
     str = (srtp_stream_ctx_t *)srtp_crypto_alloc(sizeof(srtp_stream_ctx_t));
@@ -1443,9 +1443,8 @@ static srtp_err_status_t srtp_stream_init(srtp_stream_ctx_t *srtp,
         return err;
     }
 
-    debug_print(mod_srtp,
-                "initializing stream (SSRC: 0x%08x)",
-                (unsigned int) p->ssrc.value);
+    debug_print(mod_srtp, "initializing stream (SSRC: 0x%08x)",
+                (unsigned int)p->ssrc.value);
 
     /* initialize replay database */
     /*
@@ -1511,7 +1510,7 @@ static srtp_err_status_t srtp_stream_init(srtp_stream_ctx_t *srtp,
 void srtp_event_reporter(srtp_event_data_t *data)
 {
     srtp_err_report(srtp_err_level_warning,
-                    "srtp: in stream 0x%x: ", (unsigned int) data->ssrc);
+                    "srtp: in stream 0x%x: ", (unsigned int)data->ssrc);
 
     switch (data->event) {
     case event_ssrc_collision:
@@ -1519,7 +1518,7 @@ void srtp_event_reporter(srtp_event_data_t *data)
         break;
     case event_key_soft_limit:
         srtp_err_report(srtp_err_level_warning,
-                     	"\tkey usage soft limit reached\n");
+                        "\tkey usage soft limit reached\n");
         break;
     case event_key_hard_limit:
         srtp_err_report(srtp_err_level_warning,
@@ -2551,7 +2550,7 @@ srtp_err_status_t srtp_unprotect(srtp_t ctx,
         if (ctx->stream_template != NULL) {
             stream = ctx->stream_template;
             debug_print(mod_srtp, "using provisional stream (SSRC: 0x%08x)",
-                        (unsigned int) ntohl(hdr->ssrc));
+                        (unsigned int)ntohl(hdr->ssrc));
 
             /*
              * set estimated packet index to sequence number from header,
@@ -3670,7 +3669,7 @@ static srtp_err_status_t srtp_protect_rtcp_aead(
     }
     seq_num = srtp_rdb_get_value(&stream->rtcp_rdb);
     trailer |= htonl(seq_num);
-    debug_print(mod_srtp, "srtcp index: %x", (unsigned int) seq_num);
+    debug_print(mod_srtp, "srtcp index: %x", (unsigned int)seq_num);
 
     memcpy(trailer_p, &trailer, sizeof(trailer));
 
@@ -3817,7 +3816,7 @@ static srtp_err_status_t srtp_unprotect_rtcp_aead(
      */
     /* this is easier than dealing with bitfield access */
     seq_num = ntohl(trailer) & SRTCP_INDEX_MASK;
-    debug_print(mod_srtp, "srtcp index: %x", (unsigned int) seq_num);
+    debug_print(mod_srtp, "srtcp index: %x", (unsigned int)seq_num);
     status = srtp_rdb_check(&stream->rtcp_rdb, seq_num);
     if (status) {
         return status;
@@ -4115,7 +4114,7 @@ srtp_err_status_t srtp_protect_rtcp(srtp_t ctx,
     }
     seq_num = srtp_rdb_get_value(&stream->rtcp_rdb);
     trailer |= htonl(seq_num);
-    debug_print(mod_srtp, "srtcp index: %x", (unsigned int) seq_num);
+    debug_print(mod_srtp, "srtcp index: %x", (unsigned int)seq_num);
 
     memcpy(trailer_p, &trailer, sizeof(trailer));
 
@@ -4258,7 +4257,7 @@ srtp_err_status_t srtp_unprotect_rtcp(srtp_t ctx,
 
             debug_print(mod_srtp,
                         "srtcp using provisional stream (SSRC: 0x%08x)",
-                        (unsigned int) ntohl(hdr->ssrc));
+                        (unsigned int)ntohl(hdr->ssrc));
         } else {
             /* no template stream, so we return an error */
             return srtp_err_status_no_ctx;
@@ -4338,7 +4337,7 @@ srtp_err_status_t srtp_unprotect_rtcp(srtp_t ctx,
      */
     /* this is easier than dealing with bitfield access */
     seq_num = ntohl(trailer) & SRTCP_INDEX_MASK;
-    debug_print(mod_srtp, "srtcp index: %x", (unsigned int) seq_num);
+    debug_print(mod_srtp, "srtcp index: %x", (unsigned int)seq_num);
     status = srtp_rdb_check(&stream->rtcp_rdb, seq_num);
     if (status) {
         return status;

--- a/srtp/srtp.c
+++ b/srtp/srtp.c
@@ -1507,28 +1507,28 @@ static srtp_err_status_t srtp_stream_init(srtp_stream_ctx_t *srtp,
 
 void srtp_event_reporter(srtp_event_data_t *data)
 {
-    srtp_err_report(srtp_err_level_warning,
-                    "srtp: in stream 0x%x: ", data->ssrc);
+    debug_print(srtp_err_level_warning,
+                "srtp: in stream 0x%x: ", data->ssrc);
 
     switch (data->event) {
     case event_ssrc_collision:
-        srtp_err_report(srtp_err_level_warning, "\tSSRC collision\n");
+        debug_print0(srtp_err_level_warning, "\tSSRC collision\n");
         break;
     case event_key_soft_limit:
-        srtp_err_report(srtp_err_level_warning,
-                        "\tkey usage soft limit reached\n");
+        debug_print0(srtp_err_level_warning,
+                     "\tkey usage soft limit reached\n");
         break;
     case event_key_hard_limit:
-        srtp_err_report(srtp_err_level_warning,
-                        "\tkey usage hard limit reached\n");
+        debug_print0(srtp_err_level_warning,
+                     "\tkey usage hard limit reached\n");
         break;
     case event_packet_index_limit:
-        srtp_err_report(srtp_err_level_warning,
-                        "\tpacket index limit reached\n");
+        debug_print0(srtp_err_level_warning,
+                     "\tpacket index limit reached\n");
         break;
     default:
-        srtp_err_report(srtp_err_level_warning,
-                        "\tunknown event reported to handler\n");
+        debug_print0(srtp_err_level_warning,
+                     "\tunknown event reported to handler\n");
     }
 }
 

--- a/srtp/srtp.c
+++ b/srtp/srtp.c
@@ -584,7 +584,8 @@ static srtp_err_status_t srtp_stream_clone(
     srtp_session_keys_t *session_keys = NULL;
     const srtp_session_keys_t *template_session_keys = NULL;
 
-    debug_print(mod_srtp, "cloning stream (SSRC: 0x%08x)", ntohl(ssrc));
+    debug_print(mod_srtp,
+                "cloning stream (SSRC: 0x%08x)", (unsigned int) ntohl(ssrc));
 
     /* allocate srtp stream and set str_ptr */
     str = (srtp_stream_ctx_t *)srtp_crypto_alloc(sizeof(srtp_stream_ctx_t));
@@ -1442,7 +1443,9 @@ static srtp_err_status_t srtp_stream_init(srtp_stream_ctx_t *srtp,
         return err;
     }
 
-    debug_print(mod_srtp, "initializing stream (SSRC: 0x%08x)", p->ssrc.value);
+    debug_print(mod_srtp,
+                "initializing stream (SSRC: 0x%08x)",
+                (unsigned int) p->ssrc.value);
 
     /* initialize replay database */
     /*
@@ -1508,7 +1511,7 @@ static srtp_err_status_t srtp_stream_init(srtp_stream_ctx_t *srtp,
 void srtp_event_reporter(srtp_event_data_t *data)
 {
     srtp_err_report(srtp_err_level_warning,
-                    "srtp: in stream 0x%x: ", data->ssrc);
+                    "srtp: in stream 0x%x: ", (unsigned int) data->ssrc);
 
     switch (data->event) {
     case event_ssrc_collision:
@@ -2548,7 +2551,7 @@ srtp_err_status_t srtp_unprotect(srtp_t ctx,
         if (ctx->stream_template != NULL) {
             stream = ctx->stream_template;
             debug_print(mod_srtp, "using provisional stream (SSRC: 0x%08x)",
-                        ntohl(hdr->ssrc));
+                        (unsigned int) ntohl(hdr->ssrc));
 
             /*
              * set estimated packet index to sequence number from header,
@@ -3667,7 +3670,7 @@ static srtp_err_status_t srtp_protect_rtcp_aead(
     }
     seq_num = srtp_rdb_get_value(&stream->rtcp_rdb);
     trailer |= htonl(seq_num);
-    debug_print(mod_srtp, "srtcp index: %x", seq_num);
+    debug_print(mod_srtp, "srtcp index: %x", (unsigned int) seq_num);
 
     memcpy(trailer_p, &trailer, sizeof(trailer));
 
@@ -3814,7 +3817,7 @@ static srtp_err_status_t srtp_unprotect_rtcp_aead(
      */
     /* this is easier than dealing with bitfield access */
     seq_num = ntohl(trailer) & SRTCP_INDEX_MASK;
-    debug_print(mod_srtp, "srtcp index: %x", seq_num);
+    debug_print(mod_srtp, "srtcp index: %x", (unsigned int) seq_num);
     status = srtp_rdb_check(&stream->rtcp_rdb, seq_num);
     if (status) {
         return status;
@@ -4112,7 +4115,7 @@ srtp_err_status_t srtp_protect_rtcp(srtp_t ctx,
     }
     seq_num = srtp_rdb_get_value(&stream->rtcp_rdb);
     trailer |= htonl(seq_num);
-    debug_print(mod_srtp, "srtcp index: %x", seq_num);
+    debug_print(mod_srtp, "srtcp index: %x", (unsigned int) seq_num);
 
     memcpy(trailer_p, &trailer, sizeof(trailer));
 
@@ -4255,7 +4258,7 @@ srtp_err_status_t srtp_unprotect_rtcp(srtp_t ctx,
 
             debug_print(mod_srtp,
                         "srtcp using provisional stream (SSRC: 0x%08x)",
-                        ntohl(hdr->ssrc));
+                        (unsigned int) ntohl(hdr->ssrc));
         } else {
             /* no template stream, so we return an error */
             return srtp_err_status_no_ctx;
@@ -4335,7 +4338,7 @@ srtp_err_status_t srtp_unprotect_rtcp(srtp_t ctx,
      */
     /* this is easier than dealing with bitfield access */
     seq_num = ntohl(trailer) & SRTCP_INDEX_MASK;
-    debug_print(mod_srtp, "srtcp index: %x", seq_num);
+    debug_print(mod_srtp, "srtcp index: %x", (unsigned int) seq_num);
     status = srtp_rdb_check(&stream->rtcp_rdb, seq_num);
     if (status) {
         return status;


### PR DESCRIPTION
## Description 
I tried building the libstrp for STM32H743ZI (Cortex-M7) target using ARM GNU GCC and faced some build issues. This change fixes those issues.

1. `aes_gcm_mbedtls.c` and `aes_icm_mbedtls.c` - Fix use for before declaration errors.
2. `datatypes.h` - Do not generate error when `HAVE_NETINET_IN_H` and `HAVE_WINSOCK2_H` are not defined. This enables the library to be used on embedded targets using FreeRTOS-Plus-TCP.
3. `err.h` and `srtp.c` - Allow the application to change the logging macro definitions at compile time. The application can provide these definitions in `config.h`.