### PR TITLE
Stop forcing pkgconfig static mode in configure

### DIFF
--- a/configure
+++ b/configure
@@ -5376,10 +5376,6 @@ $as_echo "no" >&6; }
 		PKG_CONFIG=""
 	fi
 fi
-if test "x$PKG_CONFIG" != "x"; then :
-  PKG_CONFIG="$PKG_CONFIG --static"
-fi
-
 { $as_echo "$as_me:${as_lineno-$LINENO}: checking for crypto library" >&5
 $as_echo_n "checking for crypto library... " >&6; }
 

--- a/configure.ac
+++ b/configure.ac
@@ -202,7 +202,11 @@ fi
 AC_MSG_RESULT([$enable_debug_logging])
 
 PKG_PROG_PKG_CONFIG
-AS_IF([test "x$PKG_CONFIG" != "x"], [PKG_CONFIG="$PKG_CONFIG --static"])
+dnl Do not append --static to PKG_CONFIG. Forcing static pkg-config flags
+dnl pulls Libs.private into configure link probes (AC_SEARCH_LIBS), which
+dnl fails on hosts whose libcrypto.pc names private archives that are not
+dnl installed (for example Ubuntu libjitterentropy). Dynamic flags are enough
+dnl for discovery; Libs.private in libsrtp3.pc still gets the resulting LIBS.
 
 AC_MSG_CHECKING([for crypto library])
 AC_ARG_WITH([crypto-library], AS_HELP_STRING([--with-crypto-library=TYPE], [Select crypto library, one of: openssl, wolfssl, nss, internal]),


### PR DESCRIPTION
## Summary
Fixes #822

configure was rewriting PKG_CONFIG to always pass static mode. That pulls private link flags into the OpenSSL discovery probes, so hosts whose libcrypto.pc names private archives that are not installed (for example Ubuntu with libjitterentropy) fail with cannot find compatible openssl crypto lib.

This change leaves pkgconfig in its normal dynamic mode for discovery. Libs.private in the generated libsrtp3.pc file still receives the resulting LIBS values.

## Test plan
* Ran ./configure with OpenSSL on macOS; crypto probes succeed
* Ran make and make runtest; all libsrtp3 and crypto self tests passed