### PR TITLE
Add Zephyr module file to support Zephyr RTOS

### DIFF
--- a/zephyr/module.yml
+++ b/zephyr/module.yml
@@ -1,0 +1,7 @@
+# Copyright (c) 2025 Sayed Naser Moravej <seyednasermoravej@gmail.com>
+# SPDX-License-Identifier: Apache-2.0
+
+name: libsrtp 
+build:
+  cmake-ext: True 
+  kconfig-ext: True 


### PR DESCRIPTION
Zephyr RTOS needs to know where libSRTP is located and how it should be used as a module. For this
purpose, every external module — including libSRTP — must contain a zephyr/ folder and a module.yml file.