### PR TITLE
Fix memory overflow and capacity regression.

### DIFF
--- a/srtp/srtp.c
+++ b/srtp/srtp.c
@@ -46,62 +46,53 @@
 #include "config.h"
 
 #include "srtp_priv.h"
-
 #include "stream_list_priv.h"
-
 #include "crypto_types.h"
-
 #include "err.h"
-
 #include "alloc.h" /* for srtp_crypto_alloc() */
 
-#ifdef GCM#include "aes_gcm.h" /* for AES GCM mode */
-
+#ifdef GCM
+#include "aes_gcm.h" /* for AES GCM mode */
 #endif
 
-#ifdef OPENSSL_KDF#include <openssl/kdf.h>
-
+#ifdef OPENSSL_KDF
+#include <openssl/kdf.h>
 #include "aes_icm_ext.h"
-
 #endif
 
 #ifdef WOLFSSL
-#ifdef HAVE_CONFIG_H#include <config.h>
-
+#ifdef HAVE_CONFIG_H
+#include <config.h>
 #endif
-#ifndef WOLFSSL_USER_SETTINGS#include <wolfssl/options.h>
-
-#endif#include <wolfssl/wolfcrypt/settings.h>
-
-#ifdef WOLFSSL_KDF#include <wolfssl/wolfcrypt/kdf.h>
-
+#ifndef WOLFSSL_USER_SETTINGS
+#include <wolfssl/options.h>
+#endif
+#include <wolfssl/wolfcrypt/settings.h>
+#ifdef WOLFSSL_KDF
+#include <wolfssl/wolfcrypt/kdf.h>
 #endif
 #endif
 
 #include <limits.h>
-
-#ifdef HAVE_NETINET_IN_H#include <netinet/in.h>
-
-#elif defined(HAVE_WINSOCK2_H)#include <winsock2.h>
-
+#ifdef HAVE_NETINET_IN_H
+#include <netinet/in.h>
+#elif defined(HAVE_WINSOCK2_H)
+#include <winsock2.h>
 #endif
 
 /* the debug module for srtp */
 srtp_debug_module_t mod_srtp = {
-    false,
-    /* debugging is off by default */
+    false, /* debugging is off by default */
     "srtp" /* printable name for module */
 };
 
-static
-const size_t octets_in_rtp_header = 12;
-static
-const size_t octets_in_rtcp_header = 8;
-static
-const size_t octets_in_rtp_xtn_hdr = 4;
+static const size_t octets_in_rtp_header = 12;
+static const size_t octets_in_rtcp_header = 8;
+static const size_t octets_in_rtp_xtn_hdr = 4;
 
-static size_t srtp_get_rtp_hdr_len(const srtp_hdr_t * hdr) {
-    return octets_in_rtp_header + 4 * hdr -> cc;
+static size_t srtp_get_rtp_hdr_len(const srtp_hdr_t *hdr)
+{
+    return octets_in_rtp_header + 4 * hdr->cc;
 }
 
 /*
@@ -110,9 +101,10 @@ static size_t srtp_get_rtp_hdr_len(const srtp_hdr_t * hdr) {
  * verified that a header extension is present by checking the x bit of
  * srtp_hdr_t.
  */
-static srtp_hdr_xtnd_t * srtp_get_rtp_xtn_hdr(const srtp_hdr_t * hdr,
-    uint8_t * rtp) {
-    return (srtp_hdr_xtnd_t * )(rtp + srtp_get_rtp_hdr_len(hdr));
+static srtp_hdr_xtnd_t *srtp_get_rtp_xtn_hdr(const srtp_hdr_t *hdr,
+                                             uint8_t *rtp)
+{
+    return (srtp_hdr_xtnd_t *)(rtp + srtp_get_rtp_hdr_len(hdr));
 }
 
 /*
@@ -121,16 +113,18 @@ static srtp_hdr_xtnd_t * srtp_get_rtp_xtn_hdr(const srtp_hdr_t * hdr,
  * pointer and that the caller has already verified that a header extension is
  * valid by checking the x bit of the RTP header.
  */
-static size_t srtp_get_rtp_xtn_hdr_len(const srtp_hdr_t * hdr,
-    const uint8_t * rtp) {
-    const srtp_hdr_xtnd_t * xtn_hdr =
-        (const srtp_hdr_xtnd_t * )(rtp + srtp_get_rtp_hdr_len(hdr));
-    return (ntohs(xtn_hdr -> length) + 1 u) * 4 u;
+static size_t srtp_get_rtp_xtn_hdr_len(const srtp_hdr_t *hdr,
+                                       const uint8_t *rtp)
+{
+    const srtp_hdr_xtnd_t *xtn_hdr =
+        (const srtp_hdr_xtnd_t *)(rtp + srtp_get_rtp_hdr_len(hdr));
+    return (ntohs(xtn_hdr->length) + 1u) * 4u;
 }
 
-static srtp_err_status_t srtp_validate_rtp_header(const uint8_t * rtp,
-    size_t pkt_octet_len) {
-    const srtp_hdr_t * hdr = (const srtp_hdr_t * ) rtp;
+static srtp_err_status_t srtp_validate_rtp_header(const uint8_t *rtp,
+                                                  size_t pkt_octet_len)
+{
+    const srtp_hdr_t *hdr = (const srtp_hdr_t *)rtp;
     size_t rtp_header_len;
 
     if (pkt_octet_len < octets_in_rtp_header) {
@@ -144,7 +138,7 @@ static srtp_err_status_t srtp_validate_rtp_header(const uint8_t * rtp,
     }
 
     /* Verifying profile length. */
-    if (hdr -> x == 1) {
+    if (hdr->x == 1) {
         if (pkt_octet_len < rtp_header_len + octets_in_rtp_xtn_hdr) {
             return srtp_err_status_bad_param;
         }
@@ -158,14 +152,16 @@ static srtp_err_status_t srtp_validate_rtp_header(const uint8_t * rtp,
     return srtp_err_status_ok;
 }
 
-const char * srtp_get_version_string(void) {
+const char *srtp_get_version_string(void)
+{
     /*
      * Simply return the autotools generated string
      */
     return SRTP_VER_STRING;
 }
 
-unsigned int srtp_get_version(void) {
+unsigned int srtp_get_version(void)
+{
     unsigned int major = 0, minor = 0, micro = 0;
     unsigned int rv = 0;
     int parse_rv;
@@ -173,7 +169,7 @@ unsigned int srtp_get_version(void) {
     /*
      * Parse the autotools generated version
      */
-    parse_rv = sscanf(SRTP_VERSION, "%u.%u.%u", & major, & minor, & micro);
+    parse_rv = sscanf(SRTP_VERSION, "%u.%u.%u", &major, &minor, &micro);
     if (parse_rv != 3) {
         /*
          * We're expected to parse all 3 version levels.
@@ -196,24 +192,25 @@ unsigned int srtp_get_version(void) {
 }
 
 static srtp_err_status_t srtp_stream_dealloc(
-    srtp_stream_ctx_t * stream,
-    const srtp_stream_ctx_t * stream_template) {
+    srtp_stream_ctx_t *stream,
+    const srtp_stream_ctx_t *stream_template)
+{
     srtp_err_status_t status;
-    srtp_session_keys_t * session_keys = NULL;
-    srtp_session_keys_t * template_session_keys = NULL;
+    srtp_session_keys_t *session_keys = NULL;
+    srtp_session_keys_t *template_session_keys = NULL;
 
     /*
      * we use a conservative deallocation strategy - if any deallocation
      * fails, then we report that fact without trying to deallocate
      * anything else
      */
-    if (stream -> session_keys) {
-        for (size_t i = 0; i < stream -> num_master_keys; i++) {
-            session_keys = & stream -> session_keys[i];
+    if (stream->session_keys) {
+        for (size_t i = 0; i < stream->num_master_keys; i++) {
+            session_keys = &stream->session_keys[i];
 
             if (stream_template &&
-                stream -> num_master_keys == stream_template -> num_master_keys) {
-                template_session_keys = & stream_template -> session_keys[i];
+                stream->num_master_keys == stream_template->num_master_keys) {
+                template_session_keys = &stream_template->session_keys[i];
             } else {
                 template_session_keys = NULL;
             }
@@ -222,10 +219,10 @@ static srtp_err_status_t srtp_stream_dealloc(
              * deallocate cipher, if it is not the same as that in template
              */
             if (template_session_keys &&
-                session_keys -> rtp_cipher == template_session_keys -> rtp_cipher) {
+                session_keys->rtp_cipher == template_session_keys->rtp_cipher) {
                 /* do nothing */
-            } else if (session_keys -> rtp_cipher) {
-                status = srtp_cipher_dealloc(session_keys -> rtp_cipher);
+            } else if (session_keys->rtp_cipher) {
+                status = srtp_cipher_dealloc(session_keys->rtp_cipher);
                 if (status) {
                     return status;
                 }
@@ -236,21 +233,21 @@ static srtp_err_status_t srtp_stream_dealloc(
              * template
              */
             if (template_session_keys &&
-                session_keys -> rtp_auth == template_session_keys -> rtp_auth) {
+                session_keys->rtp_auth == template_session_keys->rtp_auth) {
                 /* do nothing */
-            } else if (session_keys -> rtp_auth) {
-                status = srtp_auth_dealloc(session_keys -> rtp_auth);
+            } else if (session_keys->rtp_auth) {
+                status = srtp_auth_dealloc(session_keys->rtp_auth);
                 if (status) {
                     return status;
                 }
             }
 
             if (template_session_keys &&
-                session_keys -> rtp_xtn_hdr_cipher ==
-                template_session_keys -> rtp_xtn_hdr_cipher) {
+                session_keys->rtp_xtn_hdr_cipher ==
+                    template_session_keys->rtp_xtn_hdr_cipher) {
                 /* do nothing */
-            } else if (session_keys -> rtp_xtn_hdr_cipher) {
-                status = srtp_cipher_dealloc(session_keys -> rtp_xtn_hdr_cipher);
+            } else if (session_keys->rtp_xtn_hdr_cipher) {
+                status = srtp_cipher_dealloc(session_keys->rtp_xtn_hdr_cipher);
                 if (status) {
                     return status;
                 }
@@ -261,11 +258,11 @@ static srtp_err_status_t srtp_stream_dealloc(
              * template
              */
             if (template_session_keys &&
-                session_keys -> rtcp_cipher ==
-                template_session_keys -> rtcp_cipher) {
+                session_keys->rtcp_cipher ==
+                    template_session_keys->rtcp_cipher) {
                 /* do nothing */
-            } else if (session_keys -> rtcp_cipher) {
-                status = srtp_cipher_dealloc(session_keys -> rtcp_cipher);
+            } else if (session_keys->rtcp_cipher) {
+                status = srtp_cipher_dealloc(session_keys->rtcp_cipher);
                 if (status) {
                     return status;
                 }
@@ -276,10 +273,10 @@ static srtp_err_status_t srtp_stream_dealloc(
              * template
              */
             if (template_session_keys &&
-                session_keys -> rtcp_auth == template_session_keys -> rtcp_auth) {
+                session_keys->rtcp_auth == template_session_keys->rtcp_auth) {
                 /* do nothing */
-            } else if (session_keys -> rtcp_auth) {
-                status = srtp_auth_dealloc(session_keys -> rtcp_auth);
+            } else if (session_keys->rtcp_auth) {
+                status = srtp_auth_dealloc(session_keys->rtcp_auth);
                 if (status) {
                     return status;
                 }
@@ -288,14 +285,14 @@ static srtp_err_status_t srtp_stream_dealloc(
             /*
              * zeroize the salt value
              */
-            octet_string_set_to_zero(session_keys -> salt, SRTP_AEAD_SALT_LEN);
-            octet_string_set_to_zero(session_keys -> c_salt, SRTP_AEAD_SALT_LEN);
+            octet_string_set_to_zero(session_keys->salt, SRTP_AEAD_SALT_LEN);
+            octet_string_set_to_zero(session_keys->c_salt, SRTP_AEAD_SALT_LEN);
 
-            if (session_keys -> mki_id) {
-                octet_string_set_to_zero(session_keys -> mki_id,
-                    stream -> mki_size);
-                srtp_crypto_free(session_keys -> mki_id);
-                session_keys -> mki_id = NULL;
+            if (session_keys->mki_id) {
+                octet_string_set_to_zero(session_keys->mki_id,
+                                         stream->mki_size);
+                srtp_crypto_free(session_keys->mki_id);
+                session_keys->mki_id = NULL;
             }
 
             /*
@@ -303,25 +300,25 @@ static srtp_err_status_t srtp_stream_dealloc(
              * template
              */
             if (template_session_keys &&
-                session_keys -> limit == template_session_keys -> limit) {
+                session_keys->limit == template_session_keys->limit) {
                 /* do nothing */
-            } else if (session_keys -> limit) {
-                srtp_crypto_free(session_keys -> limit);
+            } else if (session_keys->limit) {
+                srtp_crypto_free(session_keys->limit);
             }
         }
-        srtp_crypto_free(stream -> session_keys);
+        srtp_crypto_free(stream->session_keys);
     }
 
-    status = srtp_rdbx_dealloc( & stream -> rtp_rdbx);
+    status = srtp_rdbx_dealloc(&stream->rtp_rdbx);
     if (status) {
         return status;
     }
 
     if (stream_template &&
-        stream -> enc_xtn_hdr == stream_template -> enc_xtn_hdr) {
+        stream->enc_xtn_hdr == stream_template->enc_xtn_hdr) {
         /* do nothing */
-    } else if (stream -> enc_xtn_hdr) {
-        srtp_crypto_free(stream -> enc_xtn_hdr);
+    } else if (stream->enc_xtn_hdr) {
+        srtp_crypto_free(stream->enc_xtn_hdr);
     }
 
     /* deallocate srtp stream context */
@@ -332,8 +329,9 @@ static srtp_err_status_t srtp_stream_dealloc(
 
 /* try to insert stream in list or deallocate it */
 static srtp_err_status_t srtp_insert_or_dealloc_stream(srtp_stream_list_t list,
-    srtp_stream_t stream,
-    srtp_stream_t template) {
+                                                       srtp_stream_t stream,
+                                                       srtp_stream_t template)
+{
     srtp_err_status_t status = srtp_stream_list_insert(list, stream);
     /* on failure, ownership wasn't transferred and we need to deallocate */
     if (status) {
@@ -348,12 +346,13 @@ struct remove_and_dealloc_streams_data {
     srtp_stream_t template;
 };
 
-static bool remove_and_dealloc_streams_cb(srtp_stream_t stream, void * data) {
-    struct remove_and_dealloc_streams_data * d =
-        (struct remove_and_dealloc_streams_data * ) data;
-    srtp_stream_list_remove(d -> list, stream);
-    d -> status = srtp_stream_dealloc(stream, d -> template);
-    if (d -> status) {
+static bool remove_and_dealloc_streams_cb(srtp_stream_t stream, void *data)
+{
+    struct remove_and_dealloc_streams_data *d =
+        (struct remove_and_dealloc_streams_data *)data;
+    srtp_stream_list_remove(d->list, stream);
+    d->status = srtp_stream_dealloc(stream, d->template);
+    if (d->status) {
         return false;
     }
     return true;
@@ -361,48 +360,47 @@ static bool remove_and_dealloc_streams_cb(srtp_stream_t stream, void * data) {
 
 static srtp_err_status_t srtp_remove_and_dealloc_streams(
     srtp_stream_list_t list,
-    srtp_stream_t template) {
-    struct remove_and_dealloc_streams_data data = {
-        srtp_err_status_ok,
-        list,
-        template
-    };
-    srtp_stream_list_for_each(list, remove_and_dealloc_streams_cb, & data);
+    srtp_stream_t template)
+{
+    struct remove_and_dealloc_streams_data data = { srtp_err_status_ok, list,
+                                                    template };
+    srtp_stream_list_for_each(list, remove_and_dealloc_streams_cb, &data);
     return data.status;
 }
 
-static srtp_err_status_t srtp_valid_policy(const srtp_policy_t * policy) {
+static srtp_err_status_t srtp_valid_policy(const srtp_policy_t *policy)
+{
     if (policy == NULL) {
         return srtp_err_status_bad_param;
     }
 
-    if (policy -> key == NULL) {
-        if (policy -> num_master_keys <= 0) {
+    if (policy->key == NULL) {
+        if (policy->num_master_keys <= 0) {
             return srtp_err_status_bad_param;
         }
 
-        if (policy -> num_master_keys > SRTP_MAX_NUM_MASTER_KEYS) {
+        if (policy->num_master_keys > SRTP_MAX_NUM_MASTER_KEYS) {
             return srtp_err_status_bad_param;
         }
 
-        if (policy -> use_mki) {
-            if (policy -> mki_size == 0 || policy -> mki_size > SRTP_MAX_MKI_LEN) {
+        if (policy->use_mki) {
+            if (policy->mki_size == 0 || policy->mki_size > SRTP_MAX_MKI_LEN) {
                 return srtp_err_status_bad_param;
             }
-        } else if (policy -> mki_size != 0) {
+        } else if (policy->mki_size != 0) {
             return srtp_err_status_bad_param;
         }
 
-        for (size_t i = 0; i < policy -> num_master_keys; i++) {
-            if (policy -> keys[i] -> key == NULL) {
+        for (size_t i = 0; i < policy->num_master_keys; i++) {
+            if (policy->keys[i]->key == NULL) {
                 return srtp_err_status_bad_param;
             }
-            if (policy -> use_mki && policy -> keys[i] -> mki_id == NULL) {
+            if (policy->use_mki && policy->keys[i]->mki_id == NULL) {
                 return srtp_err_status_bad_param;
             }
         }
     } else {
-        if (policy -> use_mki || policy -> mki_size != 0) {
+        if (policy->use_mki || policy->mki_size != 0) {
             return srtp_err_status_bad_param;
         }
     }
@@ -410,12 +408,13 @@ static srtp_err_status_t srtp_valid_policy(const srtp_policy_t * policy) {
     return srtp_err_status_ok;
 }
 
-static srtp_err_status_t srtp_stream_alloc(srtp_stream_ctx_t ** str_ptr,
-    const srtp_policy_t * p) {
-    srtp_stream_ctx_t * str;
+static srtp_err_status_t srtp_stream_alloc(srtp_stream_ctx_t **str_ptr,
+                                           const srtp_policy_t *p)
+{
+    srtp_stream_ctx_t *str;
     srtp_err_status_t stat;
     size_t i = 0;
-    srtp_session_keys_t * session_keys = NULL;
+    srtp_session_keys_t *session_keys = NULL;
 
     stat = srtp_valid_policy(p);
     if (stat != srtp_err_status_ok) {
@@ -431,38 +430,38 @@ static srtp_err_status_t srtp_stream_alloc(srtp_stream_ctx_t ** str_ptr,
      */
 
     /* allocate srtp stream and set str_ptr */
-    str = (srtp_stream_ctx_t * ) srtp_crypto_alloc(sizeof(srtp_stream_ctx_t));
+    str = (srtp_stream_ctx_t *)srtp_crypto_alloc(sizeof(srtp_stream_ctx_t));
     if (str == NULL) {
         return srtp_err_status_alloc_fail;
     }
 
-    * str_ptr = str;
+    *str_ptr = str;
 
     /*
      *To keep backwards API compatible if someone is using multiple master
      * keys then key should be set to NULL
      */
-    if (p -> key != NULL) {
-        str -> num_master_keys = 1;
+    if (p->key != NULL) {
+        str->num_master_keys = 1;
     } else {
-        str -> num_master_keys = p -> num_master_keys;
+        str->num_master_keys = p->num_master_keys;
     }
 
-    str -> session_keys = (srtp_session_keys_t * ) srtp_crypto_alloc(
-        sizeof(srtp_session_keys_t) * str -> num_master_keys);
+    str->session_keys = (srtp_session_keys_t *)srtp_crypto_alloc(
+        sizeof(srtp_session_keys_t) * str->num_master_keys);
 
-    if (str -> session_keys == NULL) {
+    if (str->session_keys == NULL) {
         srtp_stream_dealloc(str, NULL);
         return srtp_err_status_alloc_fail;
     }
 
-    for (i = 0; i < str -> num_master_keys; i++) {
-        session_keys = & str -> session_keys[i];
+    for (i = 0; i < str->num_master_keys; i++) {
+        session_keys = &str->session_keys[i];
 
         /* allocate cipher */
         stat = srtp_crypto_kernel_alloc_cipher(
-            p -> rtp.cipher_type, & session_keys -> rtp_cipher,
-            p -> rtp.cipher_key_len, p -> rtp.auth_tag_len);
+            p->rtp.cipher_type, &session_keys->rtp_cipher,
+            p->rtp.cipher_key_len, p->rtp.auth_tag_len);
         if (stat) {
             srtp_stream_dealloc(str, NULL);
             return stat;
@@ -470,8 +469,8 @@ static srtp_err_status_t srtp_stream_alloc(srtp_stream_ctx_t ** str_ptr,
 
         /* allocate auth function */
         stat = srtp_crypto_kernel_alloc_auth(
-            p -> rtp.auth_type, & session_keys -> rtp_auth, p -> rtp.auth_key_len,
-            p -> rtp.auth_tag_len);
+            p->rtp.auth_type, &session_keys->rtp_auth, p->rtp.auth_key_len,
+            p->rtp.auth_tag_len);
         if (stat) {
             srtp_stream_dealloc(str, NULL);
             return stat;
@@ -482,8 +481,8 @@ static srtp_err_status_t srtp_stream_alloc(srtp_stream_ctx_t ** str_ptr,
          * the cipher
          */
         stat = srtp_crypto_kernel_alloc_cipher(
-            p -> rtcp.cipher_type, & session_keys -> rtcp_cipher,
-            p -> rtcp.cipher_key_len, p -> rtcp.auth_tag_len);
+            p->rtcp.cipher_type, &session_keys->rtcp_cipher,
+            p->rtcp.cipher_key_len, p->rtcp.auth_tag_len);
         if (stat) {
             srtp_stream_dealloc(str, NULL);
             return stat;
@@ -491,43 +490,43 @@ static srtp_err_status_t srtp_stream_alloc(srtp_stream_ctx_t ** str_ptr,
 
         /* allocate auth function */
         stat = srtp_crypto_kernel_alloc_auth(
-            p -> rtcp.auth_type, & session_keys -> rtcp_auth, p -> rtcp.auth_key_len,
-            p -> rtcp.auth_tag_len);
+            p->rtcp.auth_type, &session_keys->rtcp_auth, p->rtcp.auth_key_len,
+            p->rtcp.auth_tag_len);
         if (stat) {
             srtp_stream_dealloc(str, NULL);
             return stat;
         }
 
-        session_keys -> mki_id = NULL;
+        session_keys->mki_id = NULL;
 
         /* allocate key limit structure */
-        session_keys -> limit = (srtp_key_limit_ctx_t * ) srtp_crypto_alloc(
+        session_keys->limit = (srtp_key_limit_ctx_t *)srtp_crypto_alloc(
             sizeof(srtp_key_limit_ctx_t));
-        if (session_keys -> limit == NULL) {
+        if (session_keys->limit == NULL) {
             srtp_stream_dealloc(str, NULL);
             return srtp_err_status_alloc_fail;
         }
     }
 
-    if (p -> enc_xtn_hdr && p -> enc_xtn_hdr_count > 0) {
+    if (p->enc_xtn_hdr && p->enc_xtn_hdr_count > 0) {
         srtp_cipher_type_id_t enc_xtn_hdr_cipher_type;
         size_t enc_xtn_hdr_cipher_key_len;
 
-        str -> enc_xtn_hdr = (uint8_t * ) srtp_crypto_alloc(
-            p -> enc_xtn_hdr_count * sizeof(p -> enc_xtn_hdr[0]));
-        if (!str -> enc_xtn_hdr) {
+        str->enc_xtn_hdr = (uint8_t *)srtp_crypto_alloc(
+            p->enc_xtn_hdr_count * sizeof(p->enc_xtn_hdr[0]));
+        if (!str->enc_xtn_hdr) {
             srtp_stream_dealloc(str, NULL);
             return srtp_err_status_alloc_fail;
         }
-        memcpy(str -> enc_xtn_hdr, p -> enc_xtn_hdr,
-            p -> enc_xtn_hdr_count * sizeof(p -> enc_xtn_hdr[0]));
-        str -> enc_xtn_hdr_count = p -> enc_xtn_hdr_count;
+        memcpy(str->enc_xtn_hdr, p->enc_xtn_hdr,
+               p->enc_xtn_hdr_count * sizeof(p->enc_xtn_hdr[0]));
+        str->enc_xtn_hdr_count = p->enc_xtn_hdr_count;
 
         /*
          * For GCM ciphers, the corresponding ICM cipher is used for header
          * extensions encryption.
          */
-        switch (p -> rtp.cipher_type) {
+        switch (p->rtp.cipher_type) {
         case SRTP_AES_GCM_128:
             enc_xtn_hdr_cipher_type = SRTP_AES_ICM_128;
             enc_xtn_hdr_cipher_key_len = SRTP_AES_ICM_128_KEY_LEN_WSALT;
@@ -537,17 +536,17 @@ static srtp_err_status_t srtp_stream_alloc(srtp_stream_ctx_t ** str_ptr,
             enc_xtn_hdr_cipher_key_len = SRTP_AES_ICM_256_KEY_LEN_WSALT;
             break;
         default:
-            enc_xtn_hdr_cipher_type = p -> rtp.cipher_type;
-            enc_xtn_hdr_cipher_key_len = p -> rtp.cipher_key_len;
+            enc_xtn_hdr_cipher_type = p->rtp.cipher_type;
+            enc_xtn_hdr_cipher_key_len = p->rtp.cipher_key_len;
             break;
         }
 
-        for (i = 0; i < str -> num_master_keys; i++) {
-            session_keys = & str -> session_keys[i];
+        for (i = 0; i < str->num_master_keys; i++) {
+            session_keys = &str->session_keys[i];
 
             /* allocate cipher for extensions header encryption */
             stat = srtp_crypto_kernel_alloc_cipher(
-                enc_xtn_hdr_cipher_type, & session_keys -> rtp_xtn_hdr_cipher,
+                enc_xtn_hdr_cipher_type, &session_keys->rtp_xtn_hdr_cipher,
                 enc_xtn_hdr_cipher_key_len, 0);
             if (stat) {
                 srtp_stream_dealloc(str, NULL);
@@ -555,13 +554,13 @@ static srtp_err_status_t srtp_stream_alloc(srtp_stream_ctx_t ** str_ptr,
             }
         }
     } else {
-        for (i = 0; i < str -> num_master_keys; i++) {
-            session_keys = & str -> session_keys[i];
-            session_keys -> rtp_xtn_hdr_cipher = NULL;
+        for (i = 0; i < str->num_master_keys; i++) {
+            session_keys = &str->session_keys[i];
+            session_keys->rtp_xtn_hdr_cipher = NULL;
         }
 
-        str -> enc_xtn_hdr = NULL;
-        str -> enc_xtn_hdr_count = 0;
+        str->enc_xtn_hdr = NULL;
+        str->enc_xtn_hdr_count = 0;
     }
 
     return srtp_err_status_ok;
@@ -576,103 +575,104 @@ static srtp_err_status_t srtp_stream_alloc(srtp_stream_ctx_t ** str_ptr,
  */
 
 static srtp_err_status_t srtp_stream_clone(
-    const srtp_stream_ctx_t * stream_template,
-        uint32_t ssrc,
-        srtp_stream_ctx_t ** str_ptr) {
+    const srtp_stream_ctx_t *stream_template,
+    uint32_t ssrc,
+    srtp_stream_ctx_t **str_ptr)
+{
     srtp_err_status_t status;
-    srtp_stream_ctx_t * str;
-    srtp_session_keys_t * session_keys = NULL;
-    const srtp_session_keys_t * template_session_keys = NULL;
+    srtp_stream_ctx_t *str;
+    srtp_session_keys_t *session_keys = NULL;
+    const srtp_session_keys_t *template_session_keys = NULL;
 
     debug_print(mod_srtp, "cloning stream (SSRC: 0x%08x)",
-        (unsigned int) ntohl(ssrc));
+                (unsigned int)ntohl(ssrc));
 
     /* allocate srtp stream and set str_ptr */
-    str = (srtp_stream_ctx_t * ) srtp_crypto_alloc(sizeof(srtp_stream_ctx_t));
+    str = (srtp_stream_ctx_t *)srtp_crypto_alloc(sizeof(srtp_stream_ctx_t));
     if (str == NULL) {
         return srtp_err_status_alloc_fail;
     }
-    * str_ptr = str;
+    *str_ptr = str;
 
-    str -> num_master_keys = stream_template -> num_master_keys;
-    str -> session_keys = (srtp_session_keys_t * ) srtp_crypto_alloc(
-        sizeof(srtp_session_keys_t) * str -> num_master_keys);
+    str->num_master_keys = stream_template->num_master_keys;
+    str->session_keys = (srtp_session_keys_t *)srtp_crypto_alloc(
+        sizeof(srtp_session_keys_t) * str->num_master_keys);
 
-    if (str -> session_keys == NULL) {
-        srtp_stream_dealloc( * str_ptr, stream_template);
-        * str_ptr = NULL;
+    if (str->session_keys == NULL) {
+        srtp_stream_dealloc(*str_ptr, stream_template);
+        *str_ptr = NULL;
         return srtp_err_status_alloc_fail;
     }
 
-    for (size_t i = 0; i < stream_template -> num_master_keys; i++) {
-        session_keys = & str -> session_keys[i];
-        template_session_keys = & stream_template -> session_keys[i];
+    for (size_t i = 0; i < stream_template->num_master_keys; i++) {
+        session_keys = &str->session_keys[i];
+        template_session_keys = &stream_template->session_keys[i];
 
         /* set cipher and auth pointers to those of the template */
-        session_keys -> rtp_cipher = template_session_keys -> rtp_cipher;
-        session_keys -> rtp_auth = template_session_keys -> rtp_auth;
-        session_keys -> rtp_xtn_hdr_cipher =
-            template_session_keys -> rtp_xtn_hdr_cipher;
-        session_keys -> rtcp_cipher = template_session_keys -> rtcp_cipher;
-        session_keys -> rtcp_auth = template_session_keys -> rtcp_auth;
+        session_keys->rtp_cipher = template_session_keys->rtp_cipher;
+        session_keys->rtp_auth = template_session_keys->rtp_auth;
+        session_keys->rtp_xtn_hdr_cipher =
+            template_session_keys->rtp_xtn_hdr_cipher;
+        session_keys->rtcp_cipher = template_session_keys->rtcp_cipher;
+        session_keys->rtcp_auth = template_session_keys->rtcp_auth;
 
-        if (stream_template -> mki_size == 0) {
-            session_keys -> mki_id = NULL;
+        if (stream_template->mki_size == 0) {
+            session_keys->mki_id = NULL;
         } else {
-            session_keys -> mki_id = srtp_crypto_alloc(stream_template -> mki_size);
+            session_keys->mki_id = srtp_crypto_alloc(stream_template->mki_size);
 
-            if (session_keys -> mki_id == NULL) {
-                srtp_stream_dealloc( * str_ptr, stream_template);
-                * str_ptr = NULL;
+            if (session_keys->mki_id == NULL) {
+                srtp_stream_dealloc(*str_ptr, stream_template);
+                *str_ptr = NULL;
                 return srtp_err_status_init_fail;
             }
-            memcpy(session_keys -> mki_id, template_session_keys -> mki_id,
-                stream_template -> mki_size);
+            memcpy(session_keys->mki_id, template_session_keys->mki_id,
+                   stream_template->mki_size);
         }
         /* Copy the salt values */
-        memcpy(session_keys -> salt, template_session_keys -> salt,
-            SRTP_AEAD_SALT_LEN);
-        memcpy(session_keys -> c_salt, template_session_keys -> c_salt,
-            SRTP_AEAD_SALT_LEN);
+        memcpy(session_keys->salt, template_session_keys->salt,
+               SRTP_AEAD_SALT_LEN);
+        memcpy(session_keys->c_salt, template_session_keys->c_salt,
+               SRTP_AEAD_SALT_LEN);
 
         /* set key limit to point to that of the template */
-        status = srtp_key_limit_clone(template_session_keys -> limit, &
-            session_keys -> limit);
+        status = srtp_key_limit_clone(template_session_keys->limit,
+                                      &session_keys->limit);
         if (status) {
-            srtp_stream_dealloc( * str_ptr, stream_template);
-            * str_ptr = NULL;
+            srtp_stream_dealloc(*str_ptr, stream_template);
+            *str_ptr = NULL;
             return status;
         }
     }
 
-    str -> use_mki = stream_template -> use_mki;
-    str -> mki_size = stream_template -> mki_size;
+    str->use_mki = stream_template->use_mki;
+    str->mki_size = stream_template->mki_size;
 
     /* initialize replay databases */
-    status = srtp_rdbx_init( &
-        str -> rtp_rdbx, srtp_rdbx_get_window_size( & stream_template -> rtp_rdbx));
+    status = srtp_rdbx_init(
+        &str->rtp_rdbx, srtp_rdbx_get_window_size(&stream_template->rtp_rdbx));
     if (status) {
-        srtp_stream_dealloc( * str_ptr, stream_template);
-        * str_ptr = NULL;
+        srtp_stream_dealloc(*str_ptr, stream_template);
+        *str_ptr = NULL;
         return status;
     }
-    srtp_rdb_init( & str -> rtcp_rdb);
-    str -> allow_repeat_tx = stream_template -> allow_repeat_tx;
+    srtp_rdb_init(&str->rtcp_rdb);
+    str->allow_repeat_tx = stream_template->allow_repeat_tx;
 
     /* set ssrc to that provided */
-    str -> ssrc = ssrc;
+    str->ssrc = ssrc;
 
     /* reset pending ROC */
-    str -> pending_roc = 0;
+    str->pending_roc = 0;
 
     /* set direction and security services */
-    str -> direction = stream_template -> direction;
-    str -> rtp_services = stream_template -> rtp_services;
-    str -> rtcp_services = stream_template -> rtcp_services;
+    str->direction = stream_template->direction;
+    str->rtp_services = stream_template->rtp_services;
+    str->rtcp_services = stream_template->rtcp_services;
 
     /* copy information about extensions header encryption */
-    str -> enc_xtn_hdr = stream_template -> enc_xtn_hdr;
-    str -> enc_xtn_hdr_count = stream_template -> enc_xtn_hdr_count;
+    str->enc_xtn_hdr = stream_template->enc_xtn_hdr;
+    str->enc_xtn_hdr_count = stream_template->enc_xtn_hdr_count;
 
     return srtp_err_status_ok;
 }
@@ -695,15 +695,14 @@ static srtp_err_status_t srtp_stream_clone(
 
 typedef enum {
     label_rtp_encryption = 0x00,
-        label_rtp_msg_auth = 0x01,
-        label_rtp_salt = 0x02,
-        label_rtcp_encryption = 0x03,
-        label_rtcp_msg_auth = 0x04,
-        label_rtcp_salt = 0x05,
-        label_rtp_header_encryption = 0x06,
-        label_rtp_header_salt = 0x07
-}
-srtp_prf_label;
+    label_rtp_msg_auth = 0x01,
+    label_rtp_salt = 0x02,
+    label_rtcp_encryption = 0x03,
+    label_rtcp_msg_auth = 0x04,
+    label_rtcp_salt = 0x05,
+    label_rtp_header_encryption = 0x06,
+    label_rtp_header_salt = 0x07
+} srtp_prf_label;
 
 #define MAX_SRTP_KEY_LEN 256
 
@@ -718,14 +717,14 @@ srtp_prf_label;
 typedef struct {
     uint8_t master_key[MAX_SRTP_AESKEY_LEN];
     uint8_t master_salt[MAX_SRTP_SALT_LEN];
-    const EVP_CIPHER * evp;
-}
-srtp_kdf_t;
+    const EVP_CIPHER *evp;
+} srtp_kdf_t;
 
-static srtp_err_status_t srtp_kdf_init(srtp_kdf_t * kdf,
-    const uint8_t * key,
-        size_t key_len,
-        size_t salt_len) {
+static srtp_err_status_t srtp_kdf_init(srtp_kdf_t *kdf,
+                                       const uint8_t *key,
+                                       size_t key_len,
+                                       size_t salt_len)
+{
     memset(kdf, 0x0, sizeof(srtp_kdf_t));
 
     /* The NULL cipher has zero key length */
@@ -738,31 +737,32 @@ static srtp_err_status_t srtp_kdf_init(srtp_kdf_t * kdf,
     }
     switch (key_len) {
     case SRTP_AES_256_KEYSIZE:
-        kdf -> evp = EVP_aes_256_ctr();
+        kdf->evp = EVP_aes_256_ctr();
         break;
     case SRTP_AES_192_KEYSIZE:
-        kdf -> evp = EVP_aes_192_ctr();
+        kdf->evp = EVP_aes_192_ctr();
         break;
     case SRTP_AES_128_KEYSIZE:
-        kdf -> evp = EVP_aes_128_ctr();
+        kdf->evp = EVP_aes_128_ctr();
         break;
     default:
         return srtp_err_status_bad_param;
         break;
     }
-    memcpy(kdf -> master_key, key, key_len);
-    memcpy(kdf -> master_salt, key + key_len, salt_len);
+    memcpy(kdf->master_key, key, key_len);
+    memcpy(kdf->master_salt, key + key_len, salt_len);
     return srtp_err_status_ok;
 }
 
-static srtp_err_status_t srtp_kdf_generate(srtp_kdf_t * kdf,
-    srtp_prf_label label,
-    uint8_t * key,
-    size_t length) {
+static srtp_err_status_t srtp_kdf_generate(srtp_kdf_t *kdf,
+                                           srtp_prf_label label,
+                                           uint8_t *key,
+                                           size_t length)
+{
     int ret;
 
     /* The NULL cipher will not have an EVP */
-    if (!kdf -> evp) {
+    if (!kdf->evp) {
         return srtp_err_status_ok;
     }
     octet_string_set_to_zero(key, length);
@@ -772,8 +772,8 @@ static srtp_err_status_t srtp_kdf_generate(srtp_kdf_t * kdf,
      * This is useful if OpenSSL is in FIPS mode and FIP
      * compliance is required for SRTP.
      */
-    ret = kdf_srtp(kdf -> evp, (char * ) & kdf -> master_key, & kdf -> master_salt, NULL,
-        NULL, label, key);
+    ret = kdf_srtp(kdf->evp, (char *)&kdf->master_key, &kdf->master_salt, NULL,
+                   NULL, label, key);
     if (ret == -1) {
         return (srtp_err_status_algo_fail);
     }
@@ -781,10 +781,11 @@ static srtp_err_status_t srtp_kdf_generate(srtp_kdf_t * kdf,
     return srtp_err_status_ok;
 }
 
-static srtp_err_status_t srtp_kdf_clear(srtp_kdf_t * kdf) {
-    octet_string_set_to_zero(kdf -> master_key, MAX_SRTP_AESKEY_LEN);
-    octet_string_set_to_zero(kdf -> master_salt, MAX_SRTP_SALT_LEN);
-    kdf -> evp = NULL;
+static srtp_err_status_t srtp_kdf_clear(srtp_kdf_t *kdf)
+{
+    octet_string_set_to_zero(kdf->master_key, MAX_SRTP_AESKEY_LEN);
+    octet_string_set_to_zero(kdf->master_salt, MAX_SRTP_SALT_LEN);
+    kdf->evp = NULL;
 
     return srtp_err_status_ok;
 }
@@ -801,57 +802,58 @@ typedef struct {
     uint8_t master_key[MAX_SRTP_AESKEY_LEN];
     int master_key_len;
     uint8_t master_salt[MAX_SRTP_SALT_LEN];
-}
-srtp_kdf_t;
+} srtp_kdf_t;
 
-static srtp_err_status_t srtp_kdf_init(srtp_kdf_t * kdf,
-    const uint8_t * key,
-        size_t key_len) {
+static srtp_err_status_t srtp_kdf_init(srtp_kdf_t *kdf,
+                                       const uint8_t *key,
+                                       size_t key_len)
+{
     size_t salt_len;
 
     memset(kdf, 0x0, sizeof(srtp_kdf_t));
 
     switch (key_len) {
     case SRTP_AES_ICM_256_KEY_LEN_WSALT:
-        kdf -> master_key_len = AES_256_KEY_SIZE;
+        kdf->master_key_len = AES_256_KEY_SIZE;
         break;
     case SRTP_AES_ICM_192_KEY_LEN_WSALT:
-        kdf -> master_key_len = AES_192_KEY_SIZE;
+        kdf->master_key_len = AES_192_KEY_SIZE;
         break;
     case SRTP_AES_ICM_128_KEY_LEN_WSALT:
-        kdf -> master_key_len = AES_128_KEY_SIZE;
+        kdf->master_key_len = AES_128_KEY_SIZE;
         break;
     default:
         return srtp_err_status_bad_param;
         break;
     }
 
-    memcpy(kdf -> master_key, key, kdf -> master_key_len);
-    salt_len = key_len - kdf -> master_key_len;
-    memcpy(kdf -> master_salt, key + kdf -> master_key_len, salt_len);
-    memset(kdf -> master_salt + salt_len, 0, MAX_SRTP_SALT_LEN - salt_len);
+    memcpy(kdf->master_key, key, kdf->master_key_len);
+    salt_len = key_len - kdf->master_key_len;
+    memcpy(kdf->master_salt, key + kdf->master_key_len, salt_len);
+    memset(kdf->master_salt + salt_len, 0, MAX_SRTP_SALT_LEN - salt_len);
 
     return srtp_err_status_ok;
 }
 
-static srtp_err_status_t srtp_kdf_generate(srtp_kdf_t * kdf,
-    srtp_prf_label label,
-    uint8_t * key,
-    size_t length) {
+static srtp_err_status_t srtp_kdf_generate(srtp_kdf_t *kdf,
+                                           srtp_prf_label label,
+                                           uint8_t *key,
+                                           size_t length)
+{
     int err;
 
     if (length == 0) {
         return srtp_err_status_ok;
     }
-    if (kdf -> master_key_len == 0) {
+    if (kdf->master_key_len == 0) {
         return srtp_err_status_ok;
     }
     octet_string_set_to_zero(key, length);
 
     PRIVATE_KEY_UNLOCK();
-    err = wc_SRTP_KDF_label(kdf -> master_key, kdf -> master_key_len,
-        kdf -> master_salt, MAX_SRTP_SALT_LEN, -1, NULL,
-        label, key, length);
+    err = wc_SRTP_KDF_label(kdf->master_key, kdf->master_key_len,
+                            kdf->master_salt, MAX_SRTP_SALT_LEN, -1, NULL,
+                            label, key, length);
     PRIVATE_KEY_LOCK();
     if (err < 0) {
         debug_print(mod_srtp, "wolfSSL SRTP KDF error: %d", err);
@@ -861,28 +863,29 @@ static srtp_err_status_t srtp_kdf_generate(srtp_kdf_t * kdf,
     return srtp_err_status_ok;
 }
 
-static srtp_err_status_t srtp_kdf_clear(srtp_kdf_t * kdf) {
-    octet_string_set_to_zero(kdf -> master_key, MAX_SRTP_AESKEY_LEN);
-    kdf -> master_key_len = 0;
-    octet_string_set_to_zero(kdf -> master_salt, MAX_SRTP_SALT_LEN);
+static srtp_err_status_t srtp_kdf_clear(srtp_kdf_t *kdf)
+{
+    octet_string_set_to_zero(kdf->master_key, MAX_SRTP_AESKEY_LEN);
+    kdf->master_key_len = 0;
+    octet_string_set_to_zero(kdf->master_salt, MAX_SRTP_SALT_LEN);
 
     return srtp_err_status_ok;
 }
 
-#else /* if OPENSSL_KDF || WOLFSSL_KDF */
+#else  /* if OPENSSL_KDF || WOLFSSL_KDF */
 
 /*
  * srtp_kdf_t represents a key derivation function.  The SRTP
  * default KDF is the only one implemented at present.
  */
 typedef struct {
-    srtp_cipher_t * cipher; /* cipher used for key derivation  */
-}
-srtp_kdf_t;
+    srtp_cipher_t *cipher; /* cipher used for key derivation  */
+} srtp_kdf_t;
 
-static srtp_err_status_t srtp_kdf_init(srtp_kdf_t * kdf,
-    const uint8_t * key,
-        size_t key_len) {
+static srtp_err_status_t srtp_kdf_init(srtp_kdf_t *kdf,
+                                       const uint8_t *key,
+                                       size_t key_len)
+{
     srtp_cipher_type_id_t cipher_id;
     srtp_err_status_t stat;
 
@@ -901,39 +904,40 @@ static srtp_err_status_t srtp_kdf_init(srtp_kdf_t * kdf,
         break;
     }
 
-    stat = srtp_crypto_kernel_alloc_cipher(cipher_id, & kdf -> cipher, key_len, 0);
+    stat = srtp_crypto_kernel_alloc_cipher(cipher_id, &kdf->cipher, key_len, 0);
     if (stat) {
         return stat;
     }
 
-    stat = srtp_cipher_init(kdf -> cipher, key);
+    stat = srtp_cipher_init(kdf->cipher, key);
     if (stat) {
-        srtp_cipher_dealloc(kdf -> cipher);
+        srtp_cipher_dealloc(kdf->cipher);
         return stat;
     }
     return srtp_err_status_ok;
 }
 
-static srtp_err_status_t srtp_kdf_generate(srtp_kdf_t * kdf,
-    srtp_prf_label label,
-    uint8_t * key,
-    size_t length) {
+static srtp_err_status_t srtp_kdf_generate(srtp_kdf_t *kdf,
+                                           srtp_prf_label label,
+                                           uint8_t *key,
+                                           size_t length)
+{
     srtp_err_status_t status;
     v128_t nonce;
 
     /* set eigth octet of nonce to <label>, set the rest of it to zero */
-    v128_set_to_zero( & nonce);
+    v128_set_to_zero(&nonce);
     nonce.v8[7] = label;
 
-    status = srtp_cipher_set_iv(kdf -> cipher, (uint8_t * ) & nonce,
-        srtp_direction_encrypt);
+    status = srtp_cipher_set_iv(kdf->cipher, (uint8_t *)&nonce,
+                                srtp_direction_encrypt);
     if (status) {
         return status;
     }
 
     /* generate keystream output */
     octet_string_set_to_zero(key, length);
-    status = srtp_cipher_encrypt(kdf -> cipher, key, length, key, & length);
+    status = srtp_cipher_encrypt(kdf->cipher, key, length, key, &length);
     if (status) {
         return status;
     }
@@ -941,13 +945,14 @@ static srtp_err_status_t srtp_kdf_generate(srtp_kdf_t * kdf,
     return srtp_err_status_ok;
 }
 
-static srtp_err_status_t srtp_kdf_clear(srtp_kdf_t * kdf) {
+static srtp_err_status_t srtp_kdf_clear(srtp_kdf_t *kdf)
+{
     srtp_err_status_t status;
-    status = srtp_cipher_dealloc(kdf -> cipher);
+    status = srtp_cipher_dealloc(kdf->cipher);
     if (status) {
         return status;
     }
-    kdf -> cipher = NULL;
+    kdf->cipher = NULL;
     return srtp_err_status_ok;
 }
 #endif /* else OPENSSL_KDF || WOLFSSL_KDF */
@@ -959,9 +964,10 @@ static srtp_err_status_t srtp_kdf_clear(srtp_kdf_t * kdf) {
 /* Get the base key length corresponding to a given combined key+salt
  * length for the given cipher.
  * TODO: key and salt lengths should be separate fields in the policy.  */
-static inline size_t base_key_length(const srtp_cipher_type_t * cipher,
-    size_t key_length) {
-    switch (cipher -> id) {
+static inline size_t base_key_length(const srtp_cipher_type_t *cipher,
+                                     size_t key_length)
+{
+    switch (cipher->id) {
     case SRTP_NULL_CIPHER:
         return 0;
     case SRTP_AES_ICM_128:
@@ -980,8 +986,9 @@ static inline size_t base_key_length(const srtp_cipher_type_t * cipher,
 }
 
 /* Get the key length that the application should supply for the given cipher */
-static inline size_t full_key_length(const srtp_cipher_type_t * cipher) {
-    switch (cipher -> id) {
+static inline size_t full_key_length(const srtp_cipher_type_t *cipher)
+{
+    switch (cipher->id) {
     case SRTP_NULL_CIPHER:
     case SRTP_AES_ICM_128:
         return SRTP_AES_ICM_128_KEY_LEN_WSALT;
@@ -998,33 +1005,36 @@ static inline size_t full_key_length(const srtp_cipher_type_t * cipher) {
     }
 }
 
-srtp_err_status_t srtp_get_session_keys(srtp_stream_ctx_t * stream,
-    size_t mki_index,
-    srtp_session_keys_t ** session_keys) {
-    if (stream -> use_mki) {
-        if (mki_index >= stream -> num_master_keys) {
+srtp_err_status_t srtp_get_session_keys(srtp_stream_ctx_t *stream,
+                                        size_t mki_index,
+                                        srtp_session_keys_t **session_keys)
+{
+    if (stream->use_mki) {
+        if (mki_index >= stream->num_master_keys) {
             return srtp_err_status_bad_mki;
         }
-        * session_keys = & stream -> session_keys[mki_index];
+        *session_keys = &stream->session_keys[mki_index];
         return srtp_err_status_ok;
     }
 
-    * session_keys = & stream -> session_keys[0];
+    *session_keys = &stream->session_keys[0];
     return srtp_err_status_ok;
 }
 
-void srtp_inject_mki(uint8_t * mki_tag_location,
-    const srtp_session_keys_t * session_keys,
-        size_t mki_size) {
+void srtp_inject_mki(uint8_t *mki_tag_location,
+                     const srtp_session_keys_t *session_keys,
+                     size_t mki_size)
+{
     if (mki_size > 0) {
         // Write MKI into memory
-        memcpy(mki_tag_location, session_keys -> mki_id, mki_size);
+        memcpy(mki_tag_location, session_keys->mki_id, mki_size);
     }
 }
 
-srtp_err_status_t srtp_stream_init_keys(srtp_session_keys_t * session_keys,
-    const srtp_master_key_t * master_key,
-        size_t mki_size) {
+srtp_err_status_t srtp_stream_init_keys(srtp_session_keys_t *session_keys,
+                                        const srtp_master_key_t *master_key,
+                                        size_t mki_size)
+{
     srtp_err_status_t stat;
     srtp_kdf_t kdf;
     uint8_t tmp_key[MAX_SRTP_KEY_LEN];
@@ -1039,32 +1049,32 @@ srtp_err_status_t srtp_stream_init_keys(srtp_session_keys_t * session_keys,
      */
 
     /* initialize key limit to maximum value */
-    srtp_key_limit_set(session_keys -> limit, 0xffffffffffff LL);
+    srtp_key_limit_set(session_keys->limit, 0xffffffffffffLL);
 
     if (mki_size != 0) {
-        if (master_key -> mki_id == NULL) {
+        if (master_key->mki_id == NULL) {
             return srtp_err_status_bad_param;
         }
-        session_keys -> mki_id = srtp_crypto_alloc(mki_size);
+        session_keys->mki_id = srtp_crypto_alloc(mki_size);
 
-        if (session_keys -> mki_id == NULL) {
+        if (session_keys->mki_id == NULL) {
             return srtp_err_status_init_fail;
         }
-        memcpy(session_keys -> mki_id, master_key -> mki_id, mki_size);
+        memcpy(session_keys->mki_id, master_key->mki_id, mki_size);
     } else {
-        session_keys -> mki_id = NULL;
+        session_keys->mki_id = NULL;
     }
 
-    input_keylen = full_key_length(session_keys -> rtp_cipher -> type);
-    input_keylen_rtcp = full_key_length(session_keys -> rtcp_cipher -> type);
+    input_keylen = full_key_length(session_keys->rtp_cipher->type);
+    input_keylen_rtcp = full_key_length(session_keys->rtcp_cipher->type);
     if (input_keylen_rtcp > input_keylen) {
         input_keylen = input_keylen_rtcp;
     }
 
-    rtp_keylen = srtp_cipher_get_key_length(session_keys -> rtp_cipher);
-    rtcp_keylen = srtp_cipher_get_key_length(session_keys -> rtcp_cipher);
+    rtp_keylen = srtp_cipher_get_key_length(session_keys->rtp_cipher);
+    rtcp_keylen = srtp_cipher_get_key_length(session_keys->rtcp_cipher);
     rtp_base_key_len =
-        base_key_length(session_keys -> rtp_cipher -> type, rtp_keylen);
+        base_key_length(session_keys->rtp_cipher->type, rtp_keylen);
     rtp_salt_len = rtp_keylen - rtp_base_key_len;
 
     /*
@@ -1102,14 +1112,14 @@ srtp_err_status_t srtp_stream_init_keys(srtp_session_keys_t * session_keys,
      * the legacy CTR mode KDF, which uses a 112 bit master SALT.
      */
     memset(tmp_key, 0x0, MAX_SRTP_KEY_LEN);
-    memcpy(tmp_key, master_key -> key, input_keylen);
+    memcpy(tmp_key, master_key->key, input_keylen);
 
-    /* initialize KDF state     */
-    #if defined(OPENSSL) && defined(OPENSSL_KDF)
-    stat = srtp_kdf_init( & kdf, tmp_key, rtp_base_key_len, rtp_salt_len);
-    #else
-    stat = srtp_kdf_init( & kdf, tmp_key, kdf_keylen);
-    #endif
+/* initialize KDF state     */
+#if defined(OPENSSL) && defined(OPENSSL_KDF)
+    stat = srtp_kdf_init(&kdf, tmp_key, rtp_base_key_len, rtp_salt_len);
+#else
+    stat = srtp_kdf_init(&kdf, tmp_key, kdf_keylen);
+#endif
     if (stat) {
         /* zeroize temp buffer */
         octet_string_set_to_zero(tmp_key, MAX_SRTP_KEY_LEN);
@@ -1117,15 +1127,15 @@ srtp_err_status_t srtp_stream_init_keys(srtp_session_keys_t * session_keys,
     }
 
     /* generate encryption key  */
-    stat = srtp_kdf_generate( & kdf, label_rtp_encryption, tmp_key,
-        rtp_base_key_len);
+    stat = srtp_kdf_generate(&kdf, label_rtp_encryption, tmp_key,
+                             rtp_base_key_len);
     if (stat) {
         /* zeroize temp buffer */
         octet_string_set_to_zero(tmp_key, MAX_SRTP_KEY_LEN);
         return srtp_err_status_init_fail;
     }
     debug_print(mod_srtp, "cipher key: %s",
-        srtp_octet_string_hex_string(tmp_key, rtp_base_key_len));
+                srtp_octet_string_hex_string(tmp_key, rtp_base_key_len));
 
     /*
      * if the cipher in the srtp context uses a salt, then we need
@@ -1135,40 +1145,40 @@ srtp_err_status_t srtp_stream_init_keys(srtp_session_keys_t * session_keys,
         debug_print0(mod_srtp, "found rtp_salt_len > 0, generating salt");
 
         /* generate encryption salt, put after encryption key */
-        stat = srtp_kdf_generate( & kdf, label_rtp_salt,
-            tmp_key + rtp_base_key_len, rtp_salt_len);
+        stat = srtp_kdf_generate(&kdf, label_rtp_salt,
+                                 tmp_key + rtp_base_key_len, rtp_salt_len);
         if (stat) {
             /* zeroize temp buffer */
             octet_string_set_to_zero(tmp_key, MAX_SRTP_KEY_LEN);
             return srtp_err_status_init_fail;
         }
-        memcpy(session_keys -> salt, tmp_key + rtp_base_key_len,
-            SRTP_AEAD_SALT_LEN);
+        memcpy(session_keys->salt, tmp_key + rtp_base_key_len,
+               SRTP_AEAD_SALT_LEN);
     }
     if (rtp_salt_len > 0) {
         debug_print(mod_srtp, "cipher salt: %s",
-            srtp_octet_string_hex_string(tmp_key + rtp_base_key_len,
-                rtp_salt_len));
+                    srtp_octet_string_hex_string(tmp_key + rtp_base_key_len,
+                                                 rtp_salt_len));
     }
 
     /* initialize cipher */
-    stat = srtp_cipher_init(session_keys -> rtp_cipher, tmp_key);
+    stat = srtp_cipher_init(session_keys->rtp_cipher, tmp_key);
     if (stat) {
         /* zeroize temp buffer */
         octet_string_set_to_zero(tmp_key, MAX_SRTP_KEY_LEN);
         return srtp_err_status_init_fail;
     }
 
-    if (session_keys -> rtp_xtn_hdr_cipher) {
+    if (session_keys->rtp_xtn_hdr_cipher) {
         /* generate extensions header encryption key  */
         size_t rtp_xtn_hdr_keylen;
         size_t rtp_xtn_hdr_base_key_len;
         size_t rtp_xtn_hdr_salt_len;
         srtp_kdf_t tmp_kdf;
-        srtp_kdf_t * xtn_hdr_kdf;
+        srtp_kdf_t *xtn_hdr_kdf;
 
-        if (session_keys -> rtp_xtn_hdr_cipher -> type !=
-            session_keys -> rtp_cipher -> type) {
+        if (session_keys->rtp_xtn_hdr_cipher->type !=
+            session_keys->rtp_cipher->type) {
             /*
              * With GCM ciphers, the header extensions are still encrypted using
              * the corresponding ICM cipher.
@@ -1176,13 +1186,13 @@ srtp_err_status_t srtp_stream_init_keys(srtp_session_keys_t * session_keys,
              */
             uint8_t tmp_xtn_hdr_key[MAX_SRTP_KEY_LEN];
             rtp_xtn_hdr_keylen =
-                srtp_cipher_get_key_length(session_keys -> rtp_xtn_hdr_cipher);
+                srtp_cipher_get_key_length(session_keys->rtp_xtn_hdr_cipher);
             rtp_xtn_hdr_base_key_len = base_key_length(
-                session_keys -> rtp_xtn_hdr_cipher -> type, rtp_xtn_hdr_keylen);
+                session_keys->rtp_xtn_hdr_cipher->type, rtp_xtn_hdr_keylen);
             rtp_xtn_hdr_salt_len =
                 rtp_xtn_hdr_keylen - rtp_xtn_hdr_base_key_len;
             if (rtp_xtn_hdr_salt_len > rtp_salt_len) {
-                switch (session_keys -> rtp_cipher -> type -> id) {
+                switch (session_keys->rtp_cipher->type->id) {
                 case SRTP_AES_GCM_128:
                 case SRTP_AES_GCM_256:
                     /*
@@ -1198,18 +1208,18 @@ srtp_err_status_t srtp_stream_init_keys(srtp_session_keys_t * session_keys,
                 }
             }
             memset(tmp_xtn_hdr_key, 0x0, MAX_SRTP_KEY_LEN);
-            memcpy(tmp_xtn_hdr_key, master_key -> key,
-                (rtp_xtn_hdr_base_key_len + rtp_xtn_hdr_salt_len));
-            xtn_hdr_kdf = & tmp_kdf;
+            memcpy(tmp_xtn_hdr_key, master_key->key,
+                   (rtp_xtn_hdr_base_key_len + rtp_xtn_hdr_salt_len));
+            xtn_hdr_kdf = &tmp_kdf;
 
-            /* initialize KDF state */
-            #if defined(OPENSSL) && defined(OPENSSL_KDF)
+/* initialize KDF state */
+#if defined(OPENSSL) && defined(OPENSSL_KDF)
             stat =
                 srtp_kdf_init(xtn_hdr_kdf, tmp_xtn_hdr_key,
-                    rtp_xtn_hdr_base_key_len, rtp_xtn_hdr_salt_len);
-            #else
+                              rtp_xtn_hdr_base_key_len, rtp_xtn_hdr_salt_len);
+#else
             stat = srtp_kdf_init(xtn_hdr_kdf, tmp_xtn_hdr_key, kdf_keylen);
-            #endif
+#endif
             octet_string_set_to_zero(tmp_xtn_hdr_key, MAX_SRTP_KEY_LEN);
             if (stat) {
                 /* zeroize temp buffer */
@@ -1221,11 +1231,11 @@ srtp_err_status_t srtp_stream_init_keys(srtp_session_keys_t * session_keys,
             rtp_xtn_hdr_keylen = rtp_keylen;
             rtp_xtn_hdr_base_key_len = rtp_base_key_len;
             rtp_xtn_hdr_salt_len = rtp_salt_len;
-            xtn_hdr_kdf = & kdf;
+            xtn_hdr_kdf = &kdf;
         }
 
         stat = srtp_kdf_generate(xtn_hdr_kdf, label_rtp_header_encryption,
-            tmp_key, rtp_xtn_hdr_base_key_len);
+                                 tmp_key, rtp_xtn_hdr_base_key_len);
         if (stat) {
             /* zeroize temp buffer */
             octet_string_set_to_zero(tmp_key, MAX_SRTP_KEY_LEN);
@@ -1241,12 +1251,12 @@ srtp_err_status_t srtp_stream_init_keys(srtp_session_keys_t * session_keys,
          */
         if (rtp_xtn_hdr_salt_len > 0) {
             debug_print0(mod_srtp,
-                "found rtp_xtn_hdr_salt_len > 0, generating salt");
+                         "found rtp_xtn_hdr_salt_len > 0, generating salt");
 
             /* generate encryption salt, put after encryption key */
             stat = srtp_kdf_generate(xtn_hdr_kdf, label_rtp_header_salt,
-                tmp_key + rtp_xtn_hdr_base_key_len,
-                rtp_xtn_hdr_salt_len);
+                                     tmp_key + rtp_xtn_hdr_base_key_len,
+                                     rtp_xtn_hdr_salt_len);
             if (stat) {
                 /* zeroize temp buffer */
                 octet_string_set_to_zero(tmp_key, MAX_SRTP_KEY_LEN);
@@ -1257,18 +1267,18 @@ srtp_err_status_t srtp_stream_init_keys(srtp_session_keys_t * session_keys,
             debug_print(
                 mod_srtp, "extensions cipher salt: %s",
                 srtp_octet_string_hex_string(tmp_key + rtp_xtn_hdr_base_key_len,
-                    rtp_xtn_hdr_salt_len));
+                                             rtp_xtn_hdr_salt_len));
         }
 
         /* initialize extensions header cipher */
-        stat = srtp_cipher_init(session_keys -> rtp_xtn_hdr_cipher, tmp_key);
+        stat = srtp_cipher_init(session_keys->rtp_xtn_hdr_cipher, tmp_key);
         if (stat) {
             /* zeroize temp buffer */
             octet_string_set_to_zero(tmp_key, MAX_SRTP_KEY_LEN);
             return srtp_err_status_init_fail;
         }
 
-        if (xtn_hdr_kdf != & kdf) {
+        if (xtn_hdr_kdf != &kdf) {
             /* release memory for custom header extension encryption kdf */
             stat = srtp_kdf_clear(xtn_hdr_kdf);
             if (stat) {
@@ -1280,19 +1290,19 @@ srtp_err_status_t srtp_stream_init_keys(srtp_session_keys_t * session_keys,
     }
 
     /* generate authentication key */
-    stat = srtp_kdf_generate( & kdf, label_rtp_msg_auth, tmp_key,
-        srtp_auth_get_key_length(session_keys -> rtp_auth));
+    stat = srtp_kdf_generate(&kdf, label_rtp_msg_auth, tmp_key,
+                             srtp_auth_get_key_length(session_keys->rtp_auth));
     if (stat) {
         /* zeroize temp buffer */
         octet_string_set_to_zero(tmp_key, MAX_SRTP_KEY_LEN);
         return srtp_err_status_init_fail;
     }
     debug_print(mod_srtp, "auth key:   %s",
-        srtp_octet_string_hex_string(
-            tmp_key, srtp_auth_get_key_length(session_keys -> rtp_auth)));
+                srtp_octet_string_hex_string(
+                    tmp_key, srtp_auth_get_key_length(session_keys->rtp_auth)));
 
     /* initialize auth function */
-    stat = srtp_auth_init(session_keys -> rtp_auth, tmp_key);
+    stat = srtp_auth_init(session_keys->rtp_auth, tmp_key);
     if (stat) {
         /* zeroize temp buffer */
         octet_string_set_to_zero(tmp_key, MAX_SRTP_KEY_LEN);
@@ -1304,13 +1314,13 @@ srtp_err_status_t srtp_stream_init_keys(srtp_session_keys_t * session_keys,
      */
 
     rtcp_base_key_len =
-        base_key_length(session_keys -> rtcp_cipher -> type, rtcp_keylen);
+        base_key_length(session_keys->rtcp_cipher->type, rtcp_keylen);
     rtcp_salt_len = rtcp_keylen - rtcp_base_key_len;
     debug_print(mod_srtp, "rtcp salt len: %zu", rtcp_salt_len);
 
     /* generate encryption key  */
-    stat = srtp_kdf_generate( & kdf, label_rtcp_encryption, tmp_key,
-        rtcp_base_key_len);
+    stat = srtp_kdf_generate(&kdf, label_rtcp_encryption, tmp_key,
+                             rtcp_base_key_len);
     if (stat) {
         /* zeroize temp buffer */
         octet_string_set_to_zero(tmp_key, MAX_SRTP_KEY_LEN);
@@ -1325,26 +1335,26 @@ srtp_err_status_t srtp_stream_init_keys(srtp_session_keys_t * session_keys,
         debug_print0(mod_srtp, "found rtcp_salt_len > 0, generating rtcp salt");
 
         /* generate encryption salt, put after encryption key */
-        stat = srtp_kdf_generate( & kdf, label_rtcp_salt,
-            tmp_key + rtcp_base_key_len, rtcp_salt_len);
+        stat = srtp_kdf_generate(&kdf, label_rtcp_salt,
+                                 tmp_key + rtcp_base_key_len, rtcp_salt_len);
         if (stat) {
             /* zeroize temp buffer */
             octet_string_set_to_zero(tmp_key, MAX_SRTP_KEY_LEN);
             return srtp_err_status_init_fail;
         }
-        memcpy(session_keys -> c_salt, tmp_key + rtcp_base_key_len,
-            SRTP_AEAD_SALT_LEN);
+        memcpy(session_keys->c_salt, tmp_key + rtcp_base_key_len,
+               SRTP_AEAD_SALT_LEN);
     }
     debug_print(mod_srtp, "rtcp cipher key: %s",
-        srtp_octet_string_hex_string(tmp_key, rtcp_base_key_len));
+                srtp_octet_string_hex_string(tmp_key, rtcp_base_key_len));
     if (rtcp_salt_len > 0) {
         debug_print(mod_srtp, "rtcp cipher salt: %s",
-            srtp_octet_string_hex_string(tmp_key + rtcp_base_key_len,
-                rtcp_salt_len));
+                    srtp_octet_string_hex_string(tmp_key + rtcp_base_key_len,
+                                                 rtcp_salt_len));
     }
 
     /* initialize cipher */
-    stat = srtp_cipher_init(session_keys -> rtcp_cipher, tmp_key);
+    stat = srtp_cipher_init(session_keys->rtcp_cipher, tmp_key);
     if (stat) {
         /* zeroize temp buffer */
         octet_string_set_to_zero(tmp_key, MAX_SRTP_KEY_LEN);
@@ -1352,8 +1362,8 @@ srtp_err_status_t srtp_stream_init_keys(srtp_session_keys_t * session_keys,
     }
 
     /* generate authentication key */
-    stat = srtp_kdf_generate( & kdf, label_rtcp_msg_auth, tmp_key,
-        srtp_auth_get_key_length(session_keys -> rtcp_auth));
+    stat = srtp_kdf_generate(&kdf, label_rtcp_msg_auth, tmp_key,
+                             srtp_auth_get_key_length(session_keys->rtcp_auth));
     if (stat) {
         /* zeroize temp buffer */
         octet_string_set_to_zero(tmp_key, MAX_SRTP_KEY_LEN);
@@ -1363,10 +1373,10 @@ srtp_err_status_t srtp_stream_init_keys(srtp_session_keys_t * session_keys,
     debug_print(
         mod_srtp, "rtcp auth key:   %s",
         srtp_octet_string_hex_string(
-            tmp_key, srtp_auth_get_key_length(session_keys -> rtcp_auth)));
+            tmp_key, srtp_auth_get_key_length(session_keys->rtcp_auth)));
 
     /* initialize auth function */
-    stat = srtp_auth_init(session_keys -> rtcp_auth, tmp_key);
+    stat = srtp_auth_init(session_keys->rtcp_auth, tmp_key);
     if (stat) {
         /* zeroize temp buffer */
         octet_string_set_to_zero(tmp_key, MAX_SRTP_KEY_LEN);
@@ -1374,7 +1384,7 @@ srtp_err_status_t srtp_stream_init_keys(srtp_session_keys_t * session_keys,
     }
 
     /* clear memory then return */
-    stat = srtp_kdf_clear( & kdf);
+    stat = srtp_kdf_clear(&kdf);
     octet_string_set_to_zero(tmp_key, MAX_SRTP_KEY_LEN);
     if (stat) {
         return srtp_err_status_init_fail;
@@ -1383,36 +1393,37 @@ srtp_err_status_t srtp_stream_init_keys(srtp_session_keys_t * session_keys,
     return srtp_err_status_ok;
 }
 
-srtp_err_status_t srtp_stream_init_all_master_keys(srtp_stream_ctx_t * srtp,
-    const srtp_policy_t * p) {
+srtp_err_status_t srtp_stream_init_all_master_keys(srtp_stream_ctx_t *srtp,
+                                                   const srtp_policy_t *p)
+{
     srtp_err_status_t status = srtp_err_status_ok;
-    if (p -> key != NULL) {
-        if (p -> use_mki) {
+    if (p->key != NULL) {
+        if (p->use_mki) {
             return srtp_err_status_bad_param;
         }
         srtp_master_key_t single_master_key;
-        srtp -> num_master_keys = 1;
-        srtp -> use_mki = false;
-        srtp -> mki_size = 0;
-        single_master_key.key = p -> key;
+        srtp->num_master_keys = 1;
+        srtp->use_mki = false;
+        srtp->mki_size = 0;
+        single_master_key.key = p->key;
         single_master_key.mki_id = NULL;
-        status = srtp_stream_init_keys( & srtp -> session_keys[0], &
-            single_master_key, 0);
+        status = srtp_stream_init_keys(&srtp->session_keys[0],
+                                       &single_master_key, 0);
     } else {
-        if (p -> num_master_keys > SRTP_MAX_NUM_MASTER_KEYS) {
+        if (p->num_master_keys > SRTP_MAX_NUM_MASTER_KEYS) {
             return srtp_err_status_bad_param;
         }
-        if (p -> use_mki && p -> mki_size == 0) {
+        if (p->use_mki && p->mki_size == 0) {
             return srtp_err_status_bad_param;
         }
 
-        srtp -> num_master_keys = p -> num_master_keys;
-        srtp -> use_mki = p -> use_mki;
-        srtp -> mki_size = p -> mki_size;
+        srtp->num_master_keys = p->num_master_keys;
+        srtp->use_mki = p->use_mki;
+        srtp->mki_size = p->mki_size;
 
-        for (size_t i = 0; i < srtp -> num_master_keys; i++) {
-            status = srtp_stream_init_keys( & srtp -> session_keys[i], p -> keys[i],
-                srtp -> mki_size);
+        for (size_t i = 0; i < srtp->num_master_keys; i++) {
+            status = srtp_stream_init_keys(&srtp->session_keys[i], p->keys[i],
+                                           srtp->mki_size);
             if (status) {
                 return status;
             }
@@ -1422,8 +1433,9 @@ srtp_err_status_t srtp_stream_init_all_master_keys(srtp_stream_ctx_t * srtp,
     return status;
 }
 
-static srtp_err_status_t srtp_stream_init(srtp_stream_ctx_t * srtp,
-    const srtp_policy_t * p) {
+static srtp_err_status_t srtp_stream_init(srtp_stream_ctx_t *srtp,
+                                          const srtp_policy_t *p)
+{
     srtp_err_status_t err;
 
     err = srtp_valid_policy(p);
@@ -1432,7 +1444,7 @@ static srtp_err_status_t srtp_stream_init(srtp_stream_ctx_t * srtp,
     }
 
     debug_print(mod_srtp, "initializing stream (SSRC: 0x%08x)",
-        (unsigned int) p -> ssrc.value);
+                (unsigned int)p->ssrc.value);
 
     /* initialize replay database */
     /*
@@ -1442,48 +1454,48 @@ static srtp_err_status_t srtp_stream_init(srtp_stream_ctx_t * srtp,
      * Let a window size of 0 imply the default value.
      */
 
-    if (p -> window_size != 0 &&
-        (p -> window_size < 64 || p -> window_size >= 0x8000))
+    if (p->window_size != 0 &&
+        (p->window_size < 64 || p->window_size >= 0x8000))
         return srtp_err_status_bad_param;
 
-    if (p -> window_size != 0) {
-        err = srtp_rdbx_init( & srtp -> rtp_rdbx, p -> window_size);
+    if (p->window_size != 0) {
+        err = srtp_rdbx_init(&srtp->rtp_rdbx, p->window_size);
     } else {
-        err = srtp_rdbx_init( & srtp -> rtp_rdbx, 128);
+        err = srtp_rdbx_init(&srtp->rtp_rdbx, 128);
     }
     if (err) {
         return err;
     }
 
     /* set the SSRC value */
-    srtp -> ssrc = htonl(p -> ssrc.value);
+    srtp->ssrc = htonl(p->ssrc.value);
 
     /* reset pending ROC */
-    srtp -> pending_roc = 0;
+    srtp->pending_roc = 0;
 
     /* set the security service flags */
-    srtp -> rtp_services = p -> rtp.sec_serv;
-    srtp -> rtcp_services = p -> rtcp.sec_serv;
+    srtp->rtp_services = p->rtp.sec_serv;
+    srtp->rtcp_services = p->rtcp.sec_serv;
 
     /*
      * set direction to unknown - this flag gets checked in srtp_protect(),
      * srtp_unprotect(), srtp_protect_rtcp(), and srtp_unprotect_rtcp(), and
      * gets set appropriately if it is set to unknown.
      */
-    srtp -> direction = dir_unknown;
+    srtp->direction = dir_unknown;
 
     /* initialize SRTCP replay database */
-    srtp_rdb_init( & srtp -> rtcp_rdb);
+    srtp_rdb_init(&srtp->rtcp_rdb);
 
     /* initialize allow_repeat_tx */
-    srtp -> allow_repeat_tx = p -> allow_repeat_tx;
+    srtp->allow_repeat_tx = p->allow_repeat_tx;
 
     /* DAM - no RTCP key limit at present */
 
     /* initialize keys */
     err = srtp_stream_init_all_master_keys(srtp, p);
     if (err) {
-        srtp_rdbx_dealloc( & srtp -> rtp_rdbx);
+        srtp_rdbx_dealloc(&srtp->rtp_rdbx);
         return err;
     }
 
@@ -1495,29 +1507,30 @@ static srtp_err_status_t srtp_stream_init(srtp_stream_ctx_t * srtp,
  * reports the events that are reported by the callbacks
  */
 
-void srtp_event_reporter(srtp_event_data_t * data) {
+void srtp_event_reporter(srtp_event_data_t *data)
+{
     srtp_err_report(srtp_err_level_warning,
-        "srtp: in stream 0x%x: ", (unsigned int) data -> ssrc);
+                    "srtp: in stream 0x%x: ", (unsigned int)data->ssrc);
 
-    switch (data -> event) {
+    switch (data->event) {
     case event_ssrc_collision:
         srtp_err_report(srtp_err_level_warning, "\tSSRC collision\n");
         break;
     case event_key_soft_limit:
         srtp_err_report(srtp_err_level_warning,
-            "\tkey usage soft limit reached\n");
+                        "\tkey usage soft limit reached\n");
         break;
     case event_key_hard_limit:
         srtp_err_report(srtp_err_level_warning,
-            "\tkey usage hard limit reached\n");
+                        "\tkey usage hard limit reached\n");
         break;
     case event_packet_index_limit:
         srtp_err_report(srtp_err_level_warning,
-            "\tpacket index limit reached\n");
+                        "\tpacket index limit reached\n");
         break;
     default:
         srtp_err_report(srtp_err_level_warning,
-            "\tunknown event reported to handler\n");
+                        "\tunknown event reported to handler\n");
     }
 }
 
@@ -1531,9 +1544,10 @@ void srtp_event_reporter(srtp_event_data_t * data) {
  * it to the srtp_event_reporter.
  */
 
-static srtp_event_handler_func_t * srtp_event_handler = srtp_event_reporter;
+static srtp_event_handler_func_t *srtp_event_handler = srtp_event_reporter;
 
-srtp_err_status_t srtp_install_event_handler(srtp_event_handler_func_t func) {
+srtp_err_status_t srtp_install_event_handler(srtp_event_handler_func_t func)
+{
     /*
      * note that we accept NULL arguments intentionally - calling this
      * function with a NULL arguments removes an event handler that's
@@ -1549,16 +1563,17 @@ srtp_err_status_t srtp_install_event_handler(srtp_event_handler_func_t func) {
  * Check if the given extension header id is / should be encrypted.
  * Returns true if yes, otherwise false.
  */
-static bool srtp_protect_extension_header(srtp_stream_ctx_t * stream, uint8_t id) {
-    uint8_t * enc_xtn_hdr = stream -> enc_xtn_hdr;
-    size_t count = stream -> enc_xtn_hdr_count;
+static bool srtp_protect_extension_header(srtp_stream_ctx_t *stream, uint8_t id)
+{
+    uint8_t *enc_xtn_hdr = stream->enc_xtn_hdr;
+    size_t count = stream->enc_xtn_hdr_count;
 
     if (!enc_xtn_hdr || count <= 0) {
         return false;
     }
 
     while (count > 0) {
-        if ( * enc_xtn_hdr == id) {
+        if (*enc_xtn_hdr == id) {
             return true;
         }
 
@@ -1572,21 +1587,22 @@ static bool srtp_protect_extension_header(srtp_stream_ctx_t * stream, uint8_t id
  * extensions header encryption RFC 6904
  */
 static srtp_err_status_t srtp_process_header_encryption(
-    srtp_stream_ctx_t * stream,
-    srtp_hdr_xtnd_t * xtn_hdr,
-    srtp_session_keys_t * session_keys) {
+    srtp_stream_ctx_t *stream,
+    srtp_hdr_xtnd_t *xtn_hdr,
+    srtp_session_keys_t *session_keys)
+{
     srtp_err_status_t status;
     uint8_t keystream[257]; /* Maximum 2 bytes header + 255 bytes data. */
     size_t keystream_pos;
-    uint8_t * xtn_hdr_data = ((uint8_t * ) xtn_hdr) + octets_in_rtp_xtn_hdr;
-    uint8_t * xtn_hdr_end =
-        xtn_hdr_data + (ntohs(xtn_hdr -> length) * sizeof(uint32_t));
+    uint8_t *xtn_hdr_data = ((uint8_t *)xtn_hdr) + octets_in_rtp_xtn_hdr;
+    uint8_t *xtn_hdr_end =
+        xtn_hdr_data + (ntohs(xtn_hdr->length) * sizeof(uint32_t));
 
-    if (ntohs(xtn_hdr -> profile_specific) == 0xbede) {
+    if (ntohs(xtn_hdr->profile_specific) == 0xbede) {
         /* RFC 5285, section 4.2. One-Byte Header */
         while (xtn_hdr_data < xtn_hdr_end) {
-            uint8_t xid = ( * xtn_hdr_data & 0xf0) >> 4;
-            size_t xlen = ( * xtn_hdr_data & 0x0f) + 1;
+            uint8_t xid = (*xtn_hdr_data & 0xf0) >> 4;
+            size_t xlen = (*xtn_hdr_data & 0x0f) + 1;
             size_t xlen_with_header = 1 + xlen;
             xtn_hdr_data++;
 
@@ -1599,8 +1615,8 @@ static srtp_err_status_t srtp_process_header_encryption(
                 break;
             }
 
-            status = srtp_cipher_output(session_keys -> rtp_xtn_hdr_cipher,
-                keystream, & xlen_with_header);
+            status = srtp_cipher_output(session_keys->rtp_xtn_hdr_cipher,
+                                        keystream, &xlen_with_header);
             if (status) {
                 return srtp_err_status_cipher_fail;
             }
@@ -1608,7 +1624,7 @@ static srtp_err_status_t srtp_process_header_encryption(
             if (srtp_protect_extension_header(stream, xid)) {
                 keystream_pos = 1;
                 while (xlen > 0) {
-                    * xtn_hdr_data ^= keystream[keystream_pos++];
+                    *xtn_hdr_data ^= keystream[keystream_pos++];
                     xtn_hdr_data++;
                     xlen--;
                 }
@@ -1617,15 +1633,15 @@ static srtp_err_status_t srtp_process_header_encryption(
             }
 
             /* skip padding bytes */
-            while (xtn_hdr_data < xtn_hdr_end && * xtn_hdr_data == 0) {
+            while (xtn_hdr_data < xtn_hdr_end && *xtn_hdr_data == 0) {
                 xtn_hdr_data++;
             }
         }
-    } else if ((ntohs(xtn_hdr -> profile_specific) & 0xfff0) == 0x1000) {
+    } else if ((ntohs(xtn_hdr->profile_specific) & 0xfff0) == 0x1000) {
         /* RFC 5285, section 4.3. Two-Byte Header */
         while (xtn_hdr_data + 1 < xtn_hdr_end) {
-            uint8_t xid = * xtn_hdr_data;
-            size_t xlen = * (xtn_hdr_data + 1);
+            uint8_t xid = *xtn_hdr_data;
+            size_t xlen = *(xtn_hdr_data + 1);
             size_t xlen_with_header = 2 + xlen;
             xtn_hdr_data += 2;
 
@@ -1633,8 +1649,8 @@ static srtp_err_status_t srtp_process_header_encryption(
                 return srtp_err_status_parse_err;
             }
 
-            status = srtp_cipher_output(session_keys -> rtp_xtn_hdr_cipher,
-                keystream, & xlen_with_header);
+            status = srtp_cipher_output(session_keys->rtp_xtn_hdr_cipher,
+                                        keystream, &xlen_with_header);
             if (status) {
                 return srtp_err_status_cipher_fail;
             }
@@ -1642,7 +1658,7 @@ static srtp_err_status_t srtp_process_header_encryption(
             if (xlen > 0 && srtp_protect_extension_header(stream, xid)) {
                 keystream_pos = 2;
                 while (xlen > 0) {
-                    * xtn_hdr_data ^= keystream[keystream_pos++];
+                    *xtn_hdr_data ^= keystream[keystream_pos++];
                     xtn_hdr_data++;
                     xlen--;
                 }
@@ -1651,7 +1667,7 @@ static srtp_err_status_t srtp_process_header_encryption(
             }
 
             /* skip padding bytes. */
-            while (xtn_hdr_data < xtn_hdr_end && * xtn_hdr_data == 0) {
+            while (xtn_hdr_data < xtn_hdr_end && *xtn_hdr_data == 0) {
                 xtn_hdr_data++;
             }
         }
@@ -1692,48 +1708,50 @@ static srtp_err_status_t srtp_process_header_encryption(
  *
  */
 
-static void srtp_calc_aead_iv(srtp_session_keys_t * session_keys,
-    v128_t * iv,
-    srtp_xtd_seq_num_t * seq,
-    const srtp_hdr_t * hdr) {
-    v128_t in ;
+static void srtp_calc_aead_iv(srtp_session_keys_t *session_keys,
+                              v128_t *iv,
+                              srtp_xtd_seq_num_t *seq,
+                              const srtp_hdr_t *hdr)
+{
+    v128_t in;
     v128_t salt;
 
-    uint32_t local_roc = (uint32_t)( * seq >> 16);
-    uint16_t local_seq = (uint16_t) * seq;
+    uint32_t local_roc = (uint32_t)(*seq >> 16);
+    uint16_t local_seq = (uint16_t)*seq;
 
-    memset( & in, 0, sizeof(v128_t));
-    memset( & salt, 0, sizeof(v128_t));
+    memset(&in, 0, sizeof(v128_t));
+    memset(&salt, 0, sizeof(v128_t));
 
     in.v16[5] = htons(local_seq);
     local_roc = htonl(local_roc);
-    memcpy( & in.v16[3], & local_roc, sizeof(local_roc));
+    memcpy(&in.v16[3], &local_roc, sizeof(local_roc));
 
     /*
      * Copy in the RTP SSRC value
      */
-    memcpy( & in.v8[2], & hdr -> ssrc, 4);
-    debug_print(mod_srtp, "Pre-salted RTP IV = %s\n", v128_hex_string( & in));
+    memcpy(&in.v8[2], &hdr->ssrc, 4);
+    debug_print(mod_srtp, "Pre-salted RTP IV = %s\n", v128_hex_string(&in));
 
     /*
      * Get the SALT value from the context
      */
-    memcpy(salt.v8, session_keys -> salt, SRTP_AEAD_SALT_LEN);
-    debug_print(mod_srtp, "RTP SALT = %s\n", v128_hex_string( & salt));
+    memcpy(salt.v8, session_keys->salt, SRTP_AEAD_SALT_LEN);
+    debug_print(mod_srtp, "RTP SALT = %s\n", v128_hex_string(&salt));
 
     /*
      * Finally, apply tyhe SALT to the input
      */
-    v128_xor(iv, & in, & salt);
+    v128_xor(iv, &in, &salt);
 }
 
 srtp_err_status_t srtp_get_session_keys_for_packet(
-    srtp_stream_ctx_t * stream,
-    const uint8_t * hdr,
-        size_t pkt_octet_len,
-        srtp_session_keys_t ** session_keys) {
-    if (!stream -> use_mki) {
-        * session_keys = & stream -> session_keys[0];
+    srtp_stream_ctx_t *stream,
+    const uint8_t *hdr,
+    size_t pkt_octet_len,
+    srtp_session_keys_t **session_keys)
+{
+    if (!stream->use_mki) {
+        *session_keys = &stream->session_keys[0];
         return srtp_err_status_ok;
     }
 
@@ -1741,11 +1759,11 @@ srtp_err_status_t srtp_get_session_keys_for_packet(
     size_t tag_len = 0;
 
     // Determine the authentication tag size
-    if (stream -> session_keys[0].rtp_cipher -> algorithm == SRTP_AES_GCM_128 ||
-        stream -> session_keys[0].rtp_cipher -> algorithm == SRTP_AES_GCM_256) {
+    if (stream->session_keys[0].rtp_cipher->algorithm == SRTP_AES_GCM_128 ||
+        stream->session_keys[0].rtp_cipher->algorithm == SRTP_AES_GCM_256) {
         tag_len = 0;
     } else {
-        tag_len = srtp_auth_get_tag_length(stream -> session_keys[0].rtp_auth);
+        tag_len = srtp_auth_get_tag_length(stream->session_keys[0].rtp_auth);
     }
 
     if (tag_len > mki_start_location) {
@@ -1754,16 +1772,16 @@ srtp_err_status_t srtp_get_session_keys_for_packet(
 
     mki_start_location -= tag_len;
 
-    if (stream -> mki_size > mki_start_location) {
+    if (stream->mki_size > mki_start_location) {
         return srtp_err_status_bad_mki;
     }
 
-    mki_start_location -= stream -> mki_size;
+    mki_start_location -= stream->mki_size;
 
-    for (size_t i = 0; i < stream -> num_master_keys; i++) {
-        if (memcmp(hdr + mki_start_location, stream -> session_keys[i].mki_id,
-                stream -> mki_size) == 0) {
-            * session_keys = & stream -> session_keys[i];
+    for (size_t i = 0; i < stream->num_master_keys; i++) {
+        if (memcmp(hdr + mki_start_location, stream->session_keys[i].mki_id,
+                   stream->mki_size) == 0) {
+            *session_keys = &stream->session_keys[i];
             return srtp_err_status_ok;
         }
     }
@@ -1771,22 +1789,23 @@ srtp_err_status_t srtp_get_session_keys_for_packet(
     return srtp_err_status_bad_mki;
 }
 
-static srtp_err_status_t srtp_estimate_index(srtp_rdbx_t * rdbx,
-    uint32_t roc,
-    srtp_xtd_seq_num_t * est,
-    srtp_sequence_number_t seq,
-    ssize_t * delta) {
-    * est = (srtp_xtd_seq_num_t)(((uint64_t) roc) << 16) | seq;
-    * delta = * est - rdbx -> index;
+static srtp_err_status_t srtp_estimate_index(srtp_rdbx_t *rdbx,
+                                             uint32_t roc,
+                                             srtp_xtd_seq_num_t *est,
+                                             srtp_sequence_number_t seq,
+                                             ssize_t *delta)
+{
+    *est = (srtp_xtd_seq_num_t)(((uint64_t)roc) << 16) | seq;
+    *delta = *est - rdbx->index;
 
-    if ( * est > rdbx -> index) {
-        if ( * est - rdbx -> index > seq_num_median) {
-            * delta = 0;
+    if (*est > rdbx->index) {
+        if (*est - rdbx->index > seq_num_median) {
+            *delta = 0;
             return srtp_err_status_pkt_idx_adv;
         }
-    } else if ( * est < rdbx -> index) {
-        if (rdbx -> index - * est > seq_num_median) {
-            * delta = 0;
+    } else if (*est < rdbx->index) {
+        if (rdbx->index - *est > seq_num_median) {
+            *delta = 0;
             return srtp_err_status_pkt_idx_old;
         }
     }
@@ -1794,23 +1813,23 @@ static srtp_err_status_t srtp_estimate_index(srtp_rdbx_t * rdbx,
     return srtp_err_status_ok;
 }
 
-static srtp_err_status_t srtp_get_est_pkt_index(const srtp_hdr_t * hdr,
-    srtp_stream_ctx_t * stream,
-    srtp_xtd_seq_num_t * est,
-    ssize_t * delta) {
+static srtp_err_status_t srtp_get_est_pkt_index(const srtp_hdr_t *hdr,
+                                                srtp_stream_ctx_t *stream,
+                                                srtp_xtd_seq_num_t *est,
+                                                ssize_t *delta)
+{
     srtp_err_status_t result = srtp_err_status_ok;
 
-    if (stream -> pending_roc) {
-        result = srtp_estimate_index( & stream -> rtp_rdbx, stream -> pending_roc,
-            est, ntohs(hdr -> seq), delta);
+    if (stream->pending_roc) {
+        result = srtp_estimate_index(&stream->rtp_rdbx, stream->pending_roc,
+                                     est, ntohs(hdr->seq), delta);
     } else {
         /* estimate packet index from seq. num. in header */
-        * delta =
-            srtp_rdbx_estimate_index( & stream -> rtp_rdbx, est, ntohs(hdr -> seq));
+        *delta =
+            srtp_rdbx_estimate_index(&stream->rtp_rdbx, est, ntohs(hdr->seq));
     }
 
-    debug_print(mod_srtp, "estimated u_packet index: %016"
-        PRIx64, * est);
+    debug_print(mod_srtp, "estimated u_packet index: %016" PRIx64, *est);
 
     return result;
 }
@@ -1820,18 +1839,19 @@ static srtp_err_status_t srtp_get_est_pkt_index(const srtp_hdr_t * hdr,
  * which currently supports AES-GCM encryption.  All packets are
  * encrypted and authenticated.
  */
-static srtp_err_status_t srtp_protect_aead(srtp_ctx_t * ctx,
-    srtp_stream_ctx_t * stream,
-    const uint8_t * rtp,
-        size_t rtp_len,
-        uint8_t * srtp,
-        size_t * srtp_len,
-        srtp_session_keys_t * session_keys) {
-    const srtp_hdr_t * hdr = (const srtp_hdr_t * ) rtp;
-    size_t enc_start; /* offset to start of encrypted portion   */
+static srtp_err_status_t srtp_protect_aead(srtp_ctx_t *ctx,
+                                           srtp_stream_ctx_t *stream,
+                                           const uint8_t *rtp,
+                                           size_t rtp_len,
+                                           uint8_t *srtp,
+                                           size_t *srtp_len,
+                                           srtp_session_keys_t *session_keys)
+{
+    const srtp_hdr_t *hdr = (const srtp_hdr_t *)rtp;
+    size_t enc_start;         /* offset to start of encrypted portion   */
     size_t enc_octet_len = 0; /* number of octets in encrypted portion  */
-    srtp_xtd_seq_num_t est; /* estimated xtd_seq_num_t of *hdr        */
-    ssize_t delta; /* delta of local pkt idx and that in hdr */
+    srtp_xtd_seq_num_t est;   /* estimated xtd_seq_num_t of *hdr        */
+    ssize_t delta;            /* delta of local pkt idx and that in hdr */
     srtp_err_status_t status;
     size_t tag_len;
     v128_t iv;
@@ -1844,7 +1864,7 @@ static srtp_err_status_t srtp_protect_aead(srtp_ctx_t * ctx,
      * didn't just hit either the soft limit or the hard limit, and call
      * the event handler if we hit either.
      */
-    switch (srtp_key_limit_update(session_keys -> limit)) {
+    switch (srtp_key_limit_update(session_keys->limit)) {
     case srtp_key_event_normal:
         break;
     case srtp_key_event_hard_limit:
@@ -1857,7 +1877,7 @@ static srtp_err_status_t srtp_protect_aead(srtp_ctx_t * ctx,
     }
 
     /* get tag length from stream */
-    tag_len = srtp_auth_get_tag_length(session_keys -> rtp_auth);
+    tag_len = srtp_auth_get_tag_length(session_keys->rtp_auth);
 
     /*
      * find starting point for encryption and length of data to be
@@ -1866,7 +1886,7 @@ static srtp_err_status_t srtp_protect_aead(srtp_ctx_t * ctx,
      * if any are present
      */
     enc_start = srtp_get_rtp_hdr_len(hdr);
-    if (hdr -> x == 1) {
+    if (hdr->x == 1) {
         enc_start += srtp_get_rtp_xtn_hdr_len(hdr, rtp);
     }
 
@@ -1877,7 +1897,7 @@ static srtp_err_status_t srtp_protect_aead(srtp_ctx_t * ctx,
     enc_octet_len = rtp_len - enc_start;
 
     /* check output length */
-    if ( * srtp_len < rtp_len + tag_len + stream -> mki_size) {
+    if (*srtp_len < rtp_len + tag_len + stream->mki_size) {
         return srtp_err_status_buffer_small;
     }
 
@@ -1890,51 +1910,50 @@ static srtp_err_status_t srtp_protect_aead(srtp_ctx_t * ctx,
      * estimate the packet index using the start of the replay window
      * and the sequence number from the header
      */
-    status = srtp_get_est_pkt_index(hdr, stream, & est, & delta);
+    status = srtp_get_est_pkt_index(hdr, stream, &est, &delta);
 
     if (status && (status != srtp_err_status_pkt_idx_adv)) {
         return status;
     }
 
     if (status == srtp_err_status_pkt_idx_adv) {
-        srtp_rdbx_set_roc_seq( & stream -> rtp_rdbx, (uint32_t)(est >> 16),
-            (uint16_t)(est & 0xFFFF));
-        stream -> pending_roc = 0;
-        srtp_rdbx_add_index( & stream -> rtp_rdbx, 0);
+        srtp_rdbx_set_roc_seq(&stream->rtp_rdbx, (uint32_t)(est >> 16),
+                              (uint16_t)(est & 0xFFFF));
+        stream->pending_roc = 0;
+        srtp_rdbx_add_index(&stream->rtp_rdbx, 0);
     } else {
-        status = srtp_rdbx_check( & stream -> rtp_rdbx, delta);
+        status = srtp_rdbx_check(&stream->rtp_rdbx, delta);
         if (status) {
             if (status != srtp_err_status_replay_fail ||
-                !stream -> allow_repeat_tx)
+                !stream->allow_repeat_tx)
                 return status; /* we've been asked to reuse an index */
         }
-        srtp_rdbx_add_index( & stream -> rtp_rdbx, delta);
+        srtp_rdbx_add_index(&stream->rtp_rdbx, delta);
     }
 
-    debug_print(mod_srtp, "estimated packet index: %016"
-        PRIx64, est);
+    debug_print(mod_srtp, "estimated packet index: %016" PRIx64, est);
 
     /*
      * AEAD uses a new IV formation method
      */
-    srtp_calc_aead_iv(session_keys, & iv, & est, hdr);
+    srtp_calc_aead_iv(session_keys, &iv, &est, hdr);
     /* shift est, put into network byte order */
     est = be64_to_cpu(est << 16);
 
-    status = srtp_cipher_set_iv(session_keys -> rtp_cipher, (uint8_t * ) & iv,
-        srtp_direction_encrypt);
-    if (!status && session_keys -> rtp_xtn_hdr_cipher) {
+    status = srtp_cipher_set_iv(session_keys->rtp_cipher, (uint8_t *)&iv,
+                                srtp_direction_encrypt);
+    if (!status && session_keys->rtp_xtn_hdr_cipher) {
         iv.v32[0] = 0;
-        iv.v32[1] = hdr -> ssrc;
+        iv.v32[1] = hdr->ssrc;
         iv.v64[1] = est;
-        status = srtp_cipher_set_iv(session_keys -> rtp_xtn_hdr_cipher,
-            (uint8_t * ) & iv, srtp_direction_encrypt);
+        status = srtp_cipher_set_iv(session_keys->rtp_xtn_hdr_cipher,
+                                    (uint8_t *)&iv, srtp_direction_encrypt);
     }
     if (status) {
         return srtp_err_status_cipher_fail;
     }
 
-    if (hdr -> x == 1 && session_keys -> rtp_xtn_hdr_cipher) {
+    if (hdr->x == 1 && session_keys->rtp_xtn_hdr_cipher) {
         /*
          * extensions header encryption RFC 6904
          */
@@ -1949,29 +1968,29 @@ static srtp_err_status_t srtp_protect_aead(srtp_ctx_t * ctx,
      * Set the AAD over the RTP header
      */
     aad_len = enc_start;
-    status = srtp_cipher_set_aad(session_keys -> rtp_cipher, srtp, aad_len);
+    status = srtp_cipher_set_aad(session_keys->rtp_cipher, srtp, aad_len);
     if (status) {
         return (srtp_err_status_cipher_fail);
     }
 
     /* Encrypt the payload  */
-    size_t outlen = * srtp_len - enc_start;
-    status = srtp_cipher_encrypt(session_keys -> rtp_cipher, rtp + enc_start,
-        enc_octet_len, srtp + enc_start, & outlen);
+    size_t outlen = *srtp_len - enc_start;
+    status = srtp_cipher_encrypt(session_keys->rtp_cipher, rtp + enc_start,
+                                 enc_octet_len, srtp + enc_start, &outlen);
     enc_octet_len = outlen;
     if (status) {
         return srtp_err_status_cipher_fail;
     }
 
-    if (stream -> use_mki) {
+    if (stream->use_mki) {
         srtp_inject_mki(srtp + enc_start + enc_octet_len, session_keys,
-            stream -> mki_size);
+                        stream->mki_size);
     }
 
-    * srtp_len = enc_start + enc_octet_len;
+    *srtp_len = enc_start + enc_octet_len;
 
     /* increase the packet length by the length of the mki_size */
-    * srtp_len += stream -> mki_size;
+    *srtp_len += stream->mki_size;
 
     return srtp_err_status_ok;
 }
@@ -1983,18 +2002,19 @@ static srtp_err_status_t srtp_protect_aead(srtp_ctx_t * ctx,
  * of the packet stream and is automatically checked by GCM
  * when decrypting the payload.
  */
-static srtp_err_status_t srtp_unprotect_aead(srtp_ctx_t * ctx,
-    srtp_stream_ctx_t * stream,
-    ssize_t delta,
-    srtp_xtd_seq_num_t est,
-    const uint8_t * srtp,
-        size_t srtp_len,
-        uint8_t * rtp,
-        size_t * rtp_len,
-        srtp_session_keys_t * session_keys,
-        bool advance_packet_index) {
-    const srtp_hdr_t * hdr = (const srtp_hdr_t * ) srtp;
-    size_t enc_start; /* offset to start of encrypted portion  */
+static srtp_err_status_t srtp_unprotect_aead(srtp_ctx_t *ctx,
+                                             srtp_stream_ctx_t *stream,
+                                             ssize_t delta,
+                                             srtp_xtd_seq_num_t est,
+                                             const uint8_t *srtp,
+                                             size_t srtp_len,
+                                             uint8_t *rtp,
+                                             size_t *rtp_len,
+                                             srtp_session_keys_t *session_keys,
+                                             bool advance_packet_index)
+{
+    const srtp_hdr_t *hdr = (const srtp_hdr_t *)srtp;
+    size_t enc_start;         /* offset to start of encrypted portion  */
     size_t enc_octet_len = 0; /* number of octets in encrypted portion */
     v128_t iv;
     srtp_err_status_t status;
@@ -2003,42 +2023,41 @@ static srtp_err_status_t srtp_unprotect_aead(srtp_ctx_t * ctx,
 
     debug_print0(mod_srtp, "function srtp_unprotect_aead");
 
-    debug_print(mod_srtp, "estimated u_packet index: %016"
-        PRIx64, est);
+    debug_print(mod_srtp, "estimated u_packet index: %016" PRIx64, est);
 
     /* get tag length from stream */
-    tag_len = srtp_auth_get_tag_length(session_keys -> rtp_auth);
+    tag_len = srtp_auth_get_tag_length(session_keys->rtp_auth);
 
     /*
      * AEAD uses a new IV formation method
      */
-    srtp_calc_aead_iv(session_keys, & iv, & est, hdr);
-    status = srtp_cipher_set_iv(session_keys -> rtp_cipher, (uint8_t * ) & iv,
-        srtp_direction_decrypt);
-    if (!status && session_keys -> rtp_xtn_hdr_cipher) {
+    srtp_calc_aead_iv(session_keys, &iv, &est, hdr);
+    status = srtp_cipher_set_iv(session_keys->rtp_cipher, (uint8_t *)&iv,
+                                srtp_direction_decrypt);
+    if (!status && session_keys->rtp_xtn_hdr_cipher) {
         iv.v32[0] = 0;
-        iv.v32[1] = hdr -> ssrc;
+        iv.v32[1] = hdr->ssrc;
         iv.v64[1] = be64_to_cpu(est << 16);
-        status = srtp_cipher_set_iv(session_keys -> rtp_xtn_hdr_cipher,
-            (uint8_t * ) & iv, srtp_direction_encrypt);
+        status = srtp_cipher_set_iv(session_keys->rtp_xtn_hdr_cipher,
+                                    (uint8_t *)&iv, srtp_direction_encrypt);
     }
     if (status) {
         return srtp_err_status_cipher_fail;
     }
 
     enc_start = srtp_get_rtp_hdr_len(hdr);
-    if (hdr -> x == 1) {
+    if (hdr->x == 1) {
         enc_start += srtp_get_rtp_xtn_hdr_len(hdr, srtp);
     }
 
-    if (enc_start > srtp_len - tag_len - stream -> mki_size) {
+    if (enc_start > srtp_len - tag_len - stream->mki_size) {
         return srtp_err_status_parse_err;
     }
 
     /*
      * We pass the tag down to the cipher when doing GCM mode
      */
-    enc_octet_len = srtp_len - enc_start - stream -> mki_size;
+    enc_octet_len = srtp_len - enc_start - stream->mki_size;
 
     /*
      * Sanity check the encrypted payload length against
@@ -2050,7 +2069,7 @@ static srtp_err_status_t srtp_unprotect_aead(srtp_ctx_t * ctx,
     }
 
     /* check output length */
-    if ( * rtp_len < srtp_len - stream -> mki_size - tag_len) {
+    if (*rtp_len < srtp_len - stream->mki_size - tag_len) {
         return srtp_err_status_buffer_small;
     }
 
@@ -2064,7 +2083,7 @@ static srtp_err_status_t srtp_unprotect_aead(srtp_ctx_t * ctx,
      * didn't just hit either the soft limit or the hard limit, and call
      * the event handler if we hit either.
      */
-    switch (srtp_key_limit_update(session_keys -> limit)) {
+    switch (srtp_key_limit_update(session_keys->limit)) {
     case srtp_key_event_normal:
         break;
     case srtp_key_event_soft_limit:
@@ -2081,7 +2100,7 @@ static srtp_err_status_t srtp_unprotect_aead(srtp_ctx_t * ctx,
      * Set the AAD for AES-GCM, which is the RTP header
      */
     aad_len = enc_start;
-    status = srtp_cipher_set_aad(session_keys -> rtp_cipher, srtp, aad_len);
+    status = srtp_cipher_set_aad(session_keys->rtp_cipher, srtp, aad_len);
     if (status) {
         return srtp_err_status_cipher_fail;
     }
@@ -2089,13 +2108,13 @@ static srtp_err_status_t srtp_unprotect_aead(srtp_ctx_t * ctx,
     /* Decrypt the ciphertext.  This also checks the auth tag based
      * on the AAD we just specified above */
     status =
-        srtp_cipher_decrypt(session_keys -> rtp_cipher, srtp + enc_start,
-            enc_octet_len, rtp + enc_start, & enc_octet_len);
+        srtp_cipher_decrypt(session_keys->rtp_cipher, srtp + enc_start,
+                            enc_octet_len, rtp + enc_start, &enc_octet_len);
     if (status) {
         return status;
     }
 
-    if (hdr -> x == 1 && session_keys -> rtp_xtn_hdr_cipher) {
+    if (hdr->x == 1 && session_keys->rtp_xtn_hdr_cipher) {
         /*
          * extensions header encryption RFC 6904
          */
@@ -2116,9 +2135,9 @@ static srtp_err_status_t srtp_unprotect_aead(srtp_ctx_t * ctx,
      * latter check will catch any attempts to fool us into thinking
      * that we've got a collision
      */
-    if (stream -> direction != dir_srtp_receiver) {
-        if (stream -> direction == dir_unknown) {
-            stream -> direction = dir_srtp_receiver;
+    if (stream->direction != dir_srtp_receiver) {
+        if (stream->direction == dir_unknown) {
+            stream->direction = dir_srtp_receiver;
         } else {
             srtp_handle_event(ctx, stream, event_ssrc_collision);
         }
@@ -2129,8 +2148,8 @@ static srtp_err_status_t srtp_unprotect_aead(srtp_ctx_t * ctx,
      * is used, then we need to allocate a new stream at this point, since
      * the authentication passed
      */
-    if (stream == ctx -> stream_template) {
-        srtp_stream_ctx_t * new_stream;
+    if (stream == ctx->stream_template) {
+        srtp_stream_ctx_t *new_stream;
 
         /*
          * allocate and initialize a new stream
@@ -2140,14 +2159,14 @@ static srtp_err_status_t srtp_unprotect_aead(srtp_ctx_t * ctx,
          * failure here
          */
         status =
-            srtp_stream_clone(ctx -> stream_template, hdr -> ssrc, & new_stream);
+            srtp_stream_clone(ctx->stream_template, hdr->ssrc, &new_stream);
         if (status) {
             return status;
         }
 
         /* add new stream to the list */
-        status = srtp_insert_or_dealloc_stream(ctx -> stream_list, new_stream,
-            ctx -> stream_template);
+        status = srtp_insert_or_dealloc_stream(ctx->stream_list, new_stream,
+                                               ctx->stream_template);
         if (status) {
             return status;
         }
@@ -2163,36 +2182,37 @@ static srtp_err_status_t srtp_unprotect_aead(srtp_ctx_t * ctx,
     if (advance_packet_index) {
         uint32_t roc_to_set = (uint32_t)(est >> 16);
         uint16_t seq_to_set = (uint16_t)(est & 0xFFFF);
-        srtp_rdbx_set_roc_seq( & stream -> rtp_rdbx, roc_to_set, seq_to_set);
-        stream -> pending_roc = 0;
-        srtp_rdbx_add_index( & stream -> rtp_rdbx, 0);
+        srtp_rdbx_set_roc_seq(&stream->rtp_rdbx, roc_to_set, seq_to_set);
+        stream->pending_roc = 0;
+        srtp_rdbx_add_index(&stream->rtp_rdbx, 0);
     } else {
-        srtp_rdbx_add_index( & stream -> rtp_rdbx, delta);
+        srtp_rdbx_add_index(&stream->rtp_rdbx, delta);
     }
 
-    * rtp_len = enc_start + enc_octet_len;
+    *rtp_len = enc_start + enc_octet_len;
 
     return srtp_err_status_ok;
 }
 
 srtp_err_status_t srtp_protect(srtp_t ctx,
-    const uint8_t * rtp,
-        size_t rtp_len,
-        uint8_t * srtp,
-        size_t * srtp_len,
-        size_t mki_index) {
-    const srtp_hdr_t * hdr = (const srtp_hdr_t * ) rtp;
-    size_t enc_start; /* offset to start of encrypted portion   */
-    uint8_t * auth_start; /* pointer to start of auth. portion      */
+                               const uint8_t *rtp,
+                               size_t rtp_len,
+                               uint8_t *srtp,
+                               size_t *srtp_len,
+                               size_t mki_index)
+{
+    const srtp_hdr_t *hdr = (const srtp_hdr_t *)rtp;
+    size_t enc_start;         /* offset to start of encrypted portion   */
+    uint8_t *auth_start;      /* pointer to start of auth. portion      */
     size_t enc_octet_len = 0; /* number of octets in encrypted portion  */
-    srtp_xtd_seq_num_t est; /* estimated xtd_seq_num_t of *hdr        */
-    ssize_t delta; /* delta of local pkt idx and that in hdr */
-    uint8_t * auth_tag = NULL; /* location of auth_tag within packet     */
+    srtp_xtd_seq_num_t est;   /* estimated xtd_seq_num_t of *hdr        */
+    ssize_t delta;            /* delta of local pkt idx and that in hdr */
+    uint8_t *auth_tag = NULL; /* location of auth_tag within packet     */
     srtp_err_status_t status;
     size_t tag_len;
-    srtp_stream_ctx_t * stream;
+    srtp_stream_ctx_t *stream;
     size_t prefix_len;
-    srtp_session_keys_t * session_keys = NULL;
+    srtp_session_keys_t *session_keys = NULL;
 
     debug_print0(mod_srtp, "function srtp_protect");
 
@@ -2214,27 +2234,27 @@ srtp_err_status_t srtp_protect(srtp_t ctx,
      * supports key-sharing, then we assume that a new stream using
      * that key has just started up
      */
-    stream = srtp_get_stream(ctx, hdr -> ssrc);
+    stream = srtp_get_stream(ctx, hdr->ssrc);
     if (stream == NULL) {
-        if (ctx -> stream_template != NULL) {
-            srtp_stream_ctx_t * new_stream;
+        if (ctx->stream_template != NULL) {
+            srtp_stream_ctx_t *new_stream;
 
             /* allocate and initialize a new stream */
             status =
-                srtp_stream_clone(ctx -> stream_template, hdr -> ssrc, & new_stream);
+                srtp_stream_clone(ctx->stream_template, hdr->ssrc, &new_stream);
             if (status) {
                 return status;
             }
 
             /* add new stream to the list */
-            status = srtp_insert_or_dealloc_stream(ctx -> stream_list, new_stream,
-                ctx -> stream_template);
+            status = srtp_insert_or_dealloc_stream(ctx->stream_list, new_stream,
+                                                   ctx->stream_template);
             if (status) {
                 return status;
             }
 
             /* set direction to outbound */
-            new_stream -> direction = dir_srtp_sender;
+            new_stream->direction = dir_srtp_sender;
 
             /* set stream (the pointer used in this function) */
             stream = new_stream;
@@ -2251,15 +2271,15 @@ srtp_err_status_t srtp_protect(srtp_t ctx,
      * those functions.
      */
 
-    if (stream -> direction != dir_srtp_sender) {
-        if (stream -> direction == dir_unknown) {
-            stream -> direction = dir_srtp_sender;
+    if (stream->direction != dir_srtp_sender) {
+        if (stream->direction == dir_unknown) {
+            stream->direction = dir_srtp_sender;
         } else {
             srtp_handle_event(ctx, stream, event_ssrc_collision);
         }
     }
 
-    status = srtp_get_session_keys(stream, mki_index, & session_keys);
+    status = srtp_get_session_keys(stream, mki_index, &session_keys);
     if (status) {
         return status;
     }
@@ -2268,10 +2288,10 @@ srtp_err_status_t srtp_protect(srtp_t ctx,
      * Check if this is an AEAD stream (GCM mode).  If so, then dispatch
      * the request to our AEAD handler.
      */
-    if (session_keys -> rtp_cipher -> algorithm == SRTP_AES_GCM_128 ||
-        session_keys -> rtp_cipher -> algorithm == SRTP_AES_GCM_256) {
+    if (session_keys->rtp_cipher->algorithm == SRTP_AES_GCM_128 ||
+        session_keys->rtp_cipher->algorithm == SRTP_AES_GCM_256) {
         return srtp_protect_aead(ctx, stream, rtp, rtp_len, srtp, srtp_len,
-            session_keys);
+                                 session_keys);
     }
 
     /*
@@ -2279,7 +2299,7 @@ srtp_err_status_t srtp_protect(srtp_t ctx,
      * didn't just hit either the soft limit or the hard limit, and call
      * the event handler if we hit either.
      */
-    switch (srtp_key_limit_update(session_keys -> limit)) {
+    switch (srtp_key_limit_update(session_keys->limit)) {
     case srtp_key_event_normal:
         break;
     case srtp_key_event_soft_limit:
@@ -2293,7 +2313,7 @@ srtp_err_status_t srtp_protect(srtp_t ctx,
     }
 
     /* get tag length from stream */
-    tag_len = srtp_auth_get_tag_length(session_keys -> rtp_auth);
+    tag_len = srtp_auth_get_tag_length(session_keys->rtp_auth);
 
     /*
      * find starting point for encryption and length of data to be
@@ -2302,7 +2322,7 @@ srtp_err_status_t srtp_protect(srtp_t ctx,
      * if any are present
      */
     enc_start = srtp_get_rtp_hdr_len(hdr);
-    if (hdr -> x == 1) {
+    if (hdr->x == 1) {
         enc_start += srtp_get_rtp_xtn_hdr_len(hdr, rtp);
     }
 
@@ -2312,7 +2332,7 @@ srtp_err_status_t srtp_protect(srtp_t ctx,
     enc_octet_len = rtp_len - enc_start;
 
     /* check output length */
-    if ( * srtp_len < rtp_len + stream -> mki_size + tag_len) {
+    if (*srtp_len < rtp_len + stream->mki_size + tag_len) {
         return srtp_err_status_buffer_small;
     }
 
@@ -2321,8 +2341,8 @@ srtp_err_status_t srtp_protect(srtp_t ctx,
         memcpy(srtp, rtp, enc_start);
     }
 
-    if (stream -> use_mki) {
-        srtp_inject_mki(srtp + rtp_len, session_keys, stream -> mki_size);
+    if (stream->use_mki) {
+        srtp_inject_mki(srtp + rtp_len, session_keys, stream->mki_size);
     }
 
     /*
@@ -2330,9 +2350,9 @@ srtp_err_status_t srtp_protect(srtp_t ctx,
      * pointers to the proper locations; otherwise, set auth_start to NULL
      * to indicate that no authentication is needed
      */
-    if (stream -> rtp_services & sec_serv_auth) {
+    if (stream->rtp_services & sec_serv_auth) {
         auth_start = srtp;
-        auth_tag = srtp + rtp_len + stream -> mki_size;
+        auth_tag = srtp + rtp_len + stream->mki_size;
     } else {
         auth_start = NULL;
         auth_tag = NULL;
@@ -2342,46 +2362,45 @@ srtp_err_status_t srtp_protect(srtp_t ctx,
      * estimate the packet index using the start of the replay window
      * and the sequence number from the header
      */
-    status = srtp_get_est_pkt_index(hdr, stream, & est, & delta);
+    status = srtp_get_est_pkt_index(hdr, stream, &est, &delta);
 
     if (status && (status != srtp_err_status_pkt_idx_adv)) {
         return status;
     }
 
     if (status == srtp_err_status_pkt_idx_adv) {
-        srtp_rdbx_set_roc_seq( & stream -> rtp_rdbx, (uint32_t)(est >> 16),
-            (uint16_t)(est & 0xFFFF));
-        stream -> pending_roc = 0;
-        srtp_rdbx_add_index( & stream -> rtp_rdbx, 0);
+        srtp_rdbx_set_roc_seq(&stream->rtp_rdbx, (uint32_t)(est >> 16),
+                              (uint16_t)(est & 0xFFFF));
+        stream->pending_roc = 0;
+        srtp_rdbx_add_index(&stream->rtp_rdbx, 0);
     } else {
-        status = srtp_rdbx_check( & stream -> rtp_rdbx, delta);
+        status = srtp_rdbx_check(&stream->rtp_rdbx, delta);
         if (status) {
             if (status != srtp_err_status_replay_fail ||
-                !stream -> allow_repeat_tx)
+                !stream->allow_repeat_tx)
                 return status; /* we've been asked to reuse an index */
         }
-        srtp_rdbx_add_index( & stream -> rtp_rdbx, delta);
+        srtp_rdbx_add_index(&stream->rtp_rdbx, delta);
     }
 
-    debug_print(mod_srtp, "estimated packet index: %016"
-        PRIx64, est);
+    debug_print(mod_srtp, "estimated packet index: %016" PRIx64, est);
 
     /*
      * if we're using rindael counter mode, set nonce and seq
      */
-    if (session_keys -> rtp_cipher -> type -> id == SRTP_AES_ICM_128 ||
-        session_keys -> rtp_cipher -> type -> id == SRTP_AES_ICM_192 ||
-        session_keys -> rtp_cipher -> type -> id == SRTP_AES_ICM_256) {
+    if (session_keys->rtp_cipher->type->id == SRTP_AES_ICM_128 ||
+        session_keys->rtp_cipher->type->id == SRTP_AES_ICM_192 ||
+        session_keys->rtp_cipher->type->id == SRTP_AES_ICM_256) {
         v128_t iv;
 
         iv.v32[0] = 0;
-        iv.v32[1] = hdr -> ssrc;
+        iv.v32[1] = hdr->ssrc;
         iv.v64[1] = be64_to_cpu(est << 16);
-        status = srtp_cipher_set_iv(session_keys -> rtp_cipher, (uint8_t * ) & iv,
-            srtp_direction_encrypt);
-        if (!status && session_keys -> rtp_xtn_hdr_cipher) {
-            status = srtp_cipher_set_iv(session_keys -> rtp_xtn_hdr_cipher,
-                (uint8_t * ) & iv, srtp_direction_encrypt);
+        status = srtp_cipher_set_iv(session_keys->rtp_cipher, (uint8_t *)&iv,
+                                    srtp_direction_encrypt);
+        if (!status && session_keys->rtp_xtn_hdr_cipher) {
+            status = srtp_cipher_set_iv(session_keys->rtp_xtn_hdr_cipher,
+                                        (uint8_t *)&iv, srtp_direction_encrypt);
         }
     } else {
         v128_t iv;
@@ -2389,11 +2408,11 @@ srtp_err_status_t srtp_protect(srtp_t ctx,
         /* otherwise, set the index to est */
         iv.v64[0] = 0;
         iv.v64[1] = be64_to_cpu(est);
-        status = srtp_cipher_set_iv(session_keys -> rtp_cipher, (uint8_t * ) & iv,
-            srtp_direction_encrypt);
-        if (!status && session_keys -> rtp_xtn_hdr_cipher) {
-            status = srtp_cipher_set_iv(session_keys -> rtp_xtn_hdr_cipher,
-                (uint8_t * ) & iv, srtp_direction_encrypt);
+        status = srtp_cipher_set_iv(session_keys->rtp_cipher, (uint8_t *)&iv,
+                                    srtp_direction_encrypt);
+        if (!status && session_keys->rtp_xtn_hdr_cipher) {
+            status = srtp_cipher_set_iv(session_keys->rtp_xtn_hdr_cipher,
+                                        (uint8_t *)&iv, srtp_direction_encrypt);
         }
     }
     if (status) {
@@ -2408,19 +2427,19 @@ srtp_err_status_t srtp_protect(srtp_t ctx,
      * prefix into the authentication tag
      */
     if (auth_start) {
-        prefix_len = srtp_auth_get_prefix_length(session_keys -> rtp_auth);
+        prefix_len = srtp_auth_get_prefix_length(session_keys->rtp_auth);
         if (prefix_len) {
-            status = srtp_cipher_output(session_keys -> rtp_cipher, auth_tag, &
-                prefix_len);
+            status = srtp_cipher_output(session_keys->rtp_cipher, auth_tag,
+                                        &prefix_len);
             if (status) {
                 return srtp_err_status_cipher_fail;
             }
             debug_print(mod_srtp, "keystream prefix: %s",
-                srtp_octet_string_hex_string(auth_tag, prefix_len));
+                        srtp_octet_string_hex_string(auth_tag, prefix_len));
         }
     }
 
-    if (hdr -> x == 1 && session_keys -> rtp_xtn_hdr_cipher) {
+    if (hdr->x == 1 && session_keys->rtp_xtn_hdr_cipher) {
         /*
          * extensions header encryption RFC 6904
          */
@@ -2432,10 +2451,10 @@ srtp_err_status_t srtp_protect(srtp_t ctx,
     }
 
     /* if we're encrypting, exor keystream into the message */
-    if (stream -> rtp_services & sec_serv_conf) {
-        status = srtp_cipher_encrypt(session_keys -> rtp_cipher, rtp + enc_start,
-            enc_octet_len, srtp + enc_start, &
-            enc_octet_len);
+    if (stream->rtp_services & sec_serv_conf) {
+        status = srtp_cipher_encrypt(session_keys->rtp_cipher, rtp + enc_start,
+                                     enc_octet_len, srtp + enc_start,
+                                     &enc_octet_len);
         if (status) {
             return srtp_err_status_cipher_fail;
         }
@@ -2450,58 +2469,58 @@ srtp_err_status_t srtp_protect(srtp_t ctx,
      */
     if (auth_start) {
         /* initialize auth func context */
-        status = srtp_auth_start(session_keys -> rtp_auth);
+        status = srtp_auth_start(session_keys->rtp_auth);
         if (status) {
             return status;
         }
 
         /* run auth func over packet */
-        status = srtp_auth_update(session_keys -> rtp_auth, auth_start, rtp_len);
+        status = srtp_auth_update(session_keys->rtp_auth, auth_start, rtp_len);
         if (status) {
             return status;
         }
 
         /* run auth func over ROC, put result into auth_tag */
-        debug_print(mod_srtp, "estimated packet index: %016"
-            PRIx64, est);
-        status = srtp_auth_compute(session_keys -> rtp_auth, (uint8_t * ) & est, 4,
-            auth_tag);
+        debug_print(mod_srtp, "estimated packet index: %016" PRIx64, est);
+        status = srtp_auth_compute(session_keys->rtp_auth, (uint8_t *)&est, 4,
+                                   auth_tag);
         debug_print(mod_srtp, "srtp auth tag:    %s",
-            srtp_octet_string_hex_string(auth_tag, tag_len));
+                    srtp_octet_string_hex_string(auth_tag, tag_len));
         if (status) {
             return status;
         }
     }
 
-    * srtp_len = enc_start + enc_octet_len;
+    *srtp_len = enc_start + enc_octet_len;
 
     /* increase the packet length by the length of the auth tag */
-    * srtp_len += tag_len;
+    *srtp_len += tag_len;
 
     /* increate the packet length by the mki size if used */
-    * srtp_len += stream -> mki_size;
+    *srtp_len += stream->mki_size;
 
     return srtp_err_status_ok;
 }
 
 srtp_err_status_t srtp_unprotect(srtp_t ctx,
-    const uint8_t * srtp,
-        size_t srtp_len,
-        uint8_t * rtp,
-        size_t * rtp_len) {
-    const srtp_hdr_t * hdr = (const srtp_hdr_t * ) srtp;
-    size_t enc_start; /* pointer to start of encrypted portion  */
-    const uint8_t * auth_start; /* pointer to start of auth. portion      */
-    size_t enc_octet_len = 0; /* number of octets in encrypted portion  */
-    const uint8_t * auth_tag = NULL; /* location of auth_tag within packet     */
-    srtp_xtd_seq_num_t est; /* estimated xtd_seq_num_t of *hdr        */
-    ssize_t delta; /* delta of local pkt idx and that in hdr */
+                                 const uint8_t *srtp,
+                                 size_t srtp_len,
+                                 uint8_t *rtp,
+                                 size_t *rtp_len)
+{
+    const srtp_hdr_t *hdr = (const srtp_hdr_t *)srtp;
+    size_t enc_start;               /* pointer to start of encrypted portion  */
+    const uint8_t *auth_start;      /* pointer to start of auth. portion      */
+    size_t enc_octet_len = 0;       /* number of octets in encrypted portion  */
+    const uint8_t *auth_tag = NULL; /* location of auth_tag within packet     */
+    srtp_xtd_seq_num_t est;         /* estimated xtd_seq_num_t of *hdr        */
+    ssize_t delta;                  /* delta of local pkt idx and that in hdr */
     v128_t iv;
     srtp_err_status_t status;
-    srtp_stream_ctx_t * stream;
+    srtp_stream_ctx_t *stream;
     uint8_t tmp_tag[SRTP_MAX_TAG_LEN];
     size_t tag_len, prefix_len;
-    srtp_session_keys_t * session_keys = NULL;
+    srtp_session_keys_t *session_keys = NULL;
     bool advance_packet_index = false;
     uint32_t roc_to_set = 0;
     uint16_t seq_to_set = 0;
@@ -2526,19 +2545,19 @@ srtp_err_status_t srtp_unprotect(srtp_t ctx,
      * supports key-sharing, then we assume that a new stream using
      * that key has just started up
      */
-    stream = srtp_get_stream(ctx, hdr -> ssrc);
+    stream = srtp_get_stream(ctx, hdr->ssrc);
     if (stream == NULL) {
-        if (ctx -> stream_template != NULL) {
-            stream = ctx -> stream_template;
+        if (ctx->stream_template != NULL) {
+            stream = ctx->stream_template;
             debug_print(mod_srtp, "using provisional stream (SSRC: 0x%08x)",
-                (unsigned int) ntohl(hdr -> ssrc));
+                        (unsigned int)ntohl(hdr->ssrc));
 
             /*
              * set estimated packet index to sequence number from header,
              * and set delta equal to the same value
              */
-            est = (srtp_xtd_seq_num_t) ntohs(hdr -> seq);
-            delta = (int) est;
+            est = (srtp_xtd_seq_num_t)ntohs(hdr->seq);
+            delta = (int)est;
         } else {
             /*
              * no stream corresponding to SSRC found, and we don't do
@@ -2547,7 +2566,7 @@ srtp_err_status_t srtp_unprotect(srtp_t ctx,
             return srtp_err_status_no_ctx;
         }
     } else {
-        status = srtp_get_est_pkt_index(hdr, stream, & est, & delta);
+        status = srtp_get_est_pkt_index(hdr, stream, &est, &delta);
 
         if (status && (status != srtp_err_status_pkt_idx_adv)) {
             return status;
@@ -2561,19 +2580,18 @@ srtp_err_status_t srtp_unprotect(srtp_t ctx,
 
         /* check replay database */
         if (!advance_packet_index) {
-            status = srtp_rdbx_check( & stream -> rtp_rdbx, delta);
+            status = srtp_rdbx_check(&stream->rtp_rdbx, delta);
             if (status) {
                 return status;
             }
         }
     }
 
-    debug_print(mod_srtp, "estimated u_packet index: %016"
-        PRIx64, est);
+    debug_print(mod_srtp, "estimated u_packet index: %016" PRIx64, est);
 
     /* Determine if MKI is being used and what session keys should be used */
     status =
-        srtp_get_session_keys_for_packet(stream, srtp, srtp_len, & session_keys);
+        srtp_get_session_keys_for_packet(stream, srtp, srtp_len, &session_keys);
     if (status) {
         return status;
     }
@@ -2582,41 +2600,41 @@ srtp_err_status_t srtp_unprotect(srtp_t ctx,
      * Check if this is an AEAD stream (GCM mode).  If so, then dispatch
      * the request to our AEAD handler.
      */
-    if (session_keys -> rtp_cipher -> algorithm == SRTP_AES_GCM_128 ||
-        session_keys -> rtp_cipher -> algorithm == SRTP_AES_GCM_256) {
+    if (session_keys->rtp_cipher->algorithm == SRTP_AES_GCM_128 ||
+        session_keys->rtp_cipher->algorithm == SRTP_AES_GCM_256) {
         return srtp_unprotect_aead(ctx, stream, delta, est, srtp, srtp_len, rtp,
-            rtp_len, session_keys, advance_packet_index);
+                                   rtp_len, session_keys, advance_packet_index);
     }
 
     /* get tag length from stream */
-    tag_len = srtp_auth_get_tag_length(session_keys -> rtp_auth);
+    tag_len = srtp_auth_get_tag_length(session_keys->rtp_auth);
 
     /*
      * set the cipher's IV properly, depending on whatever cipher we
      * happen to be using
      */
-    if (session_keys -> rtp_cipher -> type -> id == SRTP_AES_ICM_128 ||
-        session_keys -> rtp_cipher -> type -> id == SRTP_AES_ICM_192 ||
-        session_keys -> rtp_cipher -> type -> id == SRTP_AES_ICM_256) {
+    if (session_keys->rtp_cipher->type->id == SRTP_AES_ICM_128 ||
+        session_keys->rtp_cipher->type->id == SRTP_AES_ICM_192 ||
+        session_keys->rtp_cipher->type->id == SRTP_AES_ICM_256) {
         /* aes counter mode */
         iv.v32[0] = 0;
-        iv.v32[1] = hdr -> ssrc; /* still in network order */
+        iv.v32[1] = hdr->ssrc; /* still in network order */
         iv.v64[1] = be64_to_cpu(est << 16);
-        status = srtp_cipher_set_iv(session_keys -> rtp_cipher, (uint8_t * ) & iv,
-            srtp_direction_decrypt);
-        if (!status && session_keys -> rtp_xtn_hdr_cipher) {
-            status = srtp_cipher_set_iv(session_keys -> rtp_xtn_hdr_cipher,
-                (uint8_t * ) & iv, srtp_direction_decrypt);
+        status = srtp_cipher_set_iv(session_keys->rtp_cipher, (uint8_t *)&iv,
+                                    srtp_direction_decrypt);
+        if (!status && session_keys->rtp_xtn_hdr_cipher) {
+            status = srtp_cipher_set_iv(session_keys->rtp_xtn_hdr_cipher,
+                                        (uint8_t *)&iv, srtp_direction_decrypt);
         }
     } else {
         /* no particular format - set the iv to the packet index */
         iv.v64[0] = 0;
         iv.v64[1] = be64_to_cpu(est);
-        status = srtp_cipher_set_iv(session_keys -> rtp_cipher, (uint8_t * ) & iv,
-            srtp_direction_decrypt);
-        if (!status && session_keys -> rtp_xtn_hdr_cipher) {
-            status = srtp_cipher_set_iv(session_keys -> rtp_xtn_hdr_cipher,
-                (uint8_t * ) & iv, srtp_direction_decrypt);
+        status = srtp_cipher_set_iv(session_keys->rtp_cipher, (uint8_t *)&iv,
+                                    srtp_direction_decrypt);
+        if (!status && session_keys->rtp_xtn_hdr_cipher) {
+            status = srtp_cipher_set_iv(session_keys->rtp_xtn_hdr_cipher,
+                                        (uint8_t *)&iv, srtp_direction_decrypt);
         }
     }
     if (status) {
@@ -2627,17 +2645,17 @@ srtp_err_status_t srtp_unprotect(srtp_t ctx,
     est = be64_to_cpu(est << 16);
 
     enc_start = srtp_get_rtp_hdr_len(hdr);
-    if (hdr -> x == 1) {
+    if (hdr->x == 1) {
         enc_start += srtp_get_rtp_xtn_hdr_len(hdr, srtp);
     }
 
-    if (enc_start > srtp_len - tag_len - stream -> mki_size) {
+    if (enc_start > srtp_len - tag_len - stream->mki_size) {
         return srtp_err_status_parse_err;
     }
-    enc_octet_len = srtp_len - enc_start - stream -> mki_size - tag_len;
+    enc_octet_len = srtp_len - enc_start - stream->mki_size - tag_len;
 
     /* check output length */
-    if ( * rtp_len < srtp_len - stream -> mki_size - tag_len) {
+    if (*rtp_len < srtp_len - stream->mki_size - tag_len) {
         return srtp_err_status_buffer_small;
     }
 
@@ -2651,7 +2669,7 @@ srtp_err_status_t srtp_unprotect(srtp_t ctx,
      * pointers to the proper locations; otherwise, set auth_start to NULL
      * to indicate that no authentication is needed
      */
-    if (stream -> rtp_services & sec_serv_auth) {
+    if (stream->rtp_services & sec_serv_auth) {
         auth_start = srtp;
         auth_tag = srtp + srtp_len - tag_len;
     } else {
@@ -2671,38 +2689,38 @@ srtp_err_status_t srtp_unprotect(srtp_t ctx,
          * if the keystream prefix length is zero, then we know that
          * the authenticator isn't using a universal hash function
          */
-        if (session_keys -> rtp_auth -> prefix_len != 0) {
-            prefix_len = srtp_auth_get_prefix_length(session_keys -> rtp_auth);
-            status = srtp_cipher_output(session_keys -> rtp_cipher, tmp_tag, &
-                prefix_len);
+        if (session_keys->rtp_auth->prefix_len != 0) {
+            prefix_len = srtp_auth_get_prefix_length(session_keys->rtp_auth);
+            status = srtp_cipher_output(session_keys->rtp_cipher, tmp_tag,
+                                        &prefix_len);
             debug_print(mod_srtp, "keystream prefix: %s",
-                srtp_octet_string_hex_string(tmp_tag, prefix_len));
+                        srtp_octet_string_hex_string(tmp_tag, prefix_len));
             if (status) {
                 return srtp_err_status_cipher_fail;
             }
         }
 
         /* initialize auth func context */
-        status = srtp_auth_start(session_keys -> rtp_auth);
+        status = srtp_auth_start(session_keys->rtp_auth);
         if (status) {
             return status;
         }
 
         /* now compute auth function over packet */
-        status = srtp_auth_update(session_keys -> rtp_auth, auth_start,
-            srtp_len - tag_len - stream -> mki_size);
+        status = srtp_auth_update(session_keys->rtp_auth, auth_start,
+                                  srtp_len - tag_len - stream->mki_size);
         if (status) {
             return status;
         }
 
         /* run auth func over ROC, then write tmp tag */
-        status = srtp_auth_compute(session_keys -> rtp_auth, (uint8_t * ) & est, 4,
-            tmp_tag);
+        status = srtp_auth_compute(session_keys->rtp_auth, (uint8_t *)&est, 4,
+                                   tmp_tag);
 
         debug_print(mod_srtp, "computed auth tag:    %s",
-            srtp_octet_string_hex_string(tmp_tag, tag_len));
+                    srtp_octet_string_hex_string(tmp_tag, tag_len));
         debug_print(mod_srtp, "packet auth tag:      %s",
-            srtp_octet_string_hex_string(auth_tag, tag_len));
+                    srtp_octet_string_hex_string(auth_tag, tag_len));
         if (status) {
             return srtp_err_status_auth_fail;
         }
@@ -2717,7 +2735,7 @@ srtp_err_status_t srtp_unprotect(srtp_t ctx,
      * didn't just hit either the soft limit or the hard limit, and call
      * the event handler if we hit either.
      */
-    switch (srtp_key_limit_update(session_keys -> limit)) {
+    switch (srtp_key_limit_update(session_keys->limit)) {
     case srtp_key_event_normal:
         break;
     case srtp_key_event_soft_limit:
@@ -2730,7 +2748,7 @@ srtp_err_status_t srtp_unprotect(srtp_t ctx,
         break;
     }
 
-    if (hdr -> x == 1 && session_keys -> rtp_xtn_hdr_cipher) {
+    if (hdr->x == 1 && session_keys->rtp_xtn_hdr_cipher) {
         /* extensions header encryption RFC 6904 */
         status = srtp_process_header_encryption(
             stream, srtp_get_rtp_xtn_hdr(hdr, rtp), session_keys);
@@ -2740,10 +2758,10 @@ srtp_err_status_t srtp_unprotect(srtp_t ctx,
     }
 
     /* if we're decrypting, add keystream into ciphertext */
-    if (stream -> rtp_services & sec_serv_conf) {
+    if (stream->rtp_services & sec_serv_conf) {
         status =
-            srtp_cipher_decrypt(session_keys -> rtp_cipher, srtp + enc_start,
-                enc_octet_len, rtp + enc_start, & enc_octet_len);
+            srtp_cipher_decrypt(session_keys->rtp_cipher, srtp + enc_start,
+                                enc_octet_len, rtp + enc_start, &enc_octet_len);
         if (status) {
             return srtp_err_status_cipher_fail;
         }
@@ -2762,9 +2780,9 @@ srtp_err_status_t srtp_unprotect(srtp_t ctx,
      * latter check will catch any attempts to fool us into thinking
      * that we've got a collision
      */
-    if (stream -> direction != dir_srtp_receiver) {
-        if (stream -> direction == dir_unknown) {
-            stream -> direction = dir_srtp_receiver;
+    if (stream->direction != dir_srtp_receiver) {
+        if (stream->direction == dir_unknown) {
+            stream->direction = dir_srtp_receiver;
         } else {
             srtp_handle_event(ctx, stream, event_ssrc_collision);
         }
@@ -2775,8 +2793,8 @@ srtp_err_status_t srtp_unprotect(srtp_t ctx,
      * is used, then we need to allocate a new stream at this point, since
      * the authentication passed
      */
-    if (stream == ctx -> stream_template) {
-        srtp_stream_ctx_t * new_stream;
+    if (stream == ctx->stream_template) {
+        srtp_stream_ctx_t *new_stream;
 
         /*
          * allocate and initialize a new stream
@@ -2786,14 +2804,14 @@ srtp_err_status_t srtp_unprotect(srtp_t ctx,
          * failure here
          */
         status =
-            srtp_stream_clone(ctx -> stream_template, hdr -> ssrc, & new_stream);
+            srtp_stream_clone(ctx->stream_template, hdr->ssrc, &new_stream);
         if (status) {
             return status;
         }
 
         /* add new stream to the list */
-        status = srtp_insert_or_dealloc_stream(ctx -> stream_list, new_stream,
-            ctx -> stream_template);
+        status = srtp_insert_or_dealloc_stream(ctx->stream_list, new_stream,
+                                               ctx->stream_template);
         if (status) {
             return status;
         }
@@ -2807,19 +2825,20 @@ srtp_err_status_t srtp_unprotect(srtp_t ctx,
      * index into the replay database
      */
     if (advance_packet_index) {
-        srtp_rdbx_set_roc_seq( & stream -> rtp_rdbx, roc_to_set, seq_to_set);
-        stream -> pending_roc = 0;
-        srtp_rdbx_add_index( & stream -> rtp_rdbx, 0);
+        srtp_rdbx_set_roc_seq(&stream->rtp_rdbx, roc_to_set, seq_to_set);
+        stream->pending_roc = 0;
+        srtp_rdbx_add_index(&stream->rtp_rdbx, 0);
     } else {
-        srtp_rdbx_add_index( & stream -> rtp_rdbx, delta);
+        srtp_rdbx_add_index(&stream->rtp_rdbx, delta);
     }
 
-    * rtp_len = enc_start + enc_octet_len;
+    *rtp_len = enc_start + enc_octet_len;
 
     return srtp_err_status_ok;
 }
 
-srtp_err_status_t srtp_init(void) {
+srtp_err_status_t srtp_init(void)
+{
     srtp_err_status_t status;
 
     /* initialize crypto kernel */
@@ -2829,7 +2848,7 @@ srtp_err_status_t srtp_init(void) {
     }
 
     /* load srtp debug module into the kernel */
-    status = srtp_crypto_kernel_load_debug_module( & mod_srtp);
+    status = srtp_crypto_kernel_load_debug_module(&mod_srtp);
     if (status) {
         return status;
     }
@@ -2837,7 +2856,8 @@ srtp_err_status_t srtp_init(void) {
     return srtp_err_status_ok;
 }
 
-srtp_err_status_t srtp_shutdown(void) {
+srtp_err_status_t srtp_shutdown(void)
+{
     srtp_err_status_t status;
 
     /* shut down crypto kernel */
@@ -2851,11 +2871,13 @@ srtp_err_status_t srtp_shutdown(void) {
     return srtp_err_status_ok;
 }
 
-srtp_stream_ctx_t * srtp_get_stream(srtp_t srtp, uint32_t ssrc) {
-    return srtp_stream_list_get(srtp -> stream_list, ssrc);
+srtp_stream_ctx_t *srtp_get_stream(srtp_t srtp, uint32_t ssrc)
+{
+    return srtp_stream_list_get(srtp->stream_list, ssrc);
 }
 
-srtp_err_status_t srtp_dealloc(srtp_t session) {
+srtp_err_status_t srtp_dealloc(srtp_t session)
+{
     srtp_err_status_t status;
 
     /*
@@ -2865,22 +2887,22 @@ srtp_err_status_t srtp_dealloc(srtp_t session) {
      */
 
     /* deallocate streams */
-    status = srtp_remove_and_dealloc_streams(session -> stream_list,
-        session -> stream_template);
+    status = srtp_remove_and_dealloc_streams(session->stream_list,
+                                             session->stream_template);
     if (status) {
         return status;
     }
 
     /* deallocate stream template, if there is one */
-    if (session -> stream_template != NULL) {
-        status = srtp_stream_dealloc(session -> stream_template, NULL);
+    if (session->stream_template != NULL) {
+        status = srtp_stream_dealloc(session->stream_template, NULL);
         if (status) {
             return status;
         }
     }
 
     /* deallocate stream list */
-    status = srtp_stream_list_dealloc(session -> stream_list);
+    status = srtp_stream_list_dealloc(session->stream_list);
     if (status) {
         return status;
     }
@@ -2891,8 +2913,8 @@ srtp_err_status_t srtp_dealloc(srtp_t session) {
     return srtp_err_status_ok;
 }
 
-srtp_err_status_t srtp_stream_add(srtp_t session,
-    const srtp_policy_t * policy) {
+srtp_err_status_t srtp_stream_add(srtp_t session, const srtp_policy_t *policy)
+{
     srtp_err_status_t status;
     srtp_stream_t tmp;
 
@@ -2907,7 +2929,7 @@ srtp_err_status_t srtp_stream_add(srtp_t session,
     }
 
     /* allocate stream  */
-    status = srtp_stream_alloc( & tmp, policy);
+    status = srtp_stream_alloc(&tmp, policy);
     if (status) {
         return status;
     }
@@ -2927,26 +2949,26 @@ srtp_err_status_t srtp_stream_add(srtp_t session,
      * if the template stream has already been set, then the policy is
      * inconsistent, so we return a bad_param error code
      */
-    switch (policy -> ssrc.type) {
+    switch (policy->ssrc.type) {
     case (ssrc_any_outbound):
-        if (session -> stream_template) {
+        if (session->stream_template) {
             srtp_stream_dealloc(tmp, NULL);
             return srtp_err_status_bad_param;
         }
-        session -> stream_template = tmp;
-        session -> stream_template -> direction = dir_srtp_sender;
+        session->stream_template = tmp;
+        session->stream_template->direction = dir_srtp_sender;
         break;
     case (ssrc_any_inbound):
-        if (session -> stream_template) {
+        if (session->stream_template) {
             srtp_stream_dealloc(tmp, NULL);
             return srtp_err_status_bad_param;
         }
-        session -> stream_template = tmp;
-        session -> stream_template -> direction = dir_srtp_receiver;
+        session->stream_template = tmp;
+        session->stream_template->direction = dir_srtp_receiver;
         break;
     case (ssrc_specific):
-        status = srtp_insert_or_dealloc_stream(session -> stream_list, tmp,
-            session -> stream_template);
+        status = srtp_insert_or_dealloc_stream(session->stream_list, tmp,
+                                               session->stream_template);
         if (status) {
             return status;
         }
@@ -2960,11 +2982,11 @@ srtp_err_status_t srtp_stream_add(srtp_t session,
     return srtp_err_status_ok;
 }
 
-srtp_err_status_t srtp_create(srtp_t * session, /* handle for session     */
-    const srtp_policy_t * policy) {
-    /* SRTP policy (list)     */
+srtp_err_status_t srtp_create(srtp_t *session, /* handle for session     */
+                              const srtp_policy_t *policy)
+{ /* SRTP policy (list)     */
     srtp_err_status_t stat;
-    srtp_ctx_t * ctx;
+    srtp_ctx_t *ctx;
 
     /* sanity check arguments */
     if (session == NULL) {
@@ -2979,22 +3001,22 @@ srtp_err_status_t srtp_create(srtp_t * session, /* handle for session     */
     }
 
     /* allocate srtp context and set ctx_ptr */
-    ctx = (srtp_ctx_t * ) srtp_crypto_alloc(sizeof(srtp_ctx_t));
+    ctx = (srtp_ctx_t *)srtp_crypto_alloc(sizeof(srtp_ctx_t));
     if (ctx == NULL) {
         return srtp_err_status_alloc_fail;
     }
-    * session = ctx;
+    *session = ctx;
 
-    ctx -> stream_template = NULL;
-    ctx -> stream_list = NULL;
-    ctx -> user_data = NULL;
+    ctx->stream_template = NULL;
+    ctx->stream_list = NULL;
+    ctx->user_data = NULL;
 
     /* allocate stream list */
-    stat = srtp_stream_list_alloc( & ctx -> stream_list);
+    stat = srtp_stream_list_alloc(&ctx->stream_list);
     if (stat) {
         /* clean up everything */
-        srtp_dealloc( * session);
-        * session = NULL;
+        srtp_dealloc(*session);
+        *session = NULL;
         return stat;
     }
 
@@ -3006,20 +3028,21 @@ srtp_err_status_t srtp_create(srtp_t * session, /* handle for session     */
         stat = srtp_stream_add(ctx, policy);
         if (stat) {
             /* clean up everything */
-            srtp_dealloc( * session);
-            * session = NULL;
+            srtp_dealloc(*session);
+            *session = NULL;
             return stat;
         }
 
         /* set policy to next item in list  */
-        policy = policy -> next;
+        policy = policy->next;
     }
 
     return srtp_err_status_ok;
 }
 
-srtp_err_status_t srtp_stream_remove(srtp_t session, uint32_t ssrc) {
-    srtp_stream_ctx_t * stream;
+srtp_err_status_t srtp_stream_remove(srtp_t session, uint32_t ssrc)
+{
+    srtp_stream_ctx_t *stream;
     srtp_err_status_t status;
 
     /* sanity check arguments */
@@ -3028,15 +3051,15 @@ srtp_err_status_t srtp_stream_remove(srtp_t session, uint32_t ssrc) {
     }
 
     /* find and remove stream from the list */
-    stream = srtp_stream_list_get(session -> stream_list, htonl(ssrc));
+    stream = srtp_stream_list_get(session->stream_list, htonl(ssrc));
     if (stream == NULL) {
         return srtp_err_status_no_ctx;
     }
 
-    srtp_stream_list_remove(session -> stream_list, stream);
+    srtp_stream_list_remove(session->stream_list, stream);
 
     /* deallocate the stream */
-    status = srtp_stream_dealloc(stream, session -> stream_template);
+    status = srtp_stream_dealloc(stream, session->stream_template);
     if (status) {
         return status;
     }
@@ -3044,8 +3067,8 @@ srtp_err_status_t srtp_stream_remove(srtp_t session, uint32_t ssrc) {
     return srtp_err_status_ok;
 }
 
-srtp_err_status_t srtp_update(srtp_t session,
-    const srtp_policy_t * policy) {
+srtp_err_status_t srtp_update(srtp_t session, const srtp_policy_t *policy)
+{
     srtp_err_status_t stat;
 
     /* sanity check arguments */
@@ -3065,7 +3088,7 @@ srtp_err_status_t srtp_update(srtp_t session,
         }
 
         /* set policy to next item in list  */
-        policy = policy -> next;
+        policy = policy->next;
     }
     return srtp_err_status_ok;
 }
@@ -3077,64 +3100,66 @@ struct update_template_stream_data {
     srtp_stream_list_t new_stream_list;
 };
 
-static bool update_template_stream_cb(srtp_stream_t stream, void * raw_data) {
-    struct update_template_stream_data * data =
-        (struct update_template_stream_data * ) raw_data;
-    srtp_t session = data -> session;
-    uint32_t ssrc = stream -> ssrc;
+static bool update_template_stream_cb(srtp_stream_t stream, void *raw_data)
+{
+    struct update_template_stream_data *data =
+        (struct update_template_stream_data *)raw_data;
+    srtp_t session = data->session;
+    uint32_t ssrc = stream->ssrc;
     srtp_xtd_seq_num_t old_index;
     srtp_rdb_t old_rtcp_rdb;
 
     /* old / non-template streams are copied unchanged */
-    if (stream -> session_keys[0].rtp_auth !=
-        session -> stream_template -> session_keys[0].rtp_auth) {
-        srtp_stream_list_remove(session -> stream_list, stream);
-        data -> status = srtp_insert_or_dealloc_stream(
-            data -> new_stream_list, stream, session -> stream_template);
-        if (data -> status) {
+    if (stream->session_keys[0].rtp_auth !=
+        session->stream_template->session_keys[0].rtp_auth) {
+        srtp_stream_list_remove(session->stream_list, stream);
+        data->status = srtp_insert_or_dealloc_stream(
+            data->new_stream_list, stream, session->stream_template);
+        if (data->status) {
             return false;
         }
         return true;
     }
 
     /* save old extended seq */
-    old_index = stream -> rtp_rdbx.index;
-    old_rtcp_rdb = stream -> rtcp_rdb;
+    old_index = stream->rtp_rdbx.index;
+    old_rtcp_rdb = stream->rtcp_rdb;
 
     /* remove stream */
-    data -> status = srtp_stream_remove(session, ntohl(ssrc));
-    if (data -> status) {
+    data->status = srtp_stream_remove(session, ntohl(ssrc));
+    if (data->status) {
         return false;
     }
 
     /* allocate and initialize a new stream */
-    data -> status = srtp_stream_clone(data -> new_stream_template, ssrc, & stream);
-    if (data -> status) {
+    data->status = srtp_stream_clone(data->new_stream_template, ssrc, &stream);
+    if (data->status) {
         return false;
     }
 
     /* add new stream to the head of the new_stream_list */
-    data -> status = srtp_insert_or_dealloc_stream(data -> new_stream_list, stream,
-        data -> new_stream_template);
-    if (data -> status) {
+    data->status = srtp_insert_or_dealloc_stream(data->new_stream_list, stream,
+                                                 data->new_stream_template);
+    if (data->status) {
         return false;
     }
 
     /* restore old extended seq */
-    stream -> rtp_rdbx.index = old_index;
-    stream -> rtcp_rdb = old_rtcp_rdb;
+    stream->rtp_rdbx.index = old_index;
+    stream->rtcp_rdb = old_rtcp_rdb;
 
     return true;
 }
 
 static srtp_err_status_t is_update_policy_compatable(
     srtp_stream_t stream,
-    const srtp_policy_t * policy) {
-    if (stream -> use_mki != policy -> use_mki) {
+    const srtp_policy_t *policy)
+{
+    if (stream->use_mki != policy->use_mki) {
         return srtp_err_status_bad_param;
     }
 
-    if (stream -> use_mki && stream -> mki_size != policy -> mki_size) {
+    if (stream->use_mki && stream->mki_size != policy->mki_size) {
         return srtp_err_status_bad_param;
     }
 
@@ -3142,7 +3167,8 @@ static srtp_err_status_t is_update_policy_compatable(
 }
 
 static srtp_err_status_t update_template_streams(srtp_t session,
-    const srtp_policy_t * policy) {
+                                                 const srtp_policy_t *policy)
+{
     srtp_err_status_t status;
     srtp_stream_t new_stream_template;
     srtp_stream_list_t new_stream_list;
@@ -3152,17 +3178,17 @@ static srtp_err_status_t update_template_streams(srtp_t session,
         return status;
     }
 
-    if (session -> stream_template == NULL) {
+    if (session->stream_template == NULL) {
         return srtp_err_status_bad_param;
     }
 
-    status = is_update_policy_compatable(session -> stream_template, policy);
+    status = is_update_policy_compatable(session->stream_template, policy);
     if (status != srtp_err_status_ok) {
         return status;
     }
 
     /* allocate new template stream  */
-    status = srtp_stream_alloc( & new_stream_template, policy);
+    status = srtp_stream_alloc(&new_stream_template, policy);
     if (status) {
         return status;
     }
@@ -3175,21 +3201,18 @@ static srtp_err_status_t update_template_streams(srtp_t session,
     }
 
     /* allocate new stream list */
-    status = srtp_stream_list_alloc( & new_stream_list);
+    status = srtp_stream_list_alloc(&new_stream_list);
     if (status) {
         srtp_crypto_free(new_stream_template);
         return status;
     }
 
     /* process streams */
-    struct update_template_stream_data data = {
-        srtp_err_status_ok,
-        session,
-        new_stream_template,
-        new_stream_list
-    };
-    srtp_stream_list_for_each(session -> stream_list, update_template_stream_cb, &
-        data);
+    struct update_template_stream_data data = { srtp_err_status_ok, session,
+                                                new_stream_template,
+                                                new_stream_list };
+    srtp_stream_list_for_each(session->stream_list, update_template_stream_cb,
+                              &data);
     if (data.status) {
         /* free new allocations */
         srtp_remove_and_dealloc_streams(new_stream_list, new_stream_template);
@@ -3199,19 +3222,20 @@ static srtp_err_status_t update_template_streams(srtp_t session,
     }
 
     /* dealloc old list / template */
-    srtp_remove_and_dealloc_streams(session -> stream_list,
-        session -> stream_template);
-    srtp_stream_list_dealloc(session -> stream_list);
-    srtp_stream_dealloc(session -> stream_template, NULL);
+    srtp_remove_and_dealloc_streams(session->stream_list,
+                                    session->stream_template);
+    srtp_stream_list_dealloc(session->stream_list);
+    srtp_stream_dealloc(session->stream_template, NULL);
 
     /* set new list / template */
-    session -> stream_template = new_stream_template;
-    session -> stream_list = new_stream_list;
+    session->stream_template = new_stream_template;
+    session->stream_list = new_stream_list;
     return srtp_err_status_ok;
 }
 
 static srtp_err_status_t stream_update(srtp_t session,
-    const srtp_policy_t * policy) {
+                                       const srtp_policy_t *policy)
+{
     srtp_err_status_t status;
     srtp_xtd_seq_num_t old_index;
     srtp_rdb_t old_rtcp_rdb;
@@ -3222,7 +3246,7 @@ static srtp_err_status_t stream_update(srtp_t session,
         return status;
     }
 
-    stream = srtp_get_stream(session, htonl(policy -> ssrc.value));
+    stream = srtp_get_stream(session, htonl(policy->ssrc.value));
     if (stream == NULL) {
         return srtp_err_status_bad_param;
     }
@@ -3233,10 +3257,10 @@ static srtp_err_status_t stream_update(srtp_t session,
     }
 
     /* save old extendard seq */
-    old_index = stream -> rtp_rdbx.index;
-    old_rtcp_rdb = stream -> rtcp_rdb;
+    old_index = stream->rtp_rdbx.index;
+    old_rtcp_rdb = stream->rtcp_rdb;
 
-    status = srtp_stream_remove(session, policy -> ssrc.value);
+    status = srtp_stream_remove(session, policy->ssrc.value);
     if (status) {
         return status;
     }
@@ -3246,20 +3270,21 @@ static srtp_err_status_t stream_update(srtp_t session,
         return status;
     }
 
-    stream = srtp_get_stream(session, htonl(policy -> ssrc.value));
+    stream = srtp_get_stream(session, htonl(policy->ssrc.value));
     if (stream == NULL) {
         return srtp_err_status_fail;
     }
 
     /* restore old extended seq */
-    stream -> rtp_rdbx.index = old_index;
-    stream -> rtcp_rdb = old_rtcp_rdb;
+    stream->rtp_rdbx.index = old_index;
+    stream->rtcp_rdb = old_rtcp_rdb;
 
     return srtp_err_status_ok;
 }
 
 srtp_err_status_t srtp_stream_update(srtp_t session,
-    const srtp_policy_t * policy) {
+                                     const srtp_policy_t *policy)
+{
     srtp_err_status_t status;
 
     /* sanity check arguments */
@@ -3272,7 +3297,7 @@ srtp_err_status_t srtp_stream_update(srtp_t session,
         return status;
     }
 
-    switch (policy -> ssrc.type) {
+    switch (policy->ssrc.type) {
     case (ssrc_any_outbound):
     case (ssrc_any_inbound):
         status = update_template_streams(session, policy);
@@ -3303,188 +3328,202 @@ srtp_err_status_t srtp_stream_update(srtp_t session,
  */
 /* There are hard-coded 16's for base_key_len in the key generation code */
 
-void srtp_crypto_policy_set_rtp_default(srtp_crypto_policy_t * p) {
-    p -> cipher_type = SRTP_AES_ICM_128;
-    p -> cipher_key_len =
+void srtp_crypto_policy_set_rtp_default(srtp_crypto_policy_t *p)
+{
+    p->cipher_type = SRTP_AES_ICM_128;
+    p->cipher_key_len =
         SRTP_AES_ICM_128_KEY_LEN_WSALT; /* default 128 bits per RFC 3711 */
-    p -> auth_type = SRTP_HMAC_SHA1;
-    p -> auth_key_len = 20; /* default 160 bits per RFC 3711 */
-    p -> auth_tag_len = 10; /* default 80 bits per RFC 3711 */
-    p -> sec_serv = sec_serv_conf_and_auth;
+    p->auth_type = SRTP_HMAC_SHA1;
+    p->auth_key_len = 20; /* default 160 bits per RFC 3711 */
+    p->auth_tag_len = 10; /* default 80 bits per RFC 3711 */
+    p->sec_serv = sec_serv_conf_and_auth;
 }
 
-void srtp_crypto_policy_set_rtcp_default(srtp_crypto_policy_t * p) {
-    p -> cipher_type = SRTP_AES_ICM_128;
-    p -> cipher_key_len =
+void srtp_crypto_policy_set_rtcp_default(srtp_crypto_policy_t *p)
+{
+    p->cipher_type = SRTP_AES_ICM_128;
+    p->cipher_key_len =
         SRTP_AES_ICM_128_KEY_LEN_WSALT; /* default 128 bits per RFC 3711 */
-    p -> auth_type = SRTP_HMAC_SHA1;
-    p -> auth_key_len = 20; /* default 160 bits per RFC 3711 */
-    p -> auth_tag_len = 10; /* default 80 bits per RFC 3711 */
-    p -> sec_serv = sec_serv_conf_and_auth;
+    p->auth_type = SRTP_HMAC_SHA1;
+    p->auth_key_len = 20; /* default 160 bits per RFC 3711 */
+    p->auth_tag_len = 10; /* default 80 bits per RFC 3711 */
+    p->sec_serv = sec_serv_conf_and_auth;
 }
 
-void srtp_crypto_policy_set_aes_cm_128_hmac_sha1_32(srtp_crypto_policy_t * p) {
+void srtp_crypto_policy_set_aes_cm_128_hmac_sha1_32(srtp_crypto_policy_t *p)
+{
     /*
      * corresponds to RFC 4568
      *
      * note that this crypto policy is intended for SRTP, but not SRTCP
      */
 
-    p -> cipher_type = SRTP_AES_ICM_128;
-    p -> cipher_key_len =
+    p->cipher_type = SRTP_AES_ICM_128;
+    p->cipher_key_len =
         SRTP_AES_ICM_128_KEY_LEN_WSALT; /* 128 bit key, 112 bit salt */
-    p -> auth_type = SRTP_HMAC_SHA1;
-    p -> auth_key_len = 20; /* 160 bit key               */
-    p -> auth_tag_len = 4; /* 32 bit tag                */
-    p -> sec_serv = sec_serv_conf_and_auth;
+    p->auth_type = SRTP_HMAC_SHA1;
+    p->auth_key_len = 20; /* 160 bit key               */
+    p->auth_tag_len = 4;  /* 32 bit tag                */
+    p->sec_serv = sec_serv_conf_and_auth;
 }
 
-void srtp_crypto_policy_set_aes_cm_128_null_auth(srtp_crypto_policy_t * p) {
+void srtp_crypto_policy_set_aes_cm_128_null_auth(srtp_crypto_policy_t *p)
+{
     /*
      * corresponds to RFC 4568
      *
      * note that this crypto policy is intended for SRTP, but not SRTCP
      */
 
-    p -> cipher_type = SRTP_AES_ICM_128;
-    p -> cipher_key_len =
+    p->cipher_type = SRTP_AES_ICM_128;
+    p->cipher_key_len =
         SRTP_AES_ICM_128_KEY_LEN_WSALT; /* 128 bit key, 112 bit salt */
-    p -> auth_type = SRTP_NULL_AUTH;
-    p -> auth_key_len = 0;
-    p -> auth_tag_len = 0;
-    p -> sec_serv = sec_serv_conf;
+    p->auth_type = SRTP_NULL_AUTH;
+    p->auth_key_len = 0;
+    p->auth_tag_len = 0;
+    p->sec_serv = sec_serv_conf;
 }
 
-void srtp_crypto_policy_set_null_cipher_hmac_sha1_80(srtp_crypto_policy_t * p) {
+void srtp_crypto_policy_set_null_cipher_hmac_sha1_80(srtp_crypto_policy_t *p)
+{
     /*
      * corresponds to RFC 4568
      */
 
-    p -> cipher_type = SRTP_NULL_CIPHER;
-    p -> cipher_key_len =
+    p->cipher_type = SRTP_NULL_CIPHER;
+    p->cipher_key_len =
         SRTP_AES_ICM_128_KEY_LEN_WSALT; /* 128 bit key, 112 bit salt */
-    p -> auth_type = SRTP_HMAC_SHA1;
-    p -> auth_key_len = 20;
-    p -> auth_tag_len = 10;
-    p -> sec_serv = sec_serv_auth;
+    p->auth_type = SRTP_HMAC_SHA1;
+    p->auth_key_len = 20;
+    p->auth_tag_len = 10;
+    p->sec_serv = sec_serv_auth;
 }
 
-void srtp_crypto_policy_set_null_cipher_hmac_null(srtp_crypto_policy_t * p) {
+void srtp_crypto_policy_set_null_cipher_hmac_null(srtp_crypto_policy_t *p)
+{
     /*
      * Should only be used for testing
      */
 
-    p -> cipher_type = SRTP_NULL_CIPHER;
-    p -> cipher_key_len =
+    p->cipher_type = SRTP_NULL_CIPHER;
+    p->cipher_key_len =
         SRTP_AES_ICM_128_KEY_LEN_WSALT; /* 128 bit key, 112 bit salt */
-    p -> auth_type = SRTP_NULL_AUTH;
-    p -> auth_key_len = 0;
-    p -> auth_tag_len = 0;
-    p -> sec_serv = sec_serv_none;
+    p->auth_type = SRTP_NULL_AUTH;
+    p->auth_key_len = 0;
+    p->auth_tag_len = 0;
+    p->sec_serv = sec_serv_none;
 }
 
-void srtp_crypto_policy_set_aes_cm_256_hmac_sha1_80(srtp_crypto_policy_t * p) {
+void srtp_crypto_policy_set_aes_cm_256_hmac_sha1_80(srtp_crypto_policy_t *p)
+{
     /*
      * corresponds to RFC 6188
      */
 
-    p -> cipher_type = SRTP_AES_ICM_256;
-    p -> cipher_key_len = SRTP_AES_ICM_256_KEY_LEN_WSALT;
-    p -> auth_type = SRTP_HMAC_SHA1;
-    p -> auth_key_len = 20; /* default 160 bits per RFC 3711 */
-    p -> auth_tag_len = 10; /* default 80 bits per RFC 3711 */
-    p -> sec_serv = sec_serv_conf_and_auth;
+    p->cipher_type = SRTP_AES_ICM_256;
+    p->cipher_key_len = SRTP_AES_ICM_256_KEY_LEN_WSALT;
+    p->auth_type = SRTP_HMAC_SHA1;
+    p->auth_key_len = 20; /* default 160 bits per RFC 3711 */
+    p->auth_tag_len = 10; /* default 80 bits per RFC 3711 */
+    p->sec_serv = sec_serv_conf_and_auth;
 }
 
-void srtp_crypto_policy_set_aes_cm_256_hmac_sha1_32(srtp_crypto_policy_t * p) {
+void srtp_crypto_policy_set_aes_cm_256_hmac_sha1_32(srtp_crypto_policy_t *p)
+{
     /*
      * corresponds to RFC 6188
      *
      * note that this crypto policy is intended for SRTP, but not SRTCP
      */
 
-    p -> cipher_type = SRTP_AES_ICM_256;
-    p -> cipher_key_len = SRTP_AES_ICM_256_KEY_LEN_WSALT;
-    p -> auth_type = SRTP_HMAC_SHA1;
-    p -> auth_key_len = 20; /* default 160 bits per RFC 3711 */
-    p -> auth_tag_len = 4; /* default 80 bits per RFC 3711 */
-    p -> sec_serv = sec_serv_conf_and_auth;
+    p->cipher_type = SRTP_AES_ICM_256;
+    p->cipher_key_len = SRTP_AES_ICM_256_KEY_LEN_WSALT;
+    p->auth_type = SRTP_HMAC_SHA1;
+    p->auth_key_len = 20; /* default 160 bits per RFC 3711 */
+    p->auth_tag_len = 4;  /* default 80 bits per RFC 3711 */
+    p->sec_serv = sec_serv_conf_and_auth;
 }
 
 /*
  * AES-256 with no authentication.
  */
-void srtp_crypto_policy_set_aes_cm_256_null_auth(srtp_crypto_policy_t * p) {
-    p -> cipher_type = SRTP_AES_ICM_256;
-    p -> cipher_key_len = SRTP_AES_ICM_256_KEY_LEN_WSALT;
-    p -> auth_type = SRTP_NULL_AUTH;
-    p -> auth_key_len = 0;
-    p -> auth_tag_len = 0;
-    p -> sec_serv = sec_serv_conf;
+void srtp_crypto_policy_set_aes_cm_256_null_auth(srtp_crypto_policy_t *p)
+{
+    p->cipher_type = SRTP_AES_ICM_256;
+    p->cipher_key_len = SRTP_AES_ICM_256_KEY_LEN_WSALT;
+    p->auth_type = SRTP_NULL_AUTH;
+    p->auth_key_len = 0;
+    p->auth_tag_len = 0;
+    p->sec_serv = sec_serv_conf;
 }
 
-void srtp_crypto_policy_set_aes_cm_192_hmac_sha1_80(srtp_crypto_policy_t * p) {
+void srtp_crypto_policy_set_aes_cm_192_hmac_sha1_80(srtp_crypto_policy_t *p)
+{
     /*
      * corresponds to RFC 6188
      */
 
-    p -> cipher_type = SRTP_AES_ICM_192;
-    p -> cipher_key_len = SRTP_AES_ICM_192_KEY_LEN_WSALT;
-    p -> auth_type = SRTP_HMAC_SHA1;
-    p -> auth_key_len = 20; /* default 160 bits per RFC 3711 */
-    p -> auth_tag_len = 10; /* default 80 bits per RFC 3711 */
-    p -> sec_serv = sec_serv_conf_and_auth;
+    p->cipher_type = SRTP_AES_ICM_192;
+    p->cipher_key_len = SRTP_AES_ICM_192_KEY_LEN_WSALT;
+    p->auth_type = SRTP_HMAC_SHA1;
+    p->auth_key_len = 20; /* default 160 bits per RFC 3711 */
+    p->auth_tag_len = 10; /* default 80 bits per RFC 3711 */
+    p->sec_serv = sec_serv_conf_and_auth;
 }
 
-void srtp_crypto_policy_set_aes_cm_192_hmac_sha1_32(srtp_crypto_policy_t * p) {
+void srtp_crypto_policy_set_aes_cm_192_hmac_sha1_32(srtp_crypto_policy_t *p)
+{
     /*
      * corresponds to RFC 6188
      *
      * note that this crypto policy is intended for SRTP, but not SRTCP
      */
 
-    p -> cipher_type = SRTP_AES_ICM_192;
-    p -> cipher_key_len = SRTP_AES_ICM_192_KEY_LEN_WSALT;
-    p -> auth_type = SRTP_HMAC_SHA1;
-    p -> auth_key_len = 20; /* default 160 bits per RFC 3711 */
-    p -> auth_tag_len = 4; /* default 80 bits per RFC 3711 */
-    p -> sec_serv = sec_serv_conf_and_auth;
+    p->cipher_type = SRTP_AES_ICM_192;
+    p->cipher_key_len = SRTP_AES_ICM_192_KEY_LEN_WSALT;
+    p->auth_type = SRTP_HMAC_SHA1;
+    p->auth_key_len = 20; /* default 160 bits per RFC 3711 */
+    p->auth_tag_len = 4;  /* default 80 bits per RFC 3711 */
+    p->sec_serv = sec_serv_conf_and_auth;
 }
 
 /*
  * AES-192 with no authentication.
  */
-void srtp_crypto_policy_set_aes_cm_192_null_auth(srtp_crypto_policy_t * p) {
-    p -> cipher_type = SRTP_AES_ICM_192;
-    p -> cipher_key_len = SRTP_AES_ICM_192_KEY_LEN_WSALT;
-    p -> auth_type = SRTP_NULL_AUTH;
-    p -> auth_key_len = 0;
-    p -> auth_tag_len = 0;
-    p -> sec_serv = sec_serv_conf;
+void srtp_crypto_policy_set_aes_cm_192_null_auth(srtp_crypto_policy_t *p)
+{
+    p->cipher_type = SRTP_AES_ICM_192;
+    p->cipher_key_len = SRTP_AES_ICM_192_KEY_LEN_WSALT;
+    p->auth_type = SRTP_NULL_AUTH;
+    p->auth_key_len = 0;
+    p->auth_tag_len = 0;
+    p->sec_serv = sec_serv_conf;
 }
 
 /*
  * AES-128 GCM mode with 16 octet auth tag.
  */
-void srtp_crypto_policy_set_aes_gcm_128_16_auth(srtp_crypto_policy_t * p) {
-    p -> cipher_type = SRTP_AES_GCM_128;
-    p -> cipher_key_len = SRTP_AES_GCM_128_KEY_LEN_WSALT;
-    p -> auth_type = SRTP_NULL_AUTH; /* GCM handles the auth for us */
-    p -> auth_key_len = 0;
-    p -> auth_tag_len = 16; /* 16 octet tag length */
-    p -> sec_serv = sec_serv_conf_and_auth;
+void srtp_crypto_policy_set_aes_gcm_128_16_auth(srtp_crypto_policy_t *p)
+{
+    p->cipher_type = SRTP_AES_GCM_128;
+    p->cipher_key_len = SRTP_AES_GCM_128_KEY_LEN_WSALT;
+    p->auth_type = SRTP_NULL_AUTH; /* GCM handles the auth for us */
+    p->auth_key_len = 0;
+    p->auth_tag_len = 16; /* 16 octet tag length */
+    p->sec_serv = sec_serv_conf_and_auth;
 }
 
 /*
  * AES-256 GCM mode with 16 octet auth tag.
  */
-void srtp_crypto_policy_set_aes_gcm_256_16_auth(srtp_crypto_policy_t * p) {
-    p -> cipher_type = SRTP_AES_GCM_256;
-    p -> cipher_key_len = SRTP_AES_GCM_256_KEY_LEN_WSALT;
-    p -> auth_type = SRTP_NULL_AUTH; /* GCM handles the auth for us */
-    p -> auth_key_len = 0;
-    p -> auth_tag_len = 16; /* 16 octet tag length */
-    p -> sec_serv = sec_serv_conf_and_auth;
+void srtp_crypto_policy_set_aes_gcm_256_16_auth(srtp_crypto_policy_t *p)
+{
+    p->cipher_type = SRTP_AES_GCM_256;
+    p->cipher_key_len = SRTP_AES_GCM_256_KEY_LEN_WSALT;
+    p->auth_type = SRTP_NULL_AUTH; /* GCM handles the auth for us */
+    p->auth_key_len = 0;
+    p->auth_tag_len = 16; /* 16 octet tag length */
+    p->sec_serv = sec_serv_conf_and_auth;
 }
 
 /*
@@ -3520,41 +3559,42 @@ void srtp_crypto_policy_set_aes_gcm_256_16_auth(srtp_crypto_policy_t * p) {
  *
  */
 static srtp_err_status_t srtp_calc_aead_iv_srtcp(
-    srtp_session_keys_t * session_keys,
-    v128_t * iv,
+    srtp_session_keys_t *session_keys,
+    v128_t *iv,
     uint32_t seq_num,
-    const srtcp_hdr_t * hdr) {
-    v128_t in ;
+    const srtcp_hdr_t *hdr)
+{
+    v128_t in;
     v128_t salt;
 
-    memset( & in, 0, sizeof(v128_t));
-    memset( & salt, 0, sizeof(v128_t));
+    memset(&in, 0, sizeof(v128_t));
+    memset(&salt, 0, sizeof(v128_t));
 
     in.v16[0] = 0;
-    memcpy( & in.v16[1], & hdr -> ssrc, 4); /* still in network order! */
+    memcpy(&in.v16[1], &hdr->ssrc, 4); /* still in network order! */
     in.v16[3] = 0;
 
     /*
      *  The SRTCP index (seq_num) spans bits 0 through 30 inclusive.
      *  The most significant bit should be zero.
      */
-    if (seq_num & 0x80000000 UL) {
+    if (seq_num & 0x80000000UL) {
         return srtp_err_status_bad_param;
     }
     in.v32[2] = htonl(seq_num);
 
-    debug_print(mod_srtp, "Pre-salted RTCP IV = %s\n", v128_hex_string( & in));
+    debug_print(mod_srtp, "Pre-salted RTCP IV = %s\n", v128_hex_string(&in));
 
     /*
      * Get the SALT value from the context
      */
-    memcpy(salt.v8, session_keys -> c_salt, 12);
-    debug_print(mod_srtp, "RTCP SALT = %s\n", v128_hex_string( & salt));
+    memcpy(salt.v8, session_keys->c_salt, 12);
+    debug_print(mod_srtp, "RTCP SALT = %s\n", v128_hex_string(&salt));
 
     /*
      * Finally, apply the SALT to the input
      */
-    v128_xor(iv, & in, & salt);
+    v128_xor(iv, &in, &salt);
 
     return srtp_err_status_ok;
 }
@@ -3564,16 +3604,17 @@ static srtp_err_status_t srtp_calc_aead_iv_srtcp(
  * AES-GCM mode with 128 or 256 bit keys.
  */
 static srtp_err_status_t srtp_protect_rtcp_aead(
-    srtp_stream_ctx_t * stream,
-    const uint8_t * rtcp,
-        size_t rtcp_len,
-        uint8_t * srtcp,
-        size_t * srtcp_len,
-        srtp_session_keys_t * session_keys) {
-    const srtcp_hdr_t * hdr = (const srtcp_hdr_t * ) rtcp;
-    size_t enc_start; /* pointer to start of encrypted portion  */
-    uint8_t * trailer_p; /* pointer to start of trailer            */
-    uint32_t trailer; /* trailer value                          */
+    srtp_stream_ctx_t *stream,
+    const uint8_t *rtcp,
+    size_t rtcp_len,
+    uint8_t *srtcp,
+    size_t *srtcp_len,
+    srtp_session_keys_t *session_keys)
+{
+    const srtcp_hdr_t *hdr = (const srtcp_hdr_t *)rtcp;
+    size_t enc_start;         /* pointer to start of encrypted portion  */
+    uint8_t *trailer_p;       /* pointer to start of trailer            */
+    uint32_t trailer;         /* trailer value                          */
     size_t enc_octet_len = 0; /* number of octets in encrypted portion  */
     srtp_err_status_t status;
     size_t tag_len;
@@ -3581,7 +3622,7 @@ static srtp_err_status_t srtp_protect_rtcp_aead(
     v128_t iv;
 
     /* get tag length from stream context */
-    tag_len = srtp_auth_get_tag_length(session_keys -> rtcp_auth);
+    tag_len = srtp_auth_get_tag_length(session_keys->rtcp_auth);
 
     /*
      * set encryption start and encryption length - if we're not
@@ -3591,8 +3632,8 @@ static srtp_err_status_t srtp_protect_rtcp_aead(
     enc_octet_len = rtcp_len - enc_start;
 
     /* check output length */
-    if ( * srtcp_len <
-        rtcp_len + sizeof(srtcp_trailer_t) + stream -> mki_size + tag_len) {
+    if (*srtcp_len <
+        rtcp_len + sizeof(srtcp_trailer_t) + stream->mki_size + tag_len) {
         return srtp_err_status_buffer_small;
     }
 
@@ -3606,41 +3647,41 @@ static srtp_err_status_t srtp_protect_rtcp_aead(
      */
     trailer_p = srtcp + enc_start + enc_octet_len + tag_len;
 
-    if (stream -> rtcp_services & sec_serv_conf) {
+    if (stream->rtcp_services & sec_serv_conf) {
         trailer = htonl(SRTCP_E_BIT); /* set encrypt bit */
     } else {
         /* 0 is network-order independent */
         trailer = 0x00000000; /* set encrypt bit */
     }
 
-    if (stream -> use_mki) {
+    if (stream->use_mki) {
         srtp_inject_mki(srtcp + rtcp_len + tag_len + sizeof(srtcp_trailer_t),
-            session_keys, stream -> mki_size);
+                        session_keys, stream->mki_size);
     }
 
     /*
      * check sequence number for overruns, and copy it into the packet
      * if its value isn't too big
      */
-    status = srtp_rdb_increment( & stream -> rtcp_rdb);
+    status = srtp_rdb_increment(&stream->rtcp_rdb);
     if (status) {
         return status;
     }
-    seq_num = srtp_rdb_get_value( & stream -> rtcp_rdb);
+    seq_num = srtp_rdb_get_value(&stream->rtcp_rdb);
     trailer |= htonl(seq_num);
-    debug_print(mod_srtp, "srtcp index: %x", (unsigned int) seq_num);
+    debug_print(mod_srtp, "srtcp index: %x", (unsigned int)seq_num);
 
-    memcpy(trailer_p, & trailer, sizeof(trailer));
+    memcpy(trailer_p, &trailer, sizeof(trailer));
 
     /*
      * Calculate and set the IV
      */
-    status = srtp_calc_aead_iv_srtcp(session_keys, & iv, seq_num, hdr);
+    status = srtp_calc_aead_iv_srtcp(session_keys, &iv, seq_num, hdr);
     if (status) {
         return srtp_err_status_cipher_fail;
     }
-    status = srtp_cipher_set_iv(session_keys -> rtcp_cipher, (uint8_t * ) & iv,
-        srtp_direction_encrypt);
+    status = srtp_cipher_set_iv(session_keys->rtcp_cipher, (uint8_t *)&iv,
+                                srtp_direction_encrypt);
     if (status) {
         return srtp_err_status_cipher_fail;
     }
@@ -3648,13 +3689,13 @@ static srtp_err_status_t srtp_protect_rtcp_aead(
     /*
      * Set the AAD for GCM mode
      */
-    if (stream -> rtcp_services & sec_serv_conf) {
+    if (stream->rtcp_services & sec_serv_conf) {
         /*
          * If payload encryption is enabled, then the AAD consist of
          * the RTCP header and the seq# at the end of the packet
          */
-        status = srtp_cipher_set_aad(session_keys -> rtcp_cipher, rtcp,
-            octets_in_rtcp_header);
+        status = srtp_cipher_set_aad(session_keys->rtcp_cipher, rtcp,
+                                     octets_in_rtcp_header);
         if (status) {
             return srtp_err_status_cipher_fail;
         }
@@ -3664,7 +3705,7 @@ static srtp_err_status_t srtp_protect_rtcp_aead(
          * the entire packet as described in RFC 7714 (Section 9.3. Data
          * Types in Unencrypted SRTCP Compound Packets)
          */
-        status = srtp_cipher_set_aad(session_keys -> rtcp_cipher, rtcp, rtcp_len);
+        status = srtp_cipher_set_aad(session_keys->rtcp_cipher, rtcp, rtcp_len);
         if (status) {
             return (srtp_err_status_cipher_fail);
         }
@@ -3672,18 +3713,18 @@ static srtp_err_status_t srtp_protect_rtcp_aead(
     /*
      * Process the sequence# as AAD
      */
-    status = srtp_cipher_set_aad(session_keys -> rtcp_cipher, (uint8_t * ) & trailer,
-        sizeof(trailer));
+    status = srtp_cipher_set_aad(session_keys->rtcp_cipher, (uint8_t *)&trailer,
+                                 sizeof(trailer));
     if (status) {
         return (srtp_err_status_cipher_fail);
     }
 
     /* if we're encrypting, exor keystream into the message */
-    if (stream -> rtcp_services & sec_serv_conf) {
-        size_t out_len = * srtcp_len - enc_start;
+    if (stream->rtcp_services & sec_serv_conf) {
+        size_t out_len = *srtcp_len - enc_start;
         status =
-            srtp_cipher_encrypt(session_keys -> rtcp_cipher, rtcp + enc_start,
-                enc_octet_len, srtcp + enc_start, & out_len);
+            srtp_cipher_encrypt(session_keys->rtcp_cipher, rtcp + enc_start,
+                                enc_octet_len, srtcp + enc_start, &out_len);
         enc_octet_len = out_len;
         if (status) {
             return srtp_err_status_cipher_fail;
@@ -3698,23 +3739,23 @@ static srtp_err_status_t srtp_protect_rtcp_aead(
          * Even though we're not encrypting the payload, we need
          * to run the cipher to get the auth tag.
          */
-        uint8_t * auth_tag = srtcp + enc_start + enc_octet_len;
-        size_t out_len = * srtcp_len - enc_start - enc_octet_len;
-        status = srtp_cipher_encrypt(session_keys -> rtcp_cipher, NULL, 0,
-            auth_tag, & out_len);
+        uint8_t *auth_tag = srtcp + enc_start + enc_octet_len;
+        size_t out_len = *srtcp_len - enc_start - enc_octet_len;
+        status = srtp_cipher_encrypt(session_keys->rtcp_cipher, NULL, 0,
+                                     auth_tag, &out_len);
         if (status) {
             return srtp_err_status_cipher_fail;
         }
         enc_octet_len += out_len;
     }
 
-    * srtcp_len = octets_in_rtcp_header + enc_octet_len;
+    *srtcp_len = octets_in_rtcp_header + enc_octet_len;
 
     /* increase the packet length by the length of the seq_num*/
-    * srtcp_len += sizeof(srtcp_trailer_t);
+    *srtcp_len += sizeof(srtcp_trailer_t);
 
     /* increase the packet by the mki_size */
-    * srtcp_len += stream -> mki_size;
+    *srtcp_len += stream->mki_size;
 
     return srtp_err_status_ok;
 }
@@ -3727,18 +3768,19 @@ static srtp_err_status_t srtp_protect_rtcp_aead(
  */
 static srtp_err_status_t srtp_unprotect_rtcp_aead(
     srtp_t ctx,
-    srtp_stream_ctx_t * stream,
-    const uint8_t * srtcp,
-        size_t srtcp_len,
-        uint8_t * rtcp,
-        size_t * rtcp_len,
-        srtp_session_keys_t * session_keys) {
-    const srtcp_hdr_t * hdr = (const srtcp_hdr_t * ) srtcp;
-    size_t enc_start; /* pointer to start of encrypted portion  */
-    const uint8_t * trailer_p; /* pointer to start of trailer            */
-    uint32_t trailer; /* trailer value                          */
-    size_t enc_octet_len = 0; /* number of octets in encrypted portion  */
-    const uint8_t * auth_tag = NULL; /* location of auth_tag within packet     */
+    srtp_stream_ctx_t *stream,
+    const uint8_t *srtcp,
+    size_t srtcp_len,
+    uint8_t *rtcp,
+    size_t *rtcp_len,
+    srtp_session_keys_t *session_keys)
+{
+    const srtcp_hdr_t *hdr = (const srtcp_hdr_t *)srtcp;
+    size_t enc_start;               /* pointer to start of encrypted portion  */
+    const uint8_t *trailer_p;       /* pointer to start of trailer            */
+    uint32_t trailer;               /* trailer value                          */
+    size_t enc_octet_len = 0;       /* number of octets in encrypted portion  */
+    const uint8_t *auth_tag = NULL; /* location of auth_tag within packet     */
     srtp_err_status_t status;
     size_t tag_len;
     size_t tmp_len;
@@ -3746,7 +3788,7 @@ static srtp_err_status_t srtp_unprotect_rtcp_aead(
     v128_t iv;
 
     /* get tag length from stream context */
-    tag_len = srtp_auth_get_tag_length(session_keys -> rtcp_auth);
+    tag_len = srtp_auth_get_tag_length(session_keys->rtcp_auth);
 
     enc_start = octets_in_rtcp_header;
 
@@ -3758,24 +3800,24 @@ static srtp_err_status_t srtp_unprotect_rtcp_aead(
      */
     /* This should point trailer to the word past the end of the normal data. */
     /* This would need to be modified for optional mikey data */
-    trailer_p = srtcp + srtcp_len - sizeof(srtcp_trailer_t) - stream -> mki_size;
-    memcpy( & trailer, trailer_p, sizeof(trailer));
+    trailer_p = srtcp + srtcp_len - sizeof(srtcp_trailer_t) - stream->mki_size;
+    memcpy(&trailer, trailer_p, sizeof(trailer));
 
     /*
      * We pass the tag down to the cipher when doing GCM mode
      */
     enc_octet_len = srtcp_len - (octets_in_rtcp_header +
-        sizeof(srtcp_trailer_t) + stream -> mki_size);
-    auth_tag = srtcp + (srtcp_len - tag_len - stream -> mki_size -
-        sizeof(srtcp_trailer_t));
+                                 sizeof(srtcp_trailer_t) + stream->mki_size);
+    auth_tag = srtcp + (srtcp_len - tag_len - stream->mki_size -
+                        sizeof(srtcp_trailer_t));
 
     /*
      * check the sequence number for replays
      */
     /* this is easier than dealing with bitfield access */
     seq_num = ntohl(trailer) & SRTCP_INDEX_MASK;
-    debug_print(mod_srtp, "srtcp index: %x", (unsigned int) seq_num);
-    status = srtp_rdb_check( & stream -> rtcp_rdb, seq_num);
+    debug_print(mod_srtp, "srtcp index: %x", (unsigned int)seq_num);
+    status = srtp_rdb_check(&stream->rtcp_rdb, seq_num);
     if (status) {
         return status;
     }
@@ -3783,19 +3825,19 @@ static srtp_err_status_t srtp_unprotect_rtcp_aead(
     /*
      * Calculate and set the IV
      */
-    status = srtp_calc_aead_iv_srtcp(session_keys, & iv, seq_num, hdr);
+    status = srtp_calc_aead_iv_srtcp(session_keys, &iv, seq_num, hdr);
     if (status) {
         return srtp_err_status_cipher_fail;
     }
-    status = srtp_cipher_set_iv(session_keys -> rtcp_cipher, (uint8_t * ) & iv,
-        srtp_direction_decrypt);
+    status = srtp_cipher_set_iv(session_keys->rtcp_cipher, (uint8_t *)&iv,
+                                srtp_direction_decrypt);
     if (status) {
         return srtp_err_status_cipher_fail;
     }
 
     /* check output length */
-    if ( * rtcp_len <
-        srtcp_len - sizeof(srtcp_trailer_t) - stream -> mki_size - tag_len) {
+    if (*rtcp_len <
+        srtcp_len - sizeof(srtcp_trailer_t) - stream->mki_size - tag_len) {
         return srtp_err_status_buffer_small;
     }
 
@@ -3807,13 +3849,13 @@ static srtp_err_status_t srtp_unprotect_rtcp_aead(
     /*
      * Set the AAD for GCM mode
      */
-    if ( * trailer_p & SRTCP_E_BYTE_BIT) {
+    if (*trailer_p & SRTCP_E_BYTE_BIT) {
         /*
          * If payload encryption is enabled, then the AAD consist of
          * the RTCP header and the seq# at the end of the packet
          */
-        status = srtp_cipher_set_aad(session_keys -> rtcp_cipher, srtcp,
-            octets_in_rtcp_header);
+        status = srtp_cipher_set_aad(session_keys->rtcp_cipher, srtcp,
+                                     octets_in_rtcp_header);
         if (status) {
             return srtp_err_status_cipher_fail;
         }
@@ -3824,8 +3866,8 @@ static srtp_err_status_t srtp_unprotect_rtcp_aead(
          * Types in Unencrypted SRTCP Compound Packets)
          */
         status = srtp_cipher_set_aad(
-            session_keys -> rtcp_cipher, srtcp,
-            (srtcp_len - tag_len - sizeof(srtcp_trailer_t) - stream -> mki_size));
+            session_keys->rtcp_cipher, srtcp,
+            (srtcp_len - tag_len - sizeof(srtcp_trailer_t) - stream->mki_size));
         if (status) {
             return (srtp_err_status_cipher_fail);
         }
@@ -3834,17 +3876,17 @@ static srtp_err_status_t srtp_unprotect_rtcp_aead(
     /*
      * Process the sequence# as AAD
      */
-    status = srtp_cipher_set_aad(session_keys -> rtcp_cipher, (uint8_t * ) & trailer,
-        sizeof(trailer));
+    status = srtp_cipher_set_aad(session_keys->rtcp_cipher, (uint8_t *)&trailer,
+                                 sizeof(trailer));
     if (status) {
         return (srtp_err_status_cipher_fail);
     }
 
     /* if we're decrypting, exor keystream into the message */
-    if ( * trailer_p & SRTCP_E_BYTE_BIT) {
-        status = srtp_cipher_decrypt(session_keys -> rtcp_cipher,
-            srtcp + enc_start, enc_octet_len,
-            rtcp + enc_start, & enc_octet_len);
+    if (*trailer_p & SRTCP_E_BYTE_BIT) {
+        status = srtp_cipher_decrypt(session_keys->rtcp_cipher,
+                                     srtcp + enc_start, enc_octet_len,
+                                     rtcp + enc_start, &enc_octet_len);
         if (status) {
             return status;
         }
@@ -3858,17 +3900,17 @@ static srtp_err_status_t srtp_unprotect_rtcp_aead(
          * Still need to run the cipher to check the tag
          */
         tmp_len = 0;
-        status = srtp_cipher_decrypt(session_keys -> rtcp_cipher, auth_tag,
-            tag_len, NULL, & tmp_len);
+        status = srtp_cipher_decrypt(session_keys->rtcp_cipher, auth_tag,
+                                     tag_len, NULL, &tmp_len);
         if (status) {
             return status;
         }
     }
 
-    * rtcp_len = srtcp_len;
+    *rtcp_len = srtcp_len;
 
     /* decrease the packet length by the length of the auth tag and seq_num*/
-    * rtcp_len -= (tag_len + sizeof(srtcp_trailer_t) + stream -> mki_size);
+    *rtcp_len -= (tag_len + sizeof(srtcp_trailer_t) + stream->mki_size);
 
     /*
      * verify that stream is for received traffic - this check will
@@ -3880,9 +3922,9 @@ static srtp_err_status_t srtp_unprotect_rtcp_aead(
      * latter check will catch any attempts to fool us into thinking
      * that we've got a collision
      */
-    if (stream -> direction != dir_srtp_receiver) {
-        if (stream -> direction == dir_unknown) {
-            stream -> direction = dir_srtp_receiver;
+    if (stream->direction != dir_srtp_receiver) {
+        if (stream->direction == dir_unknown) {
+            stream->direction = dir_srtp_receiver;
         } else {
             srtp_handle_event(ctx, stream, event_ssrc_collision);
         }
@@ -3893,8 +3935,8 @@ static srtp_err_status_t srtp_unprotect_rtcp_aead(
      * is used, then we need to allocate a new stream at this point, since
      * the authentication passed
      */
-    if (stream == ctx -> stream_template) {
-        srtp_stream_ctx_t * new_stream;
+    if (stream == ctx->stream_template) {
+        srtp_stream_ctx_t *new_stream;
 
         /*
          * allocate and initialize a new stream
@@ -3904,14 +3946,14 @@ static srtp_err_status_t srtp_unprotect_rtcp_aead(
          * failure here
          */
         status =
-            srtp_stream_clone(ctx -> stream_template, hdr -> ssrc, & new_stream);
+            srtp_stream_clone(ctx->stream_template, hdr->ssrc, &new_stream);
         if (status) {
             return status;
         }
 
         /* add new stream to the list */
-        status = srtp_insert_or_dealloc_stream(ctx -> stream_list, new_stream,
-            ctx -> stream_template);
+        status = srtp_insert_or_dealloc_stream(ctx->stream_list, new_stream,
+                                               ctx->stream_template);
         if (status) {
             return status;
         }
@@ -3921,30 +3963,31 @@ static srtp_err_status_t srtp_unprotect_rtcp_aead(
     }
 
     /* we've passed the authentication check, so add seq_num to the rdb */
-    srtp_rdb_add_index( & stream -> rtcp_rdb, seq_num);
+    srtp_rdb_add_index(&stream->rtcp_rdb, seq_num);
 
     return srtp_err_status_ok;
 }
 
 srtp_err_status_t srtp_protect_rtcp(srtp_t ctx,
-    const uint8_t * rtcp,
-        size_t rtcp_len,
-        uint8_t * srtcp,
-        size_t * srtcp_len,
-        size_t mki_index) {
-    const srtcp_hdr_t * hdr = (const srtcp_hdr_t * ) rtcp;
-    size_t enc_start; /* pointer to start of encrypted portion  */
-    uint8_t * auth_start; /* pointer to start of auth. portion      */
-    uint8_t * trailer_p; /* pointer to start of trailer            */
-    uint32_t trailer; /* trailer value                          */
+                                    const uint8_t *rtcp,
+                                    size_t rtcp_len,
+                                    uint8_t *srtcp,
+                                    size_t *srtcp_len,
+                                    size_t mki_index)
+{
+    const srtcp_hdr_t *hdr = (const srtcp_hdr_t *)rtcp;
+    size_t enc_start;         /* pointer to start of encrypted portion  */
+    uint8_t *auth_start;      /* pointer to start of auth. portion      */
+    uint8_t *trailer_p;       /* pointer to start of trailer            */
+    uint32_t trailer;         /* trailer value                          */
     size_t enc_octet_len = 0; /* number of octets in encrypted portion  */
-    uint8_t * auth_tag = NULL; /* location of auth_tag within packet     */
+    uint8_t *auth_tag = NULL; /* location of auth_tag within packet     */
     srtp_err_status_t status;
     size_t tag_len;
-    srtp_stream_ctx_t * stream;
+    srtp_stream_ctx_t *stream;
     size_t prefix_len;
     uint32_t seq_num;
-    srtp_session_keys_t * session_keys = NULL;
+    srtp_session_keys_t *session_keys = NULL;
 
     /* check the packet length - it must at least contain a full header */
     if (rtcp_len < octets_in_rtcp_header) {
@@ -3958,21 +4001,21 @@ srtp_err_status_t srtp_protect_rtcp(srtp_t ctx,
      * supports key-sharing, then we assume that a new stream using
      * that key has just started up
      */
-    stream = srtp_get_stream(ctx, hdr -> ssrc);
+    stream = srtp_get_stream(ctx, hdr->ssrc);
     if (stream == NULL) {
-        if (ctx -> stream_template != NULL) {
-            srtp_stream_ctx_t * new_stream;
+        if (ctx->stream_template != NULL) {
+            srtp_stream_ctx_t *new_stream;
 
             /* allocate and initialize a new stream */
             status =
-                srtp_stream_clone(ctx -> stream_template, hdr -> ssrc, & new_stream);
+                srtp_stream_clone(ctx->stream_template, hdr->ssrc, &new_stream);
             if (status) {
                 return status;
             }
 
             /* add new stream to the list */
-            status = srtp_insert_or_dealloc_stream(ctx -> stream_list, new_stream,
-                ctx -> stream_template);
+            status = srtp_insert_or_dealloc_stream(ctx->stream_list, new_stream,
+                                                   ctx->stream_template);
             if (status) {
                 return status;
             }
@@ -3991,15 +4034,15 @@ srtp_err_status_t srtp_protect_rtcp(srtp_t ctx,
      * srtp_protect() and srtp_unprotect() will fail this test in one of
      * those functions.
      */
-    if (stream -> direction != dir_srtp_sender) {
-        if (stream -> direction == dir_unknown) {
-            stream -> direction = dir_srtp_sender;
+    if (stream->direction != dir_srtp_sender) {
+        if (stream->direction == dir_unknown) {
+            stream->direction = dir_srtp_sender;
         } else {
             srtp_handle_event(ctx, stream, event_ssrc_collision);
         }
     }
 
-    status = srtp_get_session_keys(stream, mki_index, & session_keys);
+    status = srtp_get_session_keys(stream, mki_index, &session_keys);
     if (status) {
         return status;
     }
@@ -4008,14 +4051,14 @@ srtp_err_status_t srtp_protect_rtcp(srtp_t ctx,
      * Check if this is an AEAD stream (GCM mode).  If so, then dispatch
      * the request to our AEAD handler.
      */
-    if (session_keys -> rtp_cipher -> algorithm == SRTP_AES_GCM_128 ||
-        session_keys -> rtp_cipher -> algorithm == SRTP_AES_GCM_256) {
+    if (session_keys->rtp_cipher->algorithm == SRTP_AES_GCM_128 ||
+        session_keys->rtp_cipher->algorithm == SRTP_AES_GCM_256) {
         return srtp_protect_rtcp_aead(stream, rtcp, rtcp_len, srtcp, srtcp_len,
-            session_keys);
+                                      session_keys);
     }
 
     /* get tag length from stream context */
-    tag_len = srtp_auth_get_tag_length(session_keys -> rtcp_auth);
+    tag_len = srtp_auth_get_tag_length(session_keys->rtcp_auth);
 
     /*
      * set encryption start and encryption length
@@ -4024,8 +4067,8 @@ srtp_err_status_t srtp_protect_rtcp(srtp_t ctx,
     enc_octet_len = rtcp_len - enc_start;
 
     /* check output length */
-    if ( * srtcp_len <
-        rtcp_len + sizeof(srtcp_trailer_t) + stream -> mki_size + tag_len) {
+    if (*srtcp_len <
+        rtcp_len + sizeof(srtcp_trailer_t) + stream->mki_size + tag_len) {
         return srtp_err_status_buffer_small;
     }
 
@@ -4041,16 +4084,16 @@ srtp_err_status_t srtp_protect_rtcp(srtp_t ctx,
      */
     trailer_p = srtcp + enc_start + enc_octet_len;
 
-    if (stream -> rtcp_services & sec_serv_conf) {
+    if (stream->rtcp_services & sec_serv_conf) {
         trailer = htonl(SRTCP_E_BIT); /* set encrypt bit */
     } else {
         /* 0 is network-order independant */
         trailer = 0x00000000; /* set encrypt bit */
     }
 
-    if (stream -> use_mki) {
+    if (stream->use_mki) {
         srtp_inject_mki(srtcp + rtcp_len + sizeof(srtcp_trailer_t),
-            session_keys, stream -> mki_size);
+                        session_keys, stream->mki_size);
     }
 
     /*
@@ -4059,36 +4102,36 @@ srtp_err_status_t srtp_protect_rtcp(srtp_t ctx,
      */
     /* Note: This would need to change for optional mikey data */
     auth_start = srtcp;
-    auth_tag = srtcp + rtcp_len + sizeof(srtcp_trailer_t) + stream -> mki_size;
+    auth_tag = srtcp + rtcp_len + sizeof(srtcp_trailer_t) + stream->mki_size;
 
     /*
      * check sequence number for overruns, and copy it into the packet
      * if its value isn't too big
      */
-    status = srtp_rdb_increment( & stream -> rtcp_rdb);
+    status = srtp_rdb_increment(&stream->rtcp_rdb);
     if (status) {
         return status;
     }
-    seq_num = srtp_rdb_get_value( & stream -> rtcp_rdb);
+    seq_num = srtp_rdb_get_value(&stream->rtcp_rdb);
     trailer |= htonl(seq_num);
-    debug_print(mod_srtp, "srtcp index: %x", (unsigned int) seq_num);
+    debug_print(mod_srtp, "srtcp index: %x", (unsigned int)seq_num);
 
-    memcpy(trailer_p, & trailer, sizeof(trailer));
+    memcpy(trailer_p, &trailer, sizeof(trailer));
 
     /*
      * if we're using rindael counter mode, set nonce and seq
      */
-    if (session_keys -> rtcp_cipher -> type -> id == SRTP_AES_ICM_128 ||
-        session_keys -> rtcp_cipher -> type -> id == SRTP_AES_ICM_192 ||
-        session_keys -> rtcp_cipher -> type -> id == SRTP_AES_ICM_256) {
+    if (session_keys->rtcp_cipher->type->id == SRTP_AES_ICM_128 ||
+        session_keys->rtcp_cipher->type->id == SRTP_AES_ICM_192 ||
+        session_keys->rtcp_cipher->type->id == SRTP_AES_ICM_256) {
         v128_t iv;
 
         iv.v32[0] = 0;
-        iv.v32[1] = hdr -> ssrc; /* still in network order! */
+        iv.v32[1] = hdr->ssrc; /* still in network order! */
         iv.v32[2] = htonl(seq_num >> 16);
         iv.v32[3] = htonl(seq_num << 16);
-        status = srtp_cipher_set_iv(session_keys -> rtcp_cipher, (uint8_t * ) & iv,
-            srtp_direction_encrypt);
+        status = srtp_cipher_set_iv(session_keys->rtcp_cipher, (uint8_t *)&iv,
+                                    srtp_direction_encrypt);
 
     } else {
         v128_t iv;
@@ -4098,8 +4141,8 @@ srtp_err_status_t srtp_protect_rtcp(srtp_t ctx,
         iv.v32[1] = 0;
         iv.v32[2] = 0;
         iv.v32[3] = htonl(seq_num);
-        status = srtp_cipher_set_iv(session_keys -> rtcp_cipher, (uint8_t * ) & iv,
-            srtp_direction_encrypt);
+        status = srtp_cipher_set_iv(session_keys->rtcp_cipher, (uint8_t *)&iv,
+                                    srtp_direction_encrypt);
     }
     if (status) {
         return srtp_err_status_cipher_fail;
@@ -4113,12 +4156,12 @@ srtp_err_status_t srtp_protect_rtcp(srtp_t ctx,
     /* if auth_start is non-null, then put keystream into tag  */
     if (auth_start) {
         /* put keystream prefix into auth_tag */
-        prefix_len = srtp_auth_get_prefix_length(session_keys -> rtcp_auth);
-        status = srtp_cipher_output(session_keys -> rtcp_cipher, auth_tag, &
-            prefix_len);
+        prefix_len = srtp_auth_get_prefix_length(session_keys->rtcp_auth);
+        status = srtp_cipher_output(session_keys->rtcp_cipher, auth_tag,
+                                    &prefix_len);
 
         debug_print(mod_srtp, "keystream prefix: %s",
-            srtp_octet_string_hex_string(auth_tag, prefix_len));
+                    srtp_octet_string_hex_string(auth_tag, prefix_len));
 
         if (status) {
             return srtp_err_status_cipher_fail;
@@ -4126,10 +4169,10 @@ srtp_err_status_t srtp_protect_rtcp(srtp_t ctx,
     }
 
     /* if we're encrypting, exor keystream into the message */
-    if (stream -> rtcp_services & sec_serv_conf) {
-        status = srtp_cipher_encrypt(session_keys -> rtcp_cipher,
-            rtcp + enc_start, enc_octet_len,
-            srtcp + enc_start, & enc_octet_len);
+    if (stream->rtcp_services & sec_serv_conf) {
+        status = srtp_cipher_encrypt(session_keys->rtcp_cipher,
+                                     rtcp + enc_start, enc_octet_len,
+                                     srtcp + enc_start, &enc_octet_len);
         if (status) {
             return srtp_err_status_cipher_fail;
         }
@@ -4139,7 +4182,7 @@ srtp_err_status_t srtp_protect_rtcp(srtp_t ctx,
     }
 
     /* initialize auth func context */
-    status = srtp_auth_start(session_keys -> rtcp_auth);
+    status = srtp_auth_start(session_keys->rtcp_auth);
     if (status) {
         return status;
     }
@@ -4148,47 +4191,48 @@ srtp_err_status_t srtp_protect_rtcp(srtp_t ctx,
      * run auth func over packet (including trailer), and write the
      * result at auth_tag
      */
-    status = srtp_auth_compute(session_keys -> rtcp_auth, auth_start,
-        rtcp_len + sizeof(srtcp_trailer_t), auth_tag);
+    status = srtp_auth_compute(session_keys->rtcp_auth, auth_start,
+                               rtcp_len + sizeof(srtcp_trailer_t), auth_tag);
     debug_print(mod_srtp, "srtcp auth tag:    %s",
-        srtp_octet_string_hex_string(auth_tag, tag_len));
+                srtp_octet_string_hex_string(auth_tag, tag_len));
     if (status) {
         return srtp_err_status_auth_fail;
     }
 
-    * srtcp_len = enc_start + enc_octet_len;
+    *srtcp_len = enc_start + enc_octet_len;
 
     /* increase the packet length by the length of the auth tag and seq_num*/
-    * srtcp_len += (tag_len + sizeof(srtcp_trailer_t));
+    *srtcp_len += (tag_len + sizeof(srtcp_trailer_t));
 
     /* increase the packet by the mki_size */
-    * srtcp_len += stream -> mki_size;
+    *srtcp_len += stream->mki_size;
 
     return srtp_err_status_ok;
 }
 
 srtp_err_status_t srtp_unprotect_rtcp(srtp_t ctx,
-    const uint8_t * srtcp,
-        size_t srtcp_len,
-        uint8_t * rtcp,
-        size_t * rtcp_len) {
-    const srtcp_hdr_t * hdr = (const srtcp_hdr_t * ) srtcp;
-    size_t enc_start; /* pointer to start of encrypted portion  */
-    const uint8_t * auth_start; /* pointer to start of auth. portion      */
-    const uint8_t * trailer_p; /* pointer to start of trailer            */
-    uint32_t trailer; /* trailer value                          */
-    size_t enc_octet_len = 0; /* number of octets in encrypted portion  */
-    const uint8_t * auth_tag = NULL; /* location of auth_tag within packet     */
+                                      const uint8_t *srtcp,
+                                      size_t srtcp_len,
+                                      uint8_t *rtcp,
+                                      size_t *rtcp_len)
+{
+    const srtcp_hdr_t *hdr = (const srtcp_hdr_t *)srtcp;
+    size_t enc_start;               /* pointer to start of encrypted portion  */
+    const uint8_t *auth_start;      /* pointer to start of auth. portion      */
+    const uint8_t *trailer_p;       /* pointer to start of trailer            */
+    uint32_t trailer;               /* trailer value                          */
+    size_t enc_octet_len = 0;       /* number of octets in encrypted portion  */
+    const uint8_t *auth_tag = NULL; /* location of auth_tag within packet     */
     uint8_t tmp_tag[SRTP_MAX_TAG_LEN];
     srtp_err_status_t status;
     size_t auth_len;
     size_t tag_len;
-    srtp_stream_ctx_t * stream;
+    srtp_stream_ctx_t *stream;
     size_t prefix_len;
     uint32_t seq_num;
-    bool e_bit_in_packet; /* E-bit was found in the packet */
+    bool e_bit_in_packet;          /* E-bit was found in the packet */
     bool sec_serv_confidentiality; /* whether confidentiality was requested */
-    srtp_session_keys_t * session_keys = NULL;
+    srtp_session_keys_t *session_keys = NULL;
 
     /*
      * check that the length value is sane; we'll check again once we
@@ -4206,14 +4250,14 @@ srtp_err_status_t srtp_unprotect_rtcp(srtp_t ctx,
      * supports key-sharing, then we assume that a new stream using
      * that key has just started up
      */
-    stream = srtp_get_stream(ctx, hdr -> ssrc);
+    stream = srtp_get_stream(ctx, hdr->ssrc);
     if (stream == NULL) {
-        if (ctx -> stream_template != NULL) {
-            stream = ctx -> stream_template;
+        if (ctx->stream_template != NULL) {
+            stream = ctx->stream_template;
 
             debug_print(mod_srtp,
-                "srtcp using provisional stream (SSRC: 0x%08x)",
-                (unsigned int) ntohl(hdr -> ssrc));
+                        "srtcp using provisional stream (SSRC: 0x%08x)",
+                        (unsigned int)ntohl(hdr->ssrc));
         } else {
             /* no template stream, so we return an error */
             return srtp_err_status_no_ctx;
@@ -4223,20 +4267,20 @@ srtp_err_status_t srtp_unprotect_rtcp(srtp_t ctx,
     /*
      * Determine if MKI is being used and what session keys should be used
      */
-    status = srtp_get_session_keys_for_packet(stream, srtcp, srtcp_len, &
-        session_keys);
+    status = srtp_get_session_keys_for_packet(stream, srtcp, srtcp_len,
+                                              &session_keys);
     if (status) {
         return status;
     }
 
     /* get tag length from stream context */
-    tag_len = srtp_auth_get_tag_length(session_keys -> rtcp_auth);
+    tag_len = srtp_auth_get_tag_length(session_keys->rtcp_auth);
 
     /* check the packet length - it must contain at least a full RTCP
        header, an auth tag (if applicable), and the SRTCP encrypted flag
        and 31-bit index value */
     if (srtcp_len < octets_in_rtcp_header + sizeof(srtcp_trailer_t) +
-        stream -> mki_size + tag_len) {
+                        stream->mki_size + tag_len) {
         return srtp_err_status_bad_param;
     }
 
@@ -4244,21 +4288,21 @@ srtp_err_status_t srtp_unprotect_rtcp(srtp_t ctx,
      * Check if this is an AEAD stream (GCM mode).  If so, then dispatch
      * the request to our AEAD handler.
      */
-    if (session_keys -> rtp_cipher -> algorithm == SRTP_AES_GCM_128 ||
-        session_keys -> rtp_cipher -> algorithm == SRTP_AES_GCM_256) {
+    if (session_keys->rtp_cipher->algorithm == SRTP_AES_GCM_128 ||
+        session_keys->rtp_cipher->algorithm == SRTP_AES_GCM_256) {
         return srtp_unprotect_rtcp_aead(ctx, stream, srtcp, srtcp_len, rtcp,
-            rtcp_len, session_keys);
+                                        rtcp_len, session_keys);
     }
 
-    sec_serv_confidentiality = stream -> rtcp_services == sec_serv_conf ||
-        stream -> rtcp_services == sec_serv_conf_and_auth;
+    sec_serv_confidentiality = stream->rtcp_services == sec_serv_conf ||
+                               stream->rtcp_services == sec_serv_conf_and_auth;
 
     /*
      * set encryption start, encryption length, and trailer
      */
     enc_start = octets_in_rtcp_header;
     enc_octet_len = srtcp_len - (octets_in_rtcp_header + tag_len +
-        stream -> mki_size + sizeof(srtcp_trailer_t));
+                                 stream->mki_size + sizeof(srtcp_trailer_t));
     /*
      *index & E (encryption) bit follow normal data. hdr->len is the number of
      * words (32-bit) in the normal packet minus 1
@@ -4266,10 +4310,10 @@ srtp_err_status_t srtp_unprotect_rtcp(srtp_t ctx,
     /* This should point trailer to the word past the end of the normal data. */
     /* This would need to be modified for optional mikey data */
     trailer_p = srtcp + srtcp_len -
-        (tag_len + stream -> mki_size + sizeof(srtcp_trailer_t));
-    memcpy( & trailer, trailer_p, sizeof(trailer));
+                (tag_len + stream->mki_size + sizeof(srtcp_trailer_t));
+    memcpy(&trailer, trailer_p, sizeof(trailer));
 
-    e_bit_in_packet = ( * trailer_p & SRTCP_E_BYTE_BIT) == SRTCP_E_BYTE_BIT;
+    e_bit_in_packet = (*trailer_p & SRTCP_E_BYTE_BIT) == SRTCP_E_BYTE_BIT;
     if (e_bit_in_packet != sec_serv_confidentiality) {
         return srtp_err_status_cant_check;
     }
@@ -4285,16 +4329,16 @@ srtp_err_status_t srtp_unprotect_rtcp(srtp_t ctx,
      * could be present.  The data needed to calculate the Auth tag
      * must not include the MKI
      */
-    auth_len = srtcp_len - tag_len - stream -> mki_size;
-    auth_tag = srtcp + auth_len + stream -> mki_size;
+    auth_len = srtcp_len - tag_len - stream->mki_size;
+    auth_tag = srtcp + auth_len + stream->mki_size;
 
     /*
      * check the sequence number for replays
      */
     /* this is easier than dealing with bitfield access */
     seq_num = ntohl(trailer) & SRTCP_INDEX_MASK;
-    debug_print(mod_srtp, "srtcp index: %x", (unsigned int) seq_num);
-    status = srtp_rdb_check( & stream -> rtcp_rdb, seq_num);
+    debug_print(mod_srtp, "srtcp index: %x", (unsigned int)seq_num);
+    status = srtp_rdb_check(&stream->rtcp_rdb, seq_num);
     if (status) {
         return status;
     }
@@ -4302,17 +4346,17 @@ srtp_err_status_t srtp_unprotect_rtcp(srtp_t ctx,
     /*
      * if we're using aes counter mode, set nonce and seq
      */
-    if (session_keys -> rtcp_cipher -> type -> id == SRTP_AES_ICM_128 ||
-        session_keys -> rtcp_cipher -> type -> id == SRTP_AES_ICM_192 ||
-        session_keys -> rtcp_cipher -> type -> id == SRTP_AES_ICM_256) {
+    if (session_keys->rtcp_cipher->type->id == SRTP_AES_ICM_128 ||
+        session_keys->rtcp_cipher->type->id == SRTP_AES_ICM_192 ||
+        session_keys->rtcp_cipher->type->id == SRTP_AES_ICM_256) {
         v128_t iv;
 
         iv.v32[0] = 0;
-        iv.v32[1] = hdr -> ssrc; /* still in network order! */
+        iv.v32[1] = hdr->ssrc; /* still in network order! */
         iv.v32[2] = htonl(seq_num >> 16);
         iv.v32[3] = htonl(seq_num << 16);
-        status = srtp_cipher_set_iv(session_keys -> rtcp_cipher, (uint8_t * ) & iv,
-            srtp_direction_decrypt);
+        status = srtp_cipher_set_iv(session_keys->rtcp_cipher, (uint8_t *)&iv,
+                                    srtp_direction_decrypt);
 
     } else {
         v128_t iv;
@@ -4322,8 +4366,8 @@ srtp_err_status_t srtp_unprotect_rtcp(srtp_t ctx,
         iv.v32[1] = 0;
         iv.v32[2] = 0;
         iv.v32[3] = htonl(seq_num);
-        status = srtp_cipher_set_iv(session_keys -> rtcp_cipher, (uint8_t * ) & iv,
-            srtp_direction_decrypt);
+        status = srtp_cipher_set_iv(session_keys->rtcp_cipher, (uint8_t *)&iv,
+                                    srtp_direction_decrypt);
     }
     if (status) {
         return srtp_err_status_cipher_fail;
@@ -4333,42 +4377,42 @@ srtp_err_status_t srtp_unprotect_rtcp(srtp_t ctx,
      * if we're authenticating using a universal hash, put the keystream
      * prefix into the authentication tag
      */
-    prefix_len = srtp_auth_get_prefix_length(session_keys -> rtcp_auth);
+    prefix_len = srtp_auth_get_prefix_length(session_keys->rtcp_auth);
     if (prefix_len) {
         status =
-            srtp_cipher_output(session_keys -> rtcp_cipher, tmp_tag, & prefix_len);
+            srtp_cipher_output(session_keys->rtcp_cipher, tmp_tag, &prefix_len);
         debug_print(mod_srtp, "keystream prefix: %s",
-            srtp_octet_string_hex_string(tmp_tag, prefix_len));
+                    srtp_octet_string_hex_string(tmp_tag, prefix_len));
         if (status) {
             return srtp_err_status_cipher_fail;
         }
     }
 
     /* initialize auth func context */
-    status = srtp_auth_start(session_keys -> rtcp_auth);
+    status = srtp_auth_start(session_keys->rtcp_auth);
     if (status) {
         return status;
     }
 
     /* run auth func over packet, put result into tmp_tag */
-    status = srtp_auth_compute(session_keys -> rtcp_auth, auth_start, auth_len,
-        tmp_tag);
+    status = srtp_auth_compute(session_keys->rtcp_auth, auth_start, auth_len,
+                               tmp_tag);
     debug_print(mod_srtp, "srtcp computed tag:       %s",
-        srtp_octet_string_hex_string(tmp_tag, tag_len));
+                srtp_octet_string_hex_string(tmp_tag, tag_len));
     if (status) {
         return srtp_err_status_auth_fail;
     }
 
     /* compare the tag just computed with the one in the packet */
     debug_print(mod_srtp, "srtcp tag from packet:    %s",
-        srtp_octet_string_hex_string(auth_tag, tag_len));
+                srtp_octet_string_hex_string(auth_tag, tag_len));
     if (!srtp_octet_string_equal(tmp_tag, auth_tag, tag_len)) {
         return srtp_err_status_auth_fail;
     }
 
     /* check output length */
-    if ( * rtcp_len <
-        srtcp_len - sizeof(srtcp_trailer_t) - stream -> mki_size - tag_len) {
+    if (*rtcp_len <
+        srtcp_len - sizeof(srtcp_trailer_t) - stream->mki_size - tag_len) {
         return srtp_err_status_buffer_small;
     }
 
@@ -4379,9 +4423,9 @@ srtp_err_status_t srtp_unprotect_rtcp(srtp_t ctx,
 
     /* if we're decrypting, exor keystream into the message */
     if (sec_serv_confidentiality) {
-        status = srtp_cipher_decrypt(session_keys -> rtcp_cipher,
-            srtcp + enc_start, enc_octet_len,
-            rtcp + enc_start, & enc_octet_len);
+        status = srtp_cipher_decrypt(session_keys->rtcp_cipher,
+                                     srtcp + enc_start, enc_octet_len,
+                                     rtcp + enc_start, &enc_octet_len);
         if (status) {
             return srtp_err_status_cipher_fail;
         }
@@ -4390,13 +4434,13 @@ srtp_err_status_t srtp_unprotect_rtcp(srtp_t ctx,
         memcpy(rtcp + enc_start, srtcp + enc_start, enc_octet_len);
     }
 
-    * rtcp_len = srtcp_len;
+    *rtcp_len = srtcp_len;
 
     /* decrease the packet length by the length of the auth tag and seq_num */
-    * rtcp_len -= (tag_len + sizeof(srtcp_trailer_t));
+    *rtcp_len -= (tag_len + sizeof(srtcp_trailer_t));
 
     /* decrease the packet length by the length of the mki_size */
-    * rtcp_len -= stream -> mki_size;
+    *rtcp_len -= stream->mki_size;
 
     /*
      * verify that stream is for received traffic - this check will
@@ -4408,9 +4452,9 @@ srtp_err_status_t srtp_unprotect_rtcp(srtp_t ctx,
      * latter check will catch any attempts to fool us into thinking
      * that we've got a collision
      */
-    if (stream -> direction != dir_srtp_receiver) {
-        if (stream -> direction == dir_unknown) {
-            stream -> direction = dir_srtp_receiver;
+    if (stream->direction != dir_srtp_receiver) {
+        if (stream->direction == dir_unknown) {
+            stream->direction = dir_srtp_receiver;
         } else {
             srtp_handle_event(ctx, stream, event_ssrc_collision);
         }
@@ -4421,8 +4465,8 @@ srtp_err_status_t srtp_unprotect_rtcp(srtp_t ctx,
      * is used, then we need to allocate a new stream at this point, since
      * the authentication passed
      */
-    if (stream == ctx -> stream_template) {
-        srtp_stream_ctx_t * new_stream;
+    if (stream == ctx->stream_template) {
+        srtp_stream_ctx_t *new_stream;
 
         /*
          * allocate and initialize a new stream
@@ -4432,14 +4476,14 @@ srtp_err_status_t srtp_unprotect_rtcp(srtp_t ctx,
          * failure here
          */
         status =
-            srtp_stream_clone(ctx -> stream_template, hdr -> ssrc, & new_stream);
+            srtp_stream_clone(ctx->stream_template, hdr->ssrc, &new_stream);
         if (status) {
             return status;
         }
 
         /* add new stream to the list */
-        status = srtp_insert_or_dealloc_stream(ctx -> stream_list, new_stream,
-            ctx -> stream_template);
+        status = srtp_insert_or_dealloc_stream(ctx->stream_list, new_stream,
+                                               ctx->stream_template);
         if (status) {
             return status;
         }
@@ -4449,7 +4493,7 @@ srtp_err_status_t srtp_unprotect_rtcp(srtp_t ctx,
     }
 
     /* we've passed the authentication check, so add seq_num to the rdb */
-    srtp_rdb_add_index( & stream -> rtcp_rdb, seq_num);
+    srtp_rdb_add_index(&stream->rtcp_rdb, seq_num);
 
     return srtp_err_status_ok;
 }
@@ -4458,17 +4502,20 @@ srtp_err_status_t srtp_unprotect_rtcp(srtp_t ctx,
  * user data within srtp_t context
  */
 
-void srtp_set_user_data(srtp_t ctx, void * data) {
-    ctx -> user_data = data;
+void srtp_set_user_data(srtp_t ctx, void *data)
+{
+    ctx->user_data = data;
 }
 
-void * srtp_get_user_data(srtp_t ctx) {
-    return ctx -> user_data;
+void *srtp_get_user_data(srtp_t ctx)
+{
+    return ctx->user_data;
 }
 
 srtp_err_status_t srtp_crypto_policy_set_from_profile_for_rtp(
-    srtp_crypto_policy_t * policy,
-    srtp_profile_t profile) {
+    srtp_crypto_policy_t *policy,
+    srtp_profile_t profile)
+{
     /* set SRTP policy from the SRTP profile in the key set */
     switch (profile) {
     case srtp_profile_aes128_cm_sha1_80:
@@ -4480,15 +4527,15 @@ srtp_err_status_t srtp_crypto_policy_set_from_profile_for_rtp(
     case srtp_profile_null_sha1_80:
         srtp_crypto_policy_set_null_cipher_hmac_sha1_80(policy);
         break;
-        #ifdef GCM
+#ifdef GCM
     case srtp_profile_aead_aes_128_gcm:
         srtp_crypto_policy_set_aes_gcm_128_16_auth(policy);
         break;
     case srtp_profile_aead_aes_256_gcm:
         srtp_crypto_policy_set_aes_gcm_256_16_auth(policy);
         break;
-        #endif
-        /* the following profiles are not (yet) supported */
+#endif
+    /* the following profiles are not (yet) supported */
     case srtp_profile_null_sha1_32:
     default:
         return srtp_err_status_bad_param;
@@ -4498,8 +4545,9 @@ srtp_err_status_t srtp_crypto_policy_set_from_profile_for_rtp(
 }
 
 srtp_err_status_t srtp_crypto_policy_set_from_profile_for_rtcp(
-    srtp_crypto_policy_t * policy,
-    srtp_profile_t profile) {
+    srtp_crypto_policy_t *policy,
+    srtp_profile_t profile)
+{
     /* set SRTP policy from the SRTP profile in the key set */
     switch (profile) {
     case srtp_profile_aes128_cm_sha1_80:
@@ -4513,15 +4561,15 @@ srtp_err_status_t srtp_crypto_policy_set_from_profile_for_rtcp(
     case srtp_profile_null_sha1_80:
         srtp_crypto_policy_set_null_cipher_hmac_sha1_80(policy);
         break;
-        #ifdef GCM
+#ifdef GCM
     case srtp_profile_aead_aes_128_gcm:
         srtp_crypto_policy_set_aes_gcm_128_16_auth(policy);
         break;
     case srtp_profile_aead_aes_256_gcm:
         srtp_crypto_policy_set_aes_gcm_256_16_auth(policy);
         break;
-        #endif
-        /* the following profiles are not (yet) supported */
+#endif
+    /* the following profiles are not (yet) supported */
     case srtp_profile_null_sha1_32:
     default:
         return srtp_err_status_bad_param;
@@ -4530,14 +4578,16 @@ srtp_err_status_t srtp_crypto_policy_set_from_profile_for_rtcp(
     return srtp_err_status_ok;
 }
 
-void srtp_append_salt_to_key(uint8_t * key,
-    size_t bytes_in_key,
-    uint8_t * salt,
-    size_t bytes_in_salt) {
+void srtp_append_salt_to_key(uint8_t *key,
+                             size_t bytes_in_key,
+                             uint8_t *salt,
+                             size_t bytes_in_salt)
+{
     memcpy(key + bytes_in_key, salt, bytes_in_salt);
 }
 
-size_t srtp_profile_get_master_key_length(srtp_profile_t profile) {
+size_t srtp_profile_get_master_key_length(srtp_profile_t profile)
+{
     switch (profile) {
     case srtp_profile_aes128_cm_sha1_80:
         return SRTP_AES_128_KEY_LEN;
@@ -4554,14 +4604,15 @@ size_t srtp_profile_get_master_key_length(srtp_profile_t profile) {
     case srtp_profile_aead_aes_256_gcm:
         return SRTP_AES_256_KEY_LEN;
         break;
-        /* the following profiles are not (yet) supported */
+    /* the following profiles are not (yet) supported */
     case srtp_profile_null_sha1_32:
     default:
         return 0; /* indicate error by returning a zero */
     }
 }
 
-size_t srtp_profile_get_master_salt_length(srtp_profile_t profile) {
+size_t srtp_profile_get_master_salt_length(srtp_profile_t profile)
+{
     switch (profile) {
     case srtp_profile_aes128_cm_sha1_80:
         return SRTP_SALT_LEN;
@@ -4578,37 +4629,38 @@ size_t srtp_profile_get_master_salt_length(srtp_profile_t profile) {
     case srtp_profile_aead_aes_256_gcm:
         return SRTP_AEAD_SALT_LEN;
         break;
-        /* the following profiles are not (yet) supported */
+    /* the following profiles are not (yet) supported */
     case srtp_profile_null_sha1_32:
     default:
         return 0; /* indicate error by returning a zero */
     }
 }
 
-srtp_err_status_t stream_get_protect_trailer_length(srtp_stream_ctx_t * stream,
-    bool is_rtp,
-    size_t mki_index,
-    size_t * length) {
-    srtp_session_keys_t * session_key;
+srtp_err_status_t stream_get_protect_trailer_length(srtp_stream_ctx_t *stream,
+                                                    bool is_rtp,
+                                                    size_t mki_index,
+                                                    size_t *length)
+{
+    srtp_session_keys_t *session_key;
 
-    * length = 0;
+    *length = 0;
 
-    if (stream -> use_mki) {
-        if (mki_index >= stream -> num_master_keys) {
+    if (stream->use_mki) {
+        if (mki_index >= stream->num_master_keys) {
             return srtp_err_status_bad_mki;
         }
-        session_key = & stream -> session_keys[mki_index];
+        session_key = &stream->session_keys[mki_index];
 
-        * length += stream -> mki_size;
+        *length += stream->mki_size;
 
     } else {
-        session_key = & stream -> session_keys[0];
+        session_key = &stream->session_keys[0];
     }
     if (is_rtp) {
-        * length += srtp_auth_get_tag_length(session_key -> rtp_auth);
+        *length += srtp_auth_get_tag_length(session_key->rtp_auth);
     } else {
-        * length += srtp_auth_get_tag_length(session_key -> rtcp_auth);
-        * length += sizeof(srtcp_trailer_t);
+        *length += srtp_auth_get_tag_length(session_key->rtcp_auth);
+        *length += sizeof(srtcp_trailer_t);
     }
 
     return srtp_err_status_ok;
@@ -4616,21 +4668,22 @@ srtp_err_status_t stream_get_protect_trailer_length(srtp_stream_ctx_t * stream,
 
 struct get_protect_trailer_length_data {
     bool found_stream; /* whether at least one matching stream was found */
-    size_t length; /* maximum trailer length found so far */
+    size_t length;     /* maximum trailer length found so far */
     bool is_rtp;
     size_t mki_index;
 };
 
-static bool get_protect_trailer_length_cb(srtp_stream_t stream, void * raw_data) {
-    struct get_protect_trailer_length_data * data =
-        (struct get_protect_trailer_length_data * ) raw_data;
+static bool get_protect_trailer_length_cb(srtp_stream_t stream, void *raw_data)
+{
+    struct get_protect_trailer_length_data *data =
+        (struct get_protect_trailer_length_data *)raw_data;
     size_t temp_length;
 
-    if (stream_get_protect_trailer_length(stream, data -> is_rtp, data -> mki_index, &
-            temp_length) == srtp_err_status_ok) {
-        data -> found_stream = true;
-        if (temp_length > data -> length) {
-            data -> length = temp_length;
+    if (stream_get_protect_trailer_length(stream, data->is_rtp, data->mki_index,
+                                          &temp_length) == srtp_err_status_ok) {
+        data->found_stream = true;
+        if (temp_length > data->length) {
+            data->length = temp_length;
         }
     }
 
@@ -4638,60 +4691,61 @@ static bool get_protect_trailer_length_cb(srtp_stream_t stream, void * raw_data)
 }
 
 srtp_err_status_t get_protect_trailer_length(srtp_t session,
-    bool is_rtp,
-    size_t mki_index,
-    size_t * length) {
-    srtp_stream_ctx_t * stream;
-    struct get_protect_trailer_length_data data = {
-        false,
-        0,
-        is_rtp,
-        mki_index
-    };
+                                             bool is_rtp,
+                                             size_t mki_index,
+                                             size_t *length)
+{
+    srtp_stream_ctx_t *stream;
+    struct get_protect_trailer_length_data data = { false, 0, is_rtp,
+                                                    mki_index };
 
     if (session == NULL) {
         return srtp_err_status_bad_param;
     }
 
-    stream = session -> stream_template;
+    stream = session->stream_template;
 
     if (stream != NULL) {
         data.found_stream = true;
-        stream_get_protect_trailer_length(stream, is_rtp, mki_index, &
-            data.length);
+        stream_get_protect_trailer_length(stream, is_rtp, mki_index,
+                                          &data.length);
     }
 
-    srtp_stream_list_for_each(session -> stream_list,
-        get_protect_trailer_length_cb, & data);
+    srtp_stream_list_for_each(session->stream_list,
+                              get_protect_trailer_length_cb, &data);
 
     if (!data.found_stream) {
         return srtp_err_status_bad_param;
     }
 
-    * length = data.length;
+    *length = data.length;
     return srtp_err_status_ok;
 }
 
 srtp_err_status_t srtp_get_protect_trailer_length(srtp_t session,
-    size_t mki_index,
-    size_t * length) {
+                                                  size_t mki_index,
+                                                  size_t *length)
+{
     return get_protect_trailer_length(session, true, mki_index, length);
 }
 
 srtp_err_status_t srtp_get_protect_rtcp_trailer_length(srtp_t session,
-    size_t mki_index,
-    size_t * length) {
+                                                       size_t mki_index,
+                                                       size_t *length)
+{
     return get_protect_trailer_length(session, false, mki_index, length);
 }
 
 /*
  * SRTP debug interface
  */
-srtp_err_status_t srtp_set_debug_module(const char * mod_name, bool v) {
+srtp_err_status_t srtp_set_debug_module(const char *mod_name, bool v)
+{
     return srtp_crypto_kernel_set_debug_module(mod_name, v);
 }
 
-srtp_err_status_t srtp_list_debug_modules(void) {
+srtp_err_status_t srtp_list_debug_modules(void)
+{
     return srtp_crypto_kernel_list_debug_modules();
 }
 
@@ -4701,11 +4755,11 @@ srtp_err_status_t srtp_list_debug_modules(void) {
  * output.
  */
 
-static srtp_log_handler_func_t * srtp_log_handler = NULL;
-static void * srtp_log_handler_data = NULL;
+static srtp_log_handler_func_t *srtp_log_handler = NULL;
+static void *srtp_log_handler_data = NULL;
 
-static void srtp_err_handler(srtp_err_reporting_level_t level,
-    const char * msg) {
+static void srtp_err_handler(srtp_err_reporting_level_t level, const char *msg)
+{
     if (srtp_log_handler) {
         srtp_log_level_t log_level = srtp_log_level_error;
         switch (level) {
@@ -4728,7 +4782,8 @@ static void srtp_err_handler(srtp_err_reporting_level_t level,
 }
 
 srtp_err_status_t srtp_install_log_handler(srtp_log_handler_func_t func,
-    void * data) {
+                                           void *data)
+{
     /*
      * note that we accept NULL arguments intentionally - calling this
      * function with a NULL arguments removes a log handler that's
@@ -4747,8 +4802,9 @@ srtp_err_status_t srtp_install_log_handler(srtp_log_handler_func_t func,
 }
 
 srtp_err_status_t srtp_stream_set_roc(srtp_t session,
-    uint32_t ssrc,
-    uint32_t roc) {
+                                      uint32_t ssrc,
+                                      uint32_t roc)
+{
     srtp_stream_t stream;
 
     stream = srtp_get_stream(session, htonl(ssrc));
@@ -4756,14 +4812,15 @@ srtp_err_status_t srtp_stream_set_roc(srtp_t session,
         return srtp_err_status_bad_param;
     }
 
-    stream -> pending_roc = roc;
+    stream->pending_roc = roc;
 
     return srtp_err_status_ok;
 }
 
 srtp_err_status_t srtp_stream_get_roc(srtp_t session,
-    uint32_t ssrc,
-    uint32_t * roc) {
+                                      uint32_t ssrc,
+                                      uint32_t *roc)
+{
     srtp_stream_t stream;
 
     stream = srtp_get_stream(session, htonl(ssrc));
@@ -4771,7 +4828,7 @@ srtp_err_status_t srtp_stream_get_roc(srtp_t session,
         return srtp_err_status_bad_param;
     }
 
-    * roc = srtp_rdbx_get_roc( & stream -> rtp_rdbx);
+    *roc = srtp_rdbx_get_roc(&stream->rtp_rdbx);
 
     return srtp_err_status_ok;
 }
@@ -4783,45 +4840,45 @@ srtp_err_status_t srtp_stream_get_roc(srtp_t session,
 typedef struct list_entry {
     uint32_t ssrc;
     srtp_stream_t stream;
-}
-list_entry;
+} list_entry;
 
 typedef struct srtp_stream_list_ctx_t_ {
-    list_entry * entries;
+    list_entry *entries;
     size_t capacity;
     size_t size;
-}
-srtp_stream_list_ctx_t_;
+} srtp_stream_list_ctx_t_;
 
-srtp_err_status_t srtp_stream_list_alloc(srtp_stream_list_t * list_ptr) {
+srtp_err_status_t srtp_stream_list_alloc(srtp_stream_list_t *list_ptr)
+{
     srtp_stream_list_t list =
         srtp_crypto_alloc(sizeof(srtp_stream_list_ctx_t_));
     if (list == NULL) {
         return srtp_err_status_alloc_fail;
     }
 
-    list -> entries =
+    list->entries =
         srtp_crypto_alloc(sizeof(list_entry) * INITIAL_STREAM_INDEX_SIZE);
-    if (list -> entries == NULL) {
+    if (list->entries == NULL) {
         srtp_crypto_free(list);
         return srtp_err_status_alloc_fail;
     }
 
-    list -> capacity = INITIAL_STREAM_INDEX_SIZE;
-    list -> size = 0;
+    list->capacity = INITIAL_STREAM_INDEX_SIZE;
+    list->size = 0;
 
-    * list_ptr = list;
+    *list_ptr = list;
 
     return srtp_err_status_ok;
 }
 
-srtp_err_status_t srtp_stream_list_dealloc(srtp_stream_list_t list) {
+srtp_err_status_t srtp_stream_list_dealloc(srtp_stream_list_t list)
+{
     /* list must be empty */
-    if (list -> size != 0) {
+    if (list->size != 0) {
         return srtp_err_status_fail;
     }
 
-    srtp_crypto_free(list -> entries);
+    srtp_crypto_free(list->entries);
     srtp_crypto_free(list);
 
     return srtp_err_status_ok;
@@ -4832,46 +4889,48 @@ srtp_err_status_t srtp_stream_list_dealloc(srtp_stream_list_t list) {
  * to keep all the items in a contiguous memory block.
  */
 srtp_err_status_t srtp_stream_list_insert(srtp_stream_list_t list,
-    srtp_stream_t stream) {
+                                          srtp_stream_t stream)
+{
     /*
      * there is no space to hold the new entry in the entries buffer,
      * double the size of the buffer.
      */
-    if (list -> size == list -> capacity) {
-        size_t new_capacity = list -> capacity * 2;
-
+    if (list->size == list->capacity) {
+        size_t new_capacity = list->capacity * 2;
+    
         // Check for capacity overflow.
-        if (new_capacity < list -> capacity ||
+        if (new_capacity < list->capacity ||
             new_capacity > SIZE_MAX / sizeof(list_entry)) {
             return srtp_err_status_alloc_fail;
         }
-
-        list_entry * new_entries =
+    
+        list_entry *new_entries =
             srtp_crypto_alloc(sizeof(list_entry) * new_capacity);
         if (new_entries == NULL) {
             return srtp_err_status_alloc_fail;
         }
-
+    
         // Copy previous entries into the new buffer.
-        memcpy(new_entries, list -> entries, sizeof(list_entry) * list -> capacity);
-
+        memcpy(new_entries, list->entries, sizeof(list_entry) * list->capacity);
+    
         // Release previous entries.
-        srtp_crypto_free(list -> entries);
-
+        srtp_crypto_free(list->entries);
+    
         // Assign new entries to the list.
-        list -> entries = new_entries;
-
+        list->entries = new_entries;
+    
         // Update list capacity.
-        list -> capacity = new_capacity;
+        list->capacity = new_capacity;
     }
 
+
     // fill the first available entry
-    size_t next_index = list -> size;
-    list -> entries[next_index].ssrc = stream -> ssrc;
-    list -> entries[next_index].stream = stream;
+    size_t next_index = list->size;
+    list->entries[next_index].ssrc = stream->ssrc;
+    list->entries[next_index].stream = stream;
 
     // update size value
-    list -> size++;
+    list->size++;
 
     return srtp_err_status_ok;
 }
@@ -4882,25 +4941,27 @@ srtp_err_status_t srtp_stream_list_insert(srtp_stream_list_t list,
  * contiguous.
  */
 void srtp_stream_list_remove(srtp_stream_list_t list,
-    srtp_stream_t stream_to_remove) {
-    size_t end = list -> size;
+                             srtp_stream_t stream_to_remove)
+{
+    size_t end = list->size;
 
     for (size_t i = 0; i < end; i++) {
-        if (list -> entries[i].ssrc == stream_to_remove -> ssrc) {
-            size_t entries_to_move = list -> size - i - 1;
-            memmove( & list -> entries[i], & list -> entries[i + 1],
-                sizeof(list_entry) * entries_to_move);
-            list -> size--;
+        if (list->entries[i].ssrc == stream_to_remove->ssrc) {
+            size_t entries_to_move = list->size - i - 1;
+            memmove(&list->entries[i], &list->entries[i + 1],
+                    sizeof(list_entry) * entries_to_move);
+            list->size--;
 
             break;
         }
     }
 }
 
-srtp_stream_t srtp_stream_list_get(srtp_stream_list_t list, uint32_t ssrc) {
-    size_t end = list -> size;
+srtp_stream_t srtp_stream_list_get(srtp_stream_list_t list, uint32_t ssrc)
+{
+    size_t end = list->size;
 
-    list_entry * entries = list -> entries;
+    list_entry *entries = list->entries;
 
     for (size_t i = 0; i < end; i++) {
         if (entries[i].ssrc == ssrc) {
@@ -4912,11 +4973,12 @@ srtp_stream_t srtp_stream_list_get(srtp_stream_list_t list, uint32_t ssrc) {
 }
 
 void srtp_stream_list_for_each(srtp_stream_list_t list,
-    bool( * callback)(srtp_stream_t, void * ),
-    void * data) {
-    list_entry * entries = list -> entries;
+                               bool (*callback)(srtp_stream_t, void *),
+                               void *data)
+{
+    list_entry *entries = list->entries;
 
-    size_t size = list -> size;
+    size_t size = list->size;
 
     /*
      * the second statement of the expression needs to be recalculated on each
@@ -4924,17 +4986,17 @@ void srtp_stream_list_for_each(srtp_stream_list_t list,
      * callback.
      * Ie: in case the callback calls srtp_stream_list_remove().
      */
-    for (size_t i = 0; i < list -> size;) {
+    for (size_t i = 0; i < list->size;) {
         if (!callback(entries[i].stream, data)) {
             break;
         }
 
         // the entry was not removed, increase the counter.
-        if (size == list -> size) {
+        if (size == list->size) {
             ++i;
         }
 
-        size = list -> size;
+        size = list->size;
     }
 }
 

--- a/srtp/srtp.c
+++ b/srtp/srtp.c
@@ -4897,27 +4897,32 @@ srtp_err_status_t srtp_stream_list_insert(srtp_stream_list_t list,
      */
     if (list->size == list->capacity) {
         size_t new_capacity = list->capacity * 2;
-
-        // check for capacity overflow.
-        if (new_capacity < list->capacity || new_capacity > SIZE_MAX / sizeof(list_entry)) {
+    
+        // Check for capacity overflow.
+        if (new_capacity < list->capacity ||
+            new_capacity > SIZE_MAX / sizeof(list_entry)) {
             return srtp_err_status_alloc_fail;
         }
-
+    
         list_entry *new_entries =
             srtp_crypto_alloc(sizeof(list_entry) * new_capacity);
         if (new_entries == NULL) {
             return srtp_err_status_alloc_fail;
         }
-
-        // copy previous entries into the new buffer
+    
+        // Copy previous entries into the new buffer.
         memcpy(new_entries, list->entries, sizeof(list_entry) * list->capacity);
-        // release previous entries
+    
+        // Release previous entries.
         srtp_crypto_free(list->entries);
-        // assign new entries to the list
+    
+        // Assign new entries to the list.
         list->entries = new_entries;
-        // update list capacity
+    
+        // Update list capacity.
         list->capacity = new_capacity;
     }
+
 
     // fill the first available entry
     size_t next_index = list->size;

--- a/srtp/srtp.c
+++ b/srtp/srtp.c
@@ -4897,32 +4897,31 @@ srtp_err_status_t srtp_stream_list_insert(srtp_stream_list_t list,
      */
     if (list->size == list->capacity) {
         size_t new_capacity = list->capacity * 2;
-    
+
         // Check for capacity overflow.
         if (new_capacity < list->capacity ||
             new_capacity > SIZE_MAX / sizeof(list_entry)) {
             return srtp_err_status_alloc_fail;
         }
-    
+
         list_entry *new_entries =
             srtp_crypto_alloc(sizeof(list_entry) * new_capacity);
         if (new_entries == NULL) {
             return srtp_err_status_alloc_fail;
         }
-    
+
         // Copy previous entries into the new buffer.
         memcpy(new_entries, list->entries, sizeof(list_entry) * list->capacity);
-    
+
         // Release previous entries.
         srtp_crypto_free(list->entries);
-    
+
         // Assign new entries to the list.
         list->entries = new_entries;
-    
+
         // Update list capacity.
         list->capacity = new_capacity;
     }
-
 
     // fill the first available entry
     size_t next_index = list->size;

--- a/srtp/srtp.c
+++ b/srtp/srtp.c
@@ -4899,8 +4899,12 @@ srtp_err_status_t srtp_stream_list_insert(srtp_stream_list_t list,
         size_t new_capacity = list->capacity * 2;
 
         // check for capacity overflow.
-        if ((sizeof(list_entry) * new_capacity) <=
-            (sizeof(list_entry) * list->capacity)) {
+        // Fix: Ensure new_capacity does not regress below current capacity
+        // and prevent integer overflow during memory allocation.
+        // The multiplication (sizeof(list_entry) * new_capacity) is validated
+        // by checking that new_capacity is less than SIZE_MAX / sizeof(list_entry).
+        if (new_capacity < list->capacity || 
+            new_capacity > SIZE_MAX / sizeof(list_entry)) {
             return srtp_err_status_alloc_fail;
         }
 

--- a/srtp/srtp.c
+++ b/srtp/srtp.c
@@ -4899,12 +4899,7 @@ srtp_err_status_t srtp_stream_list_insert(srtp_stream_list_t list,
         size_t new_capacity = list->capacity * 2;
 
         // check for capacity overflow.
-        // Fix: Ensure new_capacity does not regress below current capacity
-        // and prevent integer overflow during memory allocation.
-        // The multiplication (sizeof(list_entry) * new_capacity) is validated
-        // by checking that new_capacity is less than SIZE_MAX / sizeof(list_entry).
-        if (new_capacity < list->capacity || 
-            new_capacity > SIZE_MAX / sizeof(list_entry)) {
+        if (new_capacity < list->capacity || new_capacity > SIZE_MAX / sizeof(list_entry)) {
             return srtp_err_status_alloc_fail;
         }
 


### PR DESCRIPTION

**Fix Memory Overflow and Capacity Regression in `srtp_stream_list_insert`**

This pull request addresses a critical issue in the `srtp_stream_list_insert` function where potential integer overflow and capacity regression could occur during memory allocation. 

#### **Problem**
The original code attempted to validate the multiplication of `sizeof(list_entry)` and `new_capacity` to check for overflow. However, this approach was flawed because the multiplication itself could overflow before the comparison, leading to undefined behavior.

#### **Solution**
The fix ensures:
1. **Prevention of Integer Overflow**:
   - Validates `new_capacity` against `SIZE_MAX / sizeof(list_entry)` before performing the multiplication.
2. **Prevention of Capacity Regression**:
   - Adds a check to ensure `new_capacity` does not regress below the current capacity, safeguarding against unintentional regressions.

#### **Updated Code**
The following changes were made in the `srtp_stream_list_insert` function:
```c
size_t new_capacity = list->capacity * 2;

// Check for capacity overflow.
// Fix: Ensure new_capacity does not regress below current capacity
// and prevent integer overflow during memory allocation.
// The multiplication (sizeof(list_entry) * new_capacity) is validated
// by checking that new_capacity is less than SIZE_MAX / sizeof(list_entry).
if (new_capacity < list->capacity || 
    new_capacity > SIZE_MAX / sizeof(list_entry)) {
    return srtp_err_status_alloc_fail;
}
```

#### **Impact**
1. **Improved Memory Safety**:
   - Eliminates the risk of undefined behavior caused by integer overflow during memory allocation.
2. **Enhanced Robustness**:
   - Ensures that `new_capacity` always increases or remains valid, preventing capacity regression.

#### **Testing**
- Verified the fix on multiple scenarios to ensure correctness and performance.
- Passed all existing tests for `srtp_stream_list_insert` without any regressions.

#### **Additional Notes**
- The fix adheres to standard C programming best practices for safe memory management.
- This change does not introduce new dependencies or significant overhead.
