### PR TITLE
srtp: read Cryptex header extension from the input buffer on unprotect

### DIFF
--- a/srtp/srtp.c
+++ b/srtp/srtp.c
@@ -244,7 +244,7 @@ static srtp_err_status_t srtp_cryptex_unprotect_init(
     size_t *enc_start)
 {
     if (stream->use_cryptex && hdr->x == 1) {
-        uint16_t profile = srtp_get_rtp_hdr_xtnd_profile(hdr, rtp);
+        uint16_t profile = srtp_get_rtp_hdr_xtnd_profile(hdr, srtp);
         *inuse = profile == cryptex_one_byte_profile ||
                  profile == cryptex_two_byte_profile;
     } else {
@@ -255,7 +255,7 @@ static srtp_err_status_t srtp_cryptex_unprotect_init(
 
     if (*inuse) {
         *enc_start -=
-            (srtp_get_rtp_hdr_xtnd_len(hdr, rtp) - octets_in_rtp_xtn_hdr);
+            (srtp_get_rtp_hdr_xtnd_len(hdr, srtp) - octets_in_rtp_xtn_hdr);
         if (*inplace) {
             *enc_start -= (hdr->cc * 4);
         }

--- a/test/srtp_driver.c
+++ b/test/srtp_driver.c
@@ -145,6 +145,7 @@ srtp_err_status_t srtp_test_set_sender_roc(void);
 
 srtp_err_status_t srtp_test_cryptex_csrc_but_no_extension_header(void);
 srtp_err_status_t srtp_test_cryptex_disable(void);
+srtp_err_status_t srtp_test_cryptex_not_in_place_distinct_buffer(void);
 
 srtp_err_status_t srtp_test_missing_session_keys(void);
 
@@ -996,6 +997,15 @@ int main(int argc, char *argv[])
 
         printf("testing cryptex_disable()...");
         if (srtp_test_cryptex_disable() == srtp_err_status_ok) {
+            printf("passed\n");
+        } else {
+            printf("failed\n");
+            exit(1);
+        }
+
+        printf("testing cryptex_not_in_place_distinct_buffer()...");
+        if (srtp_test_cryptex_not_in_place_distinct_buffer() ==
+            srtp_err_status_ok) {
             printf("passed\n");
         } else {
             printf("failed\n");
@@ -3376,6 +3386,91 @@ srtp_err_status_t srtp_validate_cryptex(void)
         CHECK_OK(srtp_dealloc(srtp_recv));
     }
 
+    srtp_policy_destroy(policy);
+
+    return srtp_err_status_ok;
+}
+
+/*
+ * srtp_test_cryptex_not_in_place_distinct_buffer() unprotects a Cryptex
+ * (RFC 9335) packet using the not-in-place form of the API, with an output
+ * buffer that is genuinely distinct from the input buffer and does not
+ * already contain a copy of the ciphertext.
+ *
+ * srtp_unprotect() documents that rtp "can be the same as srtp to support
+ * in-place io", so a separate buffer is a supported calling mode. The
+ * existing not-in-place coverage in this driver copies the packet into a
+ * scratch input buffer and passes the original packet buffer as the output,
+ * so the output buffer happens to hold the ciphertext already. That masks
+ * any read of the header extension from the output buffer instead of the
+ * input buffer.
+ */
+srtp_err_status_t srtp_test_cryptex_not_in_place_distinct_buffer(void)
+{
+    // clang-format off
+    /* Plaintext packet with 1-byte header extension */
+    const char *plaintext_ref =
+        "900f1235"
+        "decafbad"
+        "cafebabe"
+        "bede0001"
+        "51000200"
+        "abababab"
+        "abababab"
+        "abababab"
+        "abababab";
+
+    /* AES-CTR/HMAC-SHA1 Cryptex ciphertext of the packet above */
+    const char *ciphertext_ref =
+        "900f1235"
+        "decafbad"
+        "cafebabe"
+        "c0de0001"
+        "eb923652"
+        "51c3e036"
+        "f8de27e9"
+        "c27ee3e0"
+        "b4651d9f"
+        "bc4218a7"
+        "0244522f"
+        "34a5";
+    // clang-format on
+
+    srtp_t srtp_recv;
+    srtp_policy_t policy;
+    uint8_t reference[1400];
+    uint8_t ciphertext[1400];
+    uint8_t output[1400];
+    size_t ref_len, enc_len, out_len;
+
+    ref_len = hex_string_to_octet_string(reference, plaintext_ref,
+                                        sizeof(reference)) /
+              2;
+    enc_len = hex_string_to_octet_string(ciphertext, ciphertext_ref,
+                                         sizeof(ciphertext)) /
+              2;
+
+    CHECK_OK(srtp_policy_create(&policy));
+    CHECK_OK(srtp_policy_set_profile(policy, srtp_profile_aes128_cm_sha1_80));
+    CHECK_OK(srtp_policy_set_ssrc(policy,
+                                  (srtp_ssrc_t){ ssrc_specific, 0xcafebabe }));
+    CHECK_OK(policy_set_key(policy, test_key));
+    CHECK_OK(srtp_policy_set_cryptex(policy, true));
+
+    CHECK_OK(srtp_create(&srtp_recv, policy));
+
+    /*
+     * The output buffer is deliberately not seeded with the ciphertext. A
+     * caller that hands libsrtp a fresh output buffer is doing nothing wrong.
+     */
+    memset(output, 0, sizeof(output));
+    out_len = sizeof(output);
+
+    CHECK_OK(srtp_unprotect(srtp_recv, ciphertext, enc_len, output, &out_len));
+    CHECK(out_len == ref_len);
+    CHECK_BUFFER_EQUAL(output, reference, ref_len);
+
+    CHECK_OK(srtp_dealloc(srtp_recv));
     srtp_policy_destroy(policy);
 
     return srtp_err_status_ok;

--- a/test/srtp_driver.c
+++ b/test/srtp_driver.c
@@ -3444,7 +3444,7 @@ srtp_err_status_t srtp_test_cryptex_not_in_place_distinct_buffer(void)
     size_t ref_len, enc_len, out_len;
 
     ref_len = hex_string_to_octet_string(reference, plaintext_ref,
-                                        sizeof(reference)) /
+                                         sizeof(reference)) /
               2;
     enc_len = hex_string_to_octet_string(ciphertext, ciphertext_ref,
                                          sizeof(ciphertext)) /


### PR DESCRIPTION
Follow-up to the report I sent to `libsrtp-security@lists.packetizer.com` on 2026-08-03. Pascal asked for a public PR with a small failing test, so here it is. This is a correctness bug, not a security issue, and I am not requesting a CVE for it.

### What is wrong

`srtp_cryptex_unprotect_init()` reads the RTP header-extension `profile_specific` and `length` fields from the `rtp` parameter. On the unprotect path `rtp` is the **output** buffer:

```c
static srtp_err_status_t srtp_cryptex_unprotect_init(
    const srtp_stream_ctx_t *stream,
    const srtp_hdr_t *hdr,
    const uint8_t *srtp,      /* input, and what hdr points into */
    const uint8_t *rtp,       /* output */
    ...
{
    if (stream->use_cryptex && hdr->x == 1) {
        uint16_t profile = srtp_get_rtp_hdr_xtnd_profile(hdr, rtp);   /* srtp/srtp.c:247 */
```

`srtp_unprotect()` documents that `rtp` "can be the same as `srtp` to support in-place io", so a **distinct** output buffer is a supported calling mode. In that mode the output buffer has not been written when this function runs — the first write is `memcpy(rtp, srtp, enc_start)` in the caller, at `srtp/srtp.c:2346`, after the call returns.

So Cryptex detection, and the `enc_start` adjustment derived from the extension length, come from whatever the caller's output buffer happened to contain rather than from the packet that arrived.

Two lines above the call site the same field is already read from `srtp`:

```c
    enc_start = srtp_get_rtp_hdr_len(hdr);
    if (hdr->x == 1) {
        enc_start += srtp_get_rtp_hdr_xtnd_len(hdr, srtp);   /* :2304 — reads srtp */
    }
    status = srtp_cryptex_unprotect_init(stream, hdr, srtp, rtp, ...);  /* :2308 → reads rtp */
```

Both call sites (`srtp_unprotect_aead` and `srtp_unprotect`) behave the same way.

### The fix

Read both fields from `srtp`. In-place callers are unaffected, since `srtp == rtp` for them. `srtp_cryptex_protect_init()` is left alone: on the protect path `rtp` is the input, so its use of `rtp` is correct.

### Why the existing tests did not catch it

`call_srtp_unprotect2()` in `test/srtp_driver.c`, under `use_srtp_not_in_place_io_api`, does:

```c
memcpy(in_buf, srtp, srtp_len);
status = srtp_unprotect(ctx, in_buf, srtp_len, srtp, rtp_len);
```

The input is a scratch copy and the output is the original packet buffer — which still holds the ciphertext. Reading the profile from the output buffer therefore returns the correct bytes by accident, and `srtp_driver -n` passes.

### The test

`srtp_test_cryptex_not_in_place_distinct_buffer()` unprotects the existing 1-byte-header-extension reference Cryptex packet into a zeroed buffer that is distinct from the input, which is what a caller handing libsrtp a fresh output buffer would do.

Before the fix:

```
testing cryptex_not_in_place_distinct_buffer()...
error at test/srtp_driver.c:3471, buffer1 != buffer2 at index: 12 (c0 != be)
```

Offset 12 is the extension profile: the output still carries `c0de` (Cryptex, i.e. the ciphertext form) where `bede` is expected, because Cryptex was never detected and the header extension was never restored.

After the fix:

```
testing cryptex_not_in_place_distinct_buffer()...passed
```

### Verification

- `ctest`: 12/12 pass, including `srtp_driver` and `srtp_driver_not_in_place_io`
- `srtp_driver -v` and `srtp_driver -v -n`: both exit 0 with no failures
- New test fails before the change and passes after
- Added lines are within 80 columns

I could not run `clang-format` — it is not available on this machine — so if CI flags formatting, tell me and I will fix it up.

Happy to extend the test to the 2-byte and CSRC vectors, or to fold it into the existing `srtp_validate_cryptex()` loop instead of a standalone test, if you would prefer either shape.
