### PR TITLE
Improve installation paths on windows

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -317,12 +317,7 @@ if(WIN32)
   target_compile_definitions(srtp3 PUBLIC _CRT_SECURE_NO_WARNINGS)
 endif()
 
-install(TARGETS srtp3
-  EXPORT libSRTPTargets
-  RUNTIME DESTINATION bin
-  LIBRARY DESTINATION lib
-  ARCHIVE DESTINATION lib
-)
+install(TARGETS srtp3 EXPORT libSRTPTargets)
 
 install(FILES include/srtp.h crypto/include/auth.h
   crypto/include/cipher.h


### PR DESCRIPTION
This helps windows libraries get installed to

```
bin\srtp2.dll
lib\srtp2.lib
```

This is the split we use at conda-forge to help keep the dlls findable while keeking the lib files separate.

Let me know if you have any concerns.

Excited to see this upstreamed.