### PR TITLE
Remove gcm short tag tests

### DIFF
--- a/.github/workflows/autotools.yml
+++ b/.github/workflows/autotools.yml
@@ -38,7 +38,7 @@ jobs:
       run: |
         git clone https://github.com/wolfSSL/wolfssl
         cd wolfssl
-        git checkout v5.7.0-stable
+        git checkout v5.9.2-stable
         ./autogen.sh
         ./configure '--enable-srtp-kdf' '--enable-aesctr' '--enable-intelasm' '--enable-aesgcm-stream'
         make
@@ -60,7 +60,7 @@ jobs:
         brew install autoconf automake libtool
         git clone https://github.com/wolfSSL/wolfssl
         cd wolfssl
-        git checkout v5.7.0-stable
+        git checkout v5.9.2-stable
         ./autogen.sh
         CPU=`sysctl -n machdep.cpu.brand_string`
         if [[ "$CPU" =~ Intel ]]; then

--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -53,7 +53,7 @@ jobs:
       run: |
         git clone https://github.com/wolfSSL/wolfssl
         cd wolfssl
-        git checkout v5.7.0-stable
+        git checkout v5.9.2-stable
         ./autogen.sh
         ./configure '--enable-srtp-kdf' '--enable-aesctr' '--enable-intelasm' '--enable-aesgcm-stream'
         make
@@ -94,7 +94,7 @@ jobs:
         brew install autoconf automake libtool
         git clone https://github.com/wolfSSL/wolfssl
         cd wolfssl
-        git checkout v5.7.0-stable
+        git checkout v5.9.2-stable
         ./autogen.sh
         CPU=`sysctl -n machdep.cpu.brand_string`
         if [[ "$CPU" =~ Intel ]]; then

--- a/.github/workflows/meson.yml
+++ b/.github/workflows/meson.yml
@@ -70,7 +70,7 @@ jobs:
       run: |
         git clone https://github.com/wolfSSL/wolfssl
         cd wolfssl
-        git checkout v5.7.0-stable
+        git checkout v5.9.2-stable
         ./autogen.sh
         ./configure '--enable-srtp-kdf' '--enable-aesctr' '--enable-intelasm' '--enable-aesgcm-stream'
         make
@@ -111,7 +111,7 @@ jobs:
         brew install autoconf automake libtool
         git clone https://github.com/wolfSSL/wolfssl
         cd wolfssl
-        git checkout v5.7.0-stable
+        git checkout v5.9.2-stable
         ./autogen.sh
         CPU=`sysctl -n machdep.cpu.brand_string`
         if [[ "$CPU" =~ Intel ]]; then

--- a/crypto/cipher/cipher_test_cases.c
+++ b/crypto/cipher/cipher_test_cases.c
@@ -253,20 +253,6 @@ static const uint8_t srtp_aes_gcm_128_test_case_0_ciphertext[76] = {
 };
 /* clang-format on */
 
-static const srtp_cipher_test_case_t srtp_aes_gcm_128_test_case_0a = {
-    SRTP_AES_GCM_128_KEY_LEN_WSALT,          /* octets in key            */
-    srtp_aes_gcm_128_test_case_0_key,        /* key                      */
-    srtp_aes_gcm_128_test_case_0_iv,         /* packet index             */
-    60,                                      /* octets in plaintext      */
-    srtp_aes_gcm_128_test_case_0_plaintext,  /* plaintext                */
-    68,                                      /* octets in ciphertext     */
-    srtp_aes_gcm_128_test_case_0_ciphertext, /* ciphertext  + tag        */
-    20,                                      /* octets in AAD            */
-    srtp_aes_gcm_128_test_case_0_aad,        /* AAD                      */
-    8,                                       /* */
-    NULL                                     /* pointer to next testcase */
-};
-
 const srtp_cipher_test_case_t srtp_aes_gcm_128_test_case_0 = {
     SRTP_AES_GCM_128_KEY_LEN_WSALT,          /* octets in key            */
     srtp_aes_gcm_128_test_case_0_key,        /* key                      */
@@ -278,7 +264,7 @@ const srtp_cipher_test_case_t srtp_aes_gcm_128_test_case_0 = {
     20,                                      /* octets in AAD            */
     srtp_aes_gcm_128_test_case_0_aad,        /* AAD                      */
     16,                                      /* */
-    &srtp_aes_gcm_128_test_case_0a           /* pointer to next testcase */
+    NULL                                     /* pointer to next testcase */
 };
 
 /* clang-format off */
@@ -336,20 +322,6 @@ static const uint8_t srtp_aes_gcm_256_test_case_0_ciphertext[76] = {
 };
 /* clang-format on */
 
-static const srtp_cipher_test_case_t srtp_aes_gcm_256_test_case_0a = {
-    SRTP_AES_GCM_256_KEY_LEN_WSALT,          /* octets in key            */
-    srtp_aes_gcm_256_test_case_0_key,        /* key                      */
-    srtp_aes_gcm_256_test_case_0_iv,         /* packet index             */
-    60,                                      /* octets in plaintext      */
-    srtp_aes_gcm_256_test_case_0_plaintext,  /* plaintext                */
-    68,                                      /* octets in ciphertext     */
-    srtp_aes_gcm_256_test_case_0_ciphertext, /* ciphertext  + tag        */
-    20,                                      /* octets in AAD            */
-    srtp_aes_gcm_256_test_case_0_aad,        /* AAD                      */
-    8,                                       /* */
-    NULL                                     /* pointer to next testcase */
-};
-
 const srtp_cipher_test_case_t srtp_aes_gcm_256_test_case_0 = {
     SRTP_AES_GCM_256_KEY_LEN_WSALT,          /* octets in key            */
     srtp_aes_gcm_256_test_case_0_key,        /* key                      */
@@ -361,5 +333,5 @@ const srtp_cipher_test_case_t srtp_aes_gcm_256_test_case_0 = {
     20,                                      /* octets in AAD            */
     srtp_aes_gcm_256_test_case_0_aad,        /* AAD                      */
     16,                                      /* */
-    &srtp_aes_gcm_256_test_case_0a           /* pointer to next testcase */
+    NULL                                     /* pointer to next testcase */
 };


### PR DESCRIPTION
SRTP does not support 8 byt tag length with GCM, it is not possible to configure in the api.
When updating wolfssl ci, these tests failed as it requires tag length >= 12.