### PR TITLE
update formatting scripts to  clang-format-14

### DIFF
--- a/.github/workflows/format_check.yml
+++ b/.github/workflows/format_check.yml
@@ -12,6 +12,6 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - name: Install Clang Format
-        run: sudo apt install clang-format-12
+        run: sudo apt install clang-format-14
       - name: Run clang format
         run: ./format.sh -d

--- a/format.sh
+++ b/format.sh
@@ -7,7 +7,7 @@
 # assumes git tree is clean when reporting status
 
 if [ -z "${CLANG_FORMAT}" ]; then
-    CLANG_FORMAT=clang-format-12
+    CLANG_FORMAT=clang-format-14
 fi
 
 a=`git ls-files '*.h' '*.c'`


### PR DESCRIPTION
Git hub is moving to ubuntu-latest on GitHub is moving to 24.04 and there re issues installing clang-format-12 .

(cherry picked from commit 2a6c15d733310216180eced819049957a919d706)