### PR TITLE
make it easier to use local build of wolfssl

### DIFF
--- a/cmake/FindwolfSSL.cmake
+++ b/cmake/FindwolfSSL.cmake
@@ -1,6 +1,10 @@
-find_path(WOLFSSL_INCLUDE_DIR wolfssl/ssl.h)
+if (WOLFSSL_ROOT_DIR)
+    set(_WOLFSSL_ROOT_HINTS_AND_PATHS HINTS ${WOLFSSL_ROOT_DIR} PATH_SUFFIXES include lib NO_DEFAULT_PATH)
+endif()
 
-find_library(WOLFSSL_LIBRARY wolfssl)
+find_path(WOLFSSL_INCLUDE_DIR wolfssl/ssl.h ${_WOLFSSL_ROOT_HINTS_AND_PATHS})
+
+find_library(WOLFSSL_LIBRARY wolfssl ${_WOLFSSL_ROOT_HINTS_AND_PATHS})
 
 include(FindPackageHandleStandardArgs)
 find_package_handle_standard_args(wolfSSL DEFAULT_MSG


### PR DESCRIPTION
WOLFSSL_ROOT_DIR can then be set to a local installation.