### PR TITLE
Fix function signature mismatch for `srtp_remove_stream`

### DIFF
--- a/include/srtp.h
+++ b/include/srtp.h
@@ -631,7 +631,7 @@ srtp_err_status_t srtp_add_stream(srtp_t session, const srtp_policy_t *policy);
  *    - [other]           otherwise.
  *
  */
-srtp_err_status_t srtp_remove_stream(srtp_t session, unsigned int ssrc);
+srtp_err_status_t srtp_remove_stream(srtp_t session, uint32_t ssrc);
 
 /**
  * @brief srtp_update() updates all streams in the session.


### PR DESCRIPTION
 - The definition for the function has the signature: `srtp_err_status_t srtp_remove_stream(srtp_t session, uint32_t ssrc)`
 - This is not always same as the signature present in srtp.h: `srtp_err_status_t srtp_remove_stream(srtp_t session, unsigned int ssrc)`

This causes function signature mismatch.
Aligned the signature from `srtp.h` with the definition using `uint32_t`