### PR TITLE
explicitly look for mbedcrypto dependency

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -154,7 +154,7 @@ elif crypto_library == 'nss'
     error('KDF support has not been implemented for NSS')
   endif
 elif crypto_library == 'mbedtls'
-  mbedtls_dep = dependency('mbedtls', required: false)
+  mbedtls_dep = dependency('mbedcrypto', required: false)
   if not mbedtls_dep.found()
     mbedtls_dep = cc.find_library('mbedcrypto', has_headers: ['mbedtls/aes.h'], required: true)
   endif


### PR DESCRIPTION
At least on OSX this is now required in order get the mbedcrypto library on the link line.

I ma not sure what has changed but testing shows this to fix the issue.

#700

(cherry picked from commit 981d6951a9808f062358dd700259d6f3b880cb3c)