### PR TITLE
Change to use OpenSSL as default crypto library

### DIFF
--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -23,7 +23,7 @@ jobs:
     - name: Configure CMake
       working-directory: ${{github.workspace}}/build
       shell: bash
-      run: cmake $GITHUB_WORKSPACE -DCMAKE_TOOLCHAIN_FILE=$ANDROID_NDK/build/cmake/android.toolchain.cmake -DANDROID_ABI=arm64-v8a
+      run: cmake $GITHUB_WORKSPACE -DCRYPTO_LIBRARY=internal -DCMAKE_TOOLCHAIN_FILE=$ANDROID_NDK/build/cmake/android.toolchain.cmake -DANDROID_ABI=arm64-v8a
 
     - name: Build
       working-directory: ${{github.workspace}}/build
@@ -36,7 +36,7 @@ jobs:
     - name: Configure CMake (Shared Library)
       working-directory: ${{github.workspace}}/build_shared
       shell: bash
-      run: cmake $GITHUB_WORKSPACE -DBUILD_SHARED_LIBS=ON -DCMAKE_TOOLCHAIN_FILE=$ANDROID_NDK/build/cmake/android.toolchain.cmake -DANDROID_ABI=arm64-v8a
+      run: cmake $GITHUB_WORKSPACE -DCRYPTO_LIBRARY=internal -DBUILD_SHARED_LIBS=ON -DCMAKE_TOOLCHAIN_FILE=$ANDROID_NDK/build/cmake/android.toolchain.cmake -DANDROID_ABI=arm64-v8a
 
     - name: Build (Shared Library)
       working-directory: ${{github.workspace}}/build_shared

--- a/.github/workflows/autotools.yml
+++ b/.github/workflows/autotools.yml
@@ -16,7 +16,7 @@ jobs:
         crypto: [internal, openssl, wolfssl, nss]
         include:
           - crypto: internal
-            configure-crypto-enable: ""
+            configure-crypto-enable: "--with-crypto-library=internal"
           - crypto: openssl
             configure-crypto-enable: "--with-crypto-library=openssl"
           - crypto: wolfssl

--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -30,7 +30,7 @@ jobs:
             crypto: openssl3
         include:
           - crypto: internal
-            cmake-crypto-enable: ""
+            cmake-crypto-enable: "-DCRYPTO_LIBRARY=internal"
           - crypto: openssl
             cmake-crypto-enable: "-DCRYPTO_LIBRARY=openssl"
           - crypto: openssl3

--- a/.github/workflows/meson.yml
+++ b/.github/workflows/meson.yml
@@ -30,7 +30,7 @@ jobs:
             crypto: openssl3
         include:
           - crypto: internal
-            meson-crypto-enable: ""
+            meson-crypto-enable: "-Dcrypto-library=internal"
           - crypto: openssl
             meson-crypto-enable: "-Dcrypto-library=openssl"
           - crypto: openssl3
@@ -126,12 +126,7 @@ jobs:
     - uses: actions/checkout@v2
 
     - name: Create Build Environment
-      run: meson setup ${{github.workspace}}/build
-
-    - name: Configure Meson
-      working-directory: ${{github.workspace}}/build
-      shell: bash
-      run: ${{ env.pkgconfig-crypto-dir }} meson configure ${{ matrix.meson-crypto-enable }}
+      run: meson setup ${{github.workspace}}/build ${{ matrix.meson-crypto-enable }}
 
     - name: Build
       working-directory: ${{github.workspace}}/build

--- a/.github/workflows/stream_list.yml
+++ b/.github/workflows/stream_list.yml
@@ -28,7 +28,7 @@ jobs:
     - name: Configure CMake
       working-directory: ${{github.workspace}}/build
       shell: bash
-      run: cmake $GITHUB_WORKSPACE -DLIBSRTP_TEST_APPS=ON -DCMAKE_C_FLAGS:STRING="-DSRTP_NO_STREAM_LIST -DSRTP_USE_TEST_STREAM_LIST"
+      run: cmake $GITHUB_WORKSPACE -DCRYPTO_LIBRARY=internal -DLIBSRTP_TEST_APPS=ON -DCMAKE_C_FLAGS:STRING="-DSRTP_NO_STREAM_LIST -DSRTP_USE_TEST_STREAM_LIST"
 
     - name: Build
       working-directory: ${{github.workspace}}/build

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -86,8 +86,8 @@ set(ENABLE_DEBUG_LOGGING OFF CACHE BOOL "Enable debug logging in all modules")
 set(ERR_REPORTING_STDOUT OFF CACHE BOOL "Enable logging to stdout")
 set(ERR_REPORTING_FILE "" CACHE FILEPATH "Use file for logging")
 
-set(CRYPTO_LIBRARY_VALUES "internal;openssl;wolfssl;mbedtls;nss")
-set(CRYPTO_LIBRARY "internal" CACHE STRING
+set(CRYPTO_LIBRARY_VALUES "openssl;wolfssl;mbedtls;nss;internal")
+set(CRYPTO_LIBRARY "openssl" CACHE STRING
   "Crypto library used by libSRTP, can be one of: ${CRYPTO_LIBRARY_VALUES}")
 set_property(CACHE CRYPTO_LIBRARY PROPERTY STRINGS ${CRYPTO_LIBRARY_VALUES})
 if(NOT CRYPTO_LIBRARY IN_LIST CRYPTO_LIBRARY_VALUES)

--- a/configure
+++ b/configure
@@ -1329,8 +1329,8 @@ Optional Packages:
   --with-PACKAGE[=ARG]    use PACKAGE [ARG=yes]
   --without-PACKAGE       do not use PACKAGE (same as --with-PACKAGE=no)
   --with-crypto-library=TYPE
-                          Select crypto library, one of: internal, openssl,
-                          wolfssl, nss
+                          Select crypto library, one of: openssl, wolfssl,
+                          nss, internal
   --with-openssl-dir      Location of OpenSSL installation
   --with-wolfssl-dir      Location of wolfSSL installation
   --with-nss-dir          Location of NSS installation
@@ -5387,18 +5387,23 @@ $as_echo_n "checking for crypto library... " >&6; }
 if test "${with_crypto_library+set}" = set; then :
   withval=$with_crypto_library; case "$with_crypto_library" in
          internal) ;;
-         openssl) enable_openssl=yes ;;
-         wolfssl) enable_wolfssl=yes ;;
-         nss) enable_nss=yes ;;
-         *) as_fn_error "Invalid crypto library: $with_crypto_library. Select one of: internal, openssl, wolfssl, nss," "$LINENO" 5 ;;
+         openssl) ;;
+         wolfssl) ;;
+         nss) ;;
+         *) as_fn_error "Invalid crypto library: $with_crypto_library. Select one of: openssl, wolfssl, nss, internal" "$LINENO" 5 ;;
        esac
 else
-  with_crypto_library=internal
+  with_crypto_library=openssl
 fi
 
 { $as_echo "$as_me:${as_lineno-$LINENO}: result: $with_crypto_library" >&5
 $as_echo "$with_crypto_library" >&6; }
-
+case "$with_crypto_library" in
+   internal) ;;
+   openssl) enable_openssl=yes ;;
+   wolfssl) enable_wolfssl=yes ;;
+   nss) enable_nss=yes ;;
+esac
 if test "$enable_openssl" = "yes"; then
    { $as_echo "$as_me:${as_lineno-$LINENO}: checking for user specified OpenSSL directory" >&5
 $as_echo_n "checking for user specified OpenSSL directory... " >&6; }

--- a/configure.ac
+++ b/configure.ac
@@ -205,17 +205,22 @@ PKG_PROG_PKG_CONFIG
 AS_IF([test "x$PKG_CONFIG" != "x"], [PKG_CONFIG="$PKG_CONFIG --static"])
 
 AC_MSG_CHECKING([for crypto library])
-AC_ARG_WITH([crypto-library], AS_HELP_STRING([--with-crypto-library=TYPE], [Select crypto library, one of: internal, openssl, wolfssl, nss]),
+AC_ARG_WITH([crypto-library], AS_HELP_STRING([--with-crypto-library=TYPE], [Select crypto library, one of: openssl, wolfssl, nss, internal]),
       [case "$with_crypto_library" in
          internal) ;;
-         openssl) enable_openssl=yes ;;
-         wolfssl) enable_wolfssl=yes ;;
-         nss) enable_nss=yes ;;
-         *) AC_MSG_ERROR([Invalid crypto library: $with_crypto_library. Select one of: internal, openssl, wolfssl, nss,]) ;;
+         openssl) ;;
+         wolfssl) ;;
+         nss) ;;
+         *) AC_MSG_ERROR([Invalid crypto library: $with_crypto_library. Select one of: openssl, wolfssl, nss, internal]) ;;
        esac],
-      [with_crypto_library=internal])
+      [with_crypto_library=openssl])
 AC_MSG_RESULT([$with_crypto_library])
-
+case "$with_crypto_library" in
+   internal) ;;
+   openssl) enable_openssl=yes ;;
+   wolfssl) enable_wolfssl=yes ;;
+   nss) enable_nss=yes ;;
+esac
 if test "$enable_openssl" = "yes"; then
    AC_MSG_CHECKING([for user specified OpenSSL directory])
    AC_ARG_WITH([openssl-dir],

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -4,7 +4,7 @@ option('log-stdout', type : 'boolean', value : false,
   description : 'Redirect logging to stdout')
 option('log-file', type : 'string', value : '',
   description : 'Write logging output into this file')
-option('crypto-library', type: 'combo', choices : ['none', 'openssl', 'wolfssl', 'nss', 'mbedtls'], value : 'none',
+option('crypto-library', type: 'combo', choices : ['openssl', 'wolfssl', 'nss', 'mbedtls', 'internal'], value : 'openssl',
   description : 'What external crypto library to leverage, if any (OpenSSL, wolfSSL, NSS, or mbedtls)')
 option('crypto-library-kdf', type : 'feature', value : 'auto',
   description : 'Use the external crypto library for Key Derivation Function support')


### PR DESCRIPTION
It is better to use an external and well proven crypto library as the default backend. The internal code should only be there as a fall back. This will also mean that GCM will be available by default.

#579