### PR TITLE
Fix shorten-64-to-32

### DIFF
--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -17,8 +17,6 @@ jobs:
         crypto: [internal, openssl, openssl3, wolfssl, nss, mbedtls]
         exclude:
           - os: windows-latest
-            crypto: openssl
-          - os: windows-latest
             crypto: wolfssl
           - os: windows-latest
             crypto: openssl3

--- a/.github/workflows/ios.yml
+++ b/.github/workflows/ios.yml
@@ -1,0 +1,31 @@
+name: IOS CI
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+
+jobs:
+  build:
+    strategy:
+      fail-fast: false
+
+    runs-on: macos-latest
+
+    steps:
+
+    - uses: actions/checkout@v2
+
+    - name: Create Build Environment
+      run: cmake -E make_directory ${{github.workspace}}/build
+
+    - name: Configure CMake
+      working-directory: ${{github.workspace}}/build
+      shell: bash
+      run: cmake $GITHUB_WORKSPACE -GXcode -DCMAKE_SYSTEM_NAME=iOS
+
+    - name: Build
+      working-directory: ${{github.workspace}}/build
+      shell: bash
+      run: cmake --build . --target srtp3 -- -sdk iphonesimulator

--- a/cmake/Warnings.cmake
+++ b/cmake/Warnings.cmake
@@ -31,7 +31,7 @@ function(target_set_warnings)
  #       /w14906 # string literal cast to 'LPWSTR'
     )
 
-    set(CLANG_WARNINGS
+    set(COMMON_WARNINGS
         # Baseline
         -Wall
         -Wextra # reasonable and standard
@@ -48,8 +48,13 @@ function(target_set_warnings)
         -Wcast-qual
     )
 
+    set(CLANG_WARNINGS
+        ${COMMON_WARNINGS}
+        -Wshorten-64-to-32
+    )
+
     set(GCC_WARNINGS
-        ${CLANG_WARNINGS}
+        ${COMMON_WARNINGS}
         -Wduplicated-cond # warn if if / else chain has duplicated conditions
         -Wduplicated-branches # warn if if / else branches have duplicated code
         -Wlogical-op # warn about logical operations being used where bitwise were probably wanted

--- a/crypto/cipher/aes_gcm_mbedtls.c
+++ b/crypto/cipher/aes_gcm_mbedtls.c
@@ -281,7 +281,7 @@ static srtp_err_status_t srtp_aes_gcm_mbedtls_context_init(void *cv,
 
     debug_print(srtp_mod_aes_gcm, "key:  %s",
                 srtp_octet_string_hex_string(key, c->key_size));
-    key_len_in_bits = (c->key_size << 3);
+    key_len_in_bits = (uint32_t)(c->key_size << 3);
     switch (c->key_size) {
     case SRTP_AES_256_KEY_LEN:
     case SRTP_AES_128_KEY_LEN:

--- a/crypto/cipher/aes_gcm_ossl.c
+++ b/crypto/cipher/aes_gcm_ossl.c
@@ -258,6 +258,10 @@ static srtp_err_status_t srtp_aes_gcm_openssl_set_aad(void *cv,
     debug_print(srtp_mod_aes_gcm, "setting AAD: %s",
                 srtp_octet_string_hex_string(aad, aad_len));
 
+    if (aad_len > INT_MAX) {
+        return srtp_err_status_bad_param;
+    }
+
     if (c->dir == srtp_direction_encrypt) {
         if (EVP_EncryptUpdate(c->ctx, NULL, &len, aad, (int)aad_len) != 1) {
             return srtp_err_status_algo_fail;
@@ -298,6 +302,10 @@ static srtp_err_status_t srtp_aes_gcm_openssl_encrypt(void *cv,
 
     if (*dst_len < src_len + c->tag_len) {
         return srtp_err_status_buffer_small;
+    }
+
+    if (src_len > INT_MAX) {
+        return srtp_err_status_bad_param;
     }
 
     /*
@@ -355,6 +363,10 @@ static srtp_err_status_t srtp_aes_gcm_openssl_decrypt(void *cv,
 
     if (*dst_len < src_len - c->tag_len) {
         return srtp_err_status_buffer_small;
+    }
+
+    if (src_len > INT_MAX) {
+        return srtp_err_status_bad_param;
     }
 
     /*

--- a/crypto/cipher/aes_icm_mbedtls.c
+++ b/crypto/cipher/aes_icm_mbedtls.c
@@ -301,7 +301,7 @@ static srtp_err_status_t srtp_aes_icm_mbedtls_context_init(void *cv,
                                                            const uint8_t *key)
 {
     srtp_aes_icm_ctx_t *c = (srtp_aes_icm_ctx_t *)cv;
-    uint32_t key_size_in_bits = (c->key_size << 3);
+    uint32_t key_size_in_bits = (uint32_t)(c->key_size << 3);
     int errcode = 0;
 
     /*

--- a/crypto/cipher/aes_icm_ossl.c
+++ b/crypto/cipher/aes_icm_ossl.c
@@ -316,6 +316,10 @@ static srtp_err_status_t srtp_aes_icm_openssl_encrypt(void *cv,
         return srtp_err_status_buffer_small;
     }
 
+    if (src_len > INT_MAX) {
+        return srtp_err_status_bad_param;
+    }
+
     if (!EVP_EncryptUpdate(c->ctx, dst, &len, src, (int)src_len)) {
         return srtp_err_status_cipher_fail;
     }

--- a/crypto/cipher/aes_icm_wssl.c
+++ b/crypto/cipher/aes_icm_wssl.c
@@ -56,6 +56,7 @@
 #include "alloc.h"
 #include "cipher_types.h"
 #include "cipher_test_cases.h"
+#include <limits.h>
 
 srtp_debug_module_t srtp_mod_aes_icm = {
     0,             /* debugging is off by default */
@@ -326,7 +327,11 @@ static srtp_err_status_t srtp_aes_icm_wolfssl_encrypt(void *cv,
         return srtp_err_status_buffer_small;
     }
 
-    err = wc_AesCtrEncrypt(c->ctx, dst, src, src_len);
+    if (src_len > INT_MAX) {
+        return srtp_err_status_bad_param;
+    }
+
+    err = wc_AesCtrEncrypt(c->ctx, dst, src, (word32)src_len);
     if (err < 0) {
         debug_print(srtp_mod_aes_icm, "wolfSSL encrypt error: %d", err);
         return srtp_err_status_cipher_fail;

--- a/crypto/hash/hmac_ossl.c
+++ b/crypto/hash/hmac_ossl.c
@@ -240,7 +240,11 @@ static srtp_err_status_t srtp_hmac_init(void *statev,
         return srtp_err_status_auth_fail;
     }
 #else
-    if (HMAC_Init_ex(hmac->ctx, key, key_len, EVP_sha1(), NULL) == 0) {
+    if (key_len > INT_MAX) {
+        return srtp_err_status_bad_param;
+    }
+
+    if (HMAC_Init_ex(hmac->ctx, key, (int)key_len, EVP_sha1(), NULL) == 0) {
         return srtp_err_status_auth_fail;
     }
 #endif

--- a/crypto/math/datatypes.c
+++ b/crypto/math/datatypes.c
@@ -210,7 +210,7 @@ void v128_left_shift(v128_t *x, size_t shift)
         return;
     }
 
-    const int base_index = shift >> 5;
+    const int base_index = (int)(shift >> 5);
     const int bit_index = shift & 31;
 
     __m128i mm = _mm_loadu_si128((const __m128i *)x);
@@ -325,8 +325,8 @@ void bitvector_left_shift(bitvector_t *x, size_t shift)
         ((const __m128i *)right_shift_masks)[4u - (base_index & 3u)];
     __m128i mm_left_shift_mask =
         ((const __m128i *)left_shift_masks)[base_index & 3u];
-    __m128i mm_shift_right = _mm_cvtsi32_si128(bit_index);
-    __m128i mm_shift_left = _mm_cvtsi32_si128(32 - bit_index);
+    __m128i mm_shift_right = _mm_cvtsi32_si128((int)bit_index);
+    __m128i mm_shift_left = _mm_cvtsi32_si128((int)(32 - bit_index));
 
     __m128i mm_current = _mm_loadu_si128(from);
     __m128i mm_current_r = _mm_srl_epi32(mm_current, mm_shift_right);

--- a/srtp/srtp.c
+++ b/srtp/srtp.c
@@ -850,10 +850,14 @@ static srtp_err_status_t srtp_kdf_generate(srtp_kdf_t *kdf,
     }
     octet_string_set_to_zero(key, length);
 
+    if (length > INT_MAX) {
+        return srtp_err_status_bad_param;
+    }
+
     PRIVATE_KEY_UNLOCK();
     err = wc_SRTP_KDF_label(kdf->master_key, kdf->master_key_len,
                             kdf->master_salt, MAX_SRTP_SALT_LEN, -1, NULL,
-                            label, key, length);
+                            label, key, (word32)length);
     PRIVATE_KEY_LOCK();
     if (err < 0) {
         debug_print(mod_srtp, "wolfSSL SRTP KDF error: %d", err);


### PR DESCRIPTION
This takes the changes proposed in #742 and adds a ci build as well as fixing these warnings for all backends.