### PR TITLE
mbedtls: improve debug output and fix AES-ICM issues

### DIFF
--- a/crypto/cipher/aes_gcm_mbedtls.c
+++ b/crypto/cipher/aes_gcm_mbedtls.c
@@ -455,7 +455,9 @@ static srtp_err_status_t srtp_aes_gcm_mbedtls_decrypt(void *cv,
     *dst_len = out_len;
     c->aad_size = 0;
     if (status != PSA_SUCCESS) {
+        debug_print(srtp_mod_aes_gcm, "mbedtls error code:  %d", status);
         return srtp_err_status_auth_fail;
     }
+
     return srtp_err_status_ok;
 }

--- a/crypto/cipher/aes_icm_mbedtls.c
+++ b/crypto/cipher/aes_icm_mbedtls.c
@@ -310,6 +310,11 @@ static srtp_err_status_t srtp_aes_icm_mbedtls_context_init(void *cv,
 
     status = psa_crypto_init();
 
+    if (status != PSA_SUCCESS) {
+        debug_print(srtp_mod_aes_icm, "status: %d", status);
+        return srtp_err_status_cipher_fail;
+    }
+
     /*
      * set counter and initial values to 'offset' value, being careful not to
      * go past the end of the key buffer
@@ -346,6 +351,7 @@ static srtp_err_status_t srtp_aes_icm_mbedtls_context_init(void *cv,
     psa_set_key_algorithm(&attr, PSA_ALG_CTR);
 
     if (c->ctx->key_id != PSA_KEY_ID_NULL) {
+        psa_destroy_key(c->ctx->key_id);
         c->ctx->key_id = PSA_KEY_ID_NULL;
     }
 
@@ -355,6 +361,7 @@ static srtp_err_status_t srtp_aes_icm_mbedtls_context_init(void *cv,
     if (status != PSA_SUCCESS) {
         psa_destroy_key(c->ctx->key_id);
         debug_print(srtp_mod_aes_icm, "status: %d", status);
+        return srtp_err_status_cipher_fail;
     }
 
     return srtp_err_status_ok;
@@ -439,6 +446,7 @@ static srtp_err_status_t srtp_aes_icm_mbedtls_encrypt(void *cv,
     if (*dst_len < src_len) {
         return srtp_err_status_buffer_small;
     }
+
     status =
         psa_cipher_update(&(c->ctx->op), src, src_len, dst, *dst_len, &out_len);
 
@@ -447,6 +455,7 @@ static srtp_err_status_t srtp_aes_icm_mbedtls_encrypt(void *cv,
         psa_cipher_abort(&c->ctx->op);
         return srtp_err_status_cipher_fail;
     }
+
     *dst_len = out_len;
     debug_print(srtp_mod_aes_icm, "encrypted: %s",
                 srtp_octet_string_hex_string(dst, *dst_len));


### PR DESCRIPTION
- aes_gcm: Add debug print when PSA status fails.
- aes_icm: Destroy previous key before importing new key.
- aes_icm: Add missing destination buffer argument to encrypt function.

After testing the new libSRTP on a microcontroller with a limited resources (RAM = 256KB), I faced two issues:
1. We need to check if the key is available, first we need to destroy it, after that we can address its pointer to the NULL pointer.
2. When performing in-place encryption/decryption (input buffer == output buffer), the input length must be divisible by the cipher block size. Please check this:
https://github.com/Mbed-TLS/TF-PSA-Crypto/blob/76920edddcad00ac41b248e12d937b845df7bedb/drivers/builtin/src/cipher.c#L641
