### PR TITLE
test_roc_driver.c runs timeout under riscv64 

### DIFF
--- a/test/roc_driver.c
+++ b/test/roc_driver.c
@@ -42,7 +42,7 @@
  * OF THE POSSIBILITY OF SUCH DAMAGE.
  *
  */
-
+#ifndef __riscv
 #ifdef HAVE_CONFIG_H
 #include <config.h>
 #endif
@@ -173,3 +173,4 @@ srtp_err_status_t roc_test(size_t num_trials)
 
     return srtp_err_status_ok;
 }
+#endif


### PR DESCRIPTION
# description
In this pr ,I make the test roc_driver.c don't work under riscv64.it runs TIMEOUT under riscv64, but when I run the test with 
`meson test -C build --timeout-multiplier=120 --print-errorlogs`, it turns out to be OK. 

# environment
* libsrtp-1-2.7.0-1
* Platform: RISC-V 64 bit

*  log files:

[libsrtp-12.7.0-1-riscv64-check.log](https://github.com/user-attachments/files/19960560/libsrtp-1.2.7.0-1-riscv64-check.log)

My operating environment is an riscv64 environment virtual machine of the arch architecture of Windows WSL.
# reproduce
The process is as follows:
1. Obtain  all dependencies libsrtp needed and compile it.
2. run `meson test -C build --print-errorlogs`

# patch
For fewer downstream distributors,I suggest ignore the entire test suite.I add 
```
#ifndef __riscv

#endif
```
to /test/roc_driver.c
If you find this advice helpful, please consider my PR~