### PR TITLE
Change 'libsrt' to 'libsrtp' in README

### DIFF
--- a/fuzzer/README.md
+++ b/fuzzer/README.md
@@ -1,4 +1,4 @@
-# libsrt fuzzer
+# libsrtp fuzzer
 
 By Guido Vranken <guidovranken@gmail.com> -- https://guidovranken.wordpress.com/
 


### PR DESCRIPTION
Updated the title in the README to reflect the correct library name.